### PR TITLE
Add 6.0.4.GA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Titanium_3.5.1.GA.json
 Titanium_4.0.0.GA.json
 Titanium_4.1.0.GA.json
 Titanium_5.2.0.GA.json
+Titanium_6.0.4.GA.json

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ Titanium_3.5.1.GA.json
 Titanium_4.0.0.GA.json
 Titanium_4.1.0.GA.json
 Titanium_5.2.0.GA.json
+Titanium_6.0.4.GA.json

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ path/to/example.js
 
 ##### Titanium SDK version
 
+* 6.0.4.GA
 * 5.2.0.GA
 * 4.1.0.GA
 * 4.0.0.GA

--- a/furnace.js
+++ b/furnace.js
@@ -4,8 +4,8 @@ var _ = require('lodash'),
 	fs = require('fs'),
 	path = require('path');
 
-var apis = require('./Titanium_5.2.0.GA.json'),
-	root = path.join(__dirname, 'lib', 'titanium', '5.2.0.GA');
+var apis = require('./Titanium_6.0.4.GA.json'),
+	root = path.join(__dirname, 'lib', 'titanium', '6.0.4.GA');
 
 function getType(type) {
 	var result;

--- a/index.js
+++ b/index.js
@@ -78,6 +78,9 @@ var slag = function(file, options){
 
 				if (_.has(options.module, original)) {
 					return options.module[original];
+				} else if (original.startsWith('/alloy') && _.has(options.module, original.substring(1))) {
+					// Catch up ALOY-1523 Update Alloy old require-paths
+					return options.module[original.substring(1)];
 				} else if (fs.existsSync(source)) {
 					newcontext = createContext();
 					vm.runInContext(fs.readFileSync(source, 'utf8'), newcontext);

--- a/lib/titanium/6.0.4.GA.js
+++ b/lib/titanium/6.0.4.GA.js
@@ -1,0 +1,171 @@
+var _ = require('lodash'),
+	path = require('path');
+
+module.exports = function(sdk, options){
+	return _.extend(_.extend(require(path.join(sdk, '/Titanium'))(), {
+			version: options.version
+		}), {
+		Accelerometer: require(path.join(sdk, 'Titanium', 'Accelerometer'))(),
+		Analytics: require(path.join(sdk, 'Titanium', 'Analytics'))(),
+		Android: _.extend(require(path.join(sdk, 'Titanium', 'Android'))(), {
+			ActionBar: require(path.join(sdk, 'Titanium', 'Android', 'ActionBar'))(),
+			Activity: require(path.join(sdk, 'Titanium', 'Android', 'Activity'))(),
+			BroadcastReceiver: require(path.join(sdk, 'Titanium', 'Android', 'BroadcastReceiver'))(),
+			Calendar: _.extend(require(path.join(sdk, 'Titanium', 'Android', 'Calendar'))(), {
+				Alert: require(path.join(sdk, 'Titanium', 'Android', 'Calendar', 'Alert'))(),
+				Calendar: require(path.join(sdk, 'Titanium', 'Android', 'Calendar', 'Calendar'))(),
+				Event: require(path.join(sdk, 'Titanium', 'Android', 'Calendar', 'Event'))(),
+				Reminder: require(path.join(sdk, 'Titanium', 'Android', 'Calendar', 'Reminder'))()
+			}),
+			Intent: require(path.join(sdk, 'Titanium', 'Android', 'Intent'))(),
+			Menu: require(path.join(sdk, 'Titanium', 'Android', 'Menu'))(),
+			MenuItem: require(path.join(sdk, 'Titanium', 'Android', 'MenuItem'))(),
+			Notification: require(path.join(sdk, 'Titanium', 'Android', 'Notification'))(),
+			NotificationManager: require(path.join(sdk, 'Titanium', 'Android', 'NotificationManager'))(),
+			PendingIntent: require(path.join(sdk, 'Titanium', 'Android', 'PendingIntent'))(),
+			R: require(path.join(sdk, 'Titanium', 'Android', 'R'))(),
+			RemoteViews: require(path.join(sdk, 'Titanium', 'Android', 'RemoteViews'))(),
+			Service: require(path.join(sdk, 'Titanium', 'Android', 'Service'))()
+		}),
+		API: require(path.join(sdk, 'Titanium', 'API'))(),
+		App: _.extend(require(path.join(sdk, 'Titanium', 'App'))(), {
+			Android: _.extend(require(path.join(sdk, 'Titanium', 'App', 'Android'))(), {
+				R: require(path.join(sdk, 'Titanium', 'App', 'Android', 'R'))()
+			}),
+			iOS: _.extend(require(path.join(sdk, 'Titanium', 'App', 'iOS'))(), {
+				BackgroundService: require(path.join(sdk, 'Titanium', 'App', 'iOS', 'BackgroundService'))(),
+				LocalNotification: require(path.join(sdk, 'Titanium', 'App', 'iOS', 'LocalNotification'))(),
+				UserDefaults: require(path.join(sdk, 'Titanium', 'App', 'iOS', 'UserDefaults'))(),
+				UserNotificationAction: require(path.join(sdk, 'Titanium', 'App', 'iOS', 'UserNotificationAction'))(),
+				UserNotificationCategory: require(path.join(sdk, 'Titanium', 'App', 'iOS', 'UserNotificationCategory'))()
+			}),
+			Properties: require(path.join(sdk, 'Titanium', 'App', 'Properties'))(),
+		}),
+		Blob: require(path.join(sdk, 'Titanium', 'Blob'))(),
+		BlobStream: require(path.join(sdk, 'Titanium', 'BlobStream'))(),
+		Buffer: require(path.join(sdk, 'Titanium', 'Buffer'))(),
+		BufferStream: require(path.join(sdk, 'Titanium', 'BufferStream'))(),
+		Calendar: _.extend(require(path.join(sdk, 'Titanium', 'Calendar'))(), {
+			Alert: require(path.join(sdk, 'Titanium', 'Calendar', 'Alert'))(),
+			Calendar: require(path.join(sdk, 'Titanium', 'Calendar', 'Calendar'))(),
+			Event: require(path.join(sdk, 'Titanium', 'Calendar', 'Event'))(),
+			RecurrenceRule: require(path.join(sdk, 'Titanium', 'Calendar', 'RecurrenceRule'))(),
+			Reminder: require(path.join(sdk, 'Titanium', 'Calendar', 'Reminder'))()
+		}),
+		Codec: require(path.join(sdk, 'Titanium', 'Codec'))(),
+		Contacts: _.extend(require(path.join(sdk, 'Titanium', 'Contacts'))(), {
+			Group: require(path.join(sdk, 'Titanium', 'Contacts', 'Group'))(),
+			Person: require(path.join(sdk, 'Titanium', 'Contacts', 'Person'))()
+		}),
+		Database: _.extend(require(path.join(sdk, 'Titanium', 'Database'))(), {
+			DB: require(path.join(sdk, 'Titanium', 'Database', 'DB'))(),
+			ResultSet: require(path.join(sdk, 'Titanium', 'Database', 'ResultSet'))()
+		}),
+		Filesystem: _.extend(require(path.join(sdk, 'Titanium', 'Filesystem'))(), {
+			File: require(path.join(sdk, 'Titanium', 'Filesystem', 'File'))(),
+			FileStream: require(path.join(sdk, 'Titanium', 'Filesystem', 'FileStream'))()
+		}),
+		Geolocation: _.extend(require(path.join(sdk, 'Titanium', 'Geolocation'))(), {
+			Android: _.extend(require(path.join(sdk, 'Titanium', 'Geolocation', 'Android'))(), {
+				LocationProvider: require(path.join(sdk, 'Titanium', 'Geolocation', 'Android', 'LocationProvider'))(),
+				LocationRule: require(path.join(sdk, 'Titanium', 'Geolocation', 'Android', 'LocationRule'))()
+			}),
+			MobileWeb: require(path.join(sdk, 'Titanium', 'Geolocation', 'MobileWeb'))()
+		}),
+		Gesture: require(path.join(sdk, 'Titanium', 'Gesture'))(),
+		IOStream: require(path.join(sdk, 'Titanium', 'IOStream'))(),
+		Locale: require(path.join(sdk, 'Titanium', 'Locale'))(),
+		Media: _.extend(require(path.join(sdk, 'Titanium', 'Media'))(), {
+			Android: require(path.join(sdk, 'Titanium', 'Media', 'Android'))(),
+			AudioPlayer: require(path.join(sdk, 'Titanium', 'Media', 'AudioPlayer'))(),
+			AudioRecorder: require(path.join(sdk, 'Titanium', 'Media', 'AudioRecorder'))(),
+			Item: require(path.join(sdk, 'Titanium', 'Media', 'Item'))(),
+			MusicPlayer: require(path.join(sdk, 'Titanium', 'Media', 'MusicPlayer'))(),
+			Sound: require(path.join(sdk, 'Titanium', 'Media', 'Sound'))(),
+			VideoPlayer: require(path.join(sdk, 'Titanium', 'Media', 'VideoPlayer'))()
+		}),
+		Network: _.extend(require(path.join(sdk, 'Titanium', 'Network'))(), {
+			Socket: require(path.join(sdk, 'Titanium', 'Network', 'Socket'))()
+		}),
+		Platform: _.extend(require(path.join(sdk, 'Titanium', 'Platform'))(), {
+			Android: require(path.join(sdk, 'Titanium', 'Platform', 'Android'))(),
+			displayCaps: require(path.join(sdk, 'Titanium', 'Platform', 'DisplayCaps'))()
+		}, {
+			platform: options.platform
+		}),
+		Stream: require(path.join(sdk, 'Titanium', 'Stream'))(),
+		UI: _.extend(require(path.join(sdk, 'Titanium', 'UI'))(), {
+			Android: _.extend(require(path.join(sdk, 'Titanium', 'UI', 'Android'))(), {
+				ProgressIndicator: require(path.join(sdk, 'Titanium', 'UI', 'Android', 'ProgressIndicator'))(),
+				SearchView: require(path.join(sdk, 'Titanium', 'UI', 'Android', 'SearchView'))()
+			}),
+			iOS: _.extend(require(path.join(sdk, 'Titanium', 'UI', 'iOS'))(), {
+				AdView: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'AdView'))(),
+				AnchorAttachmentBehavior: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'AnchorAttachmentBehavior'))(),
+				Animator: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'Animator'))(),
+				CollisionBehavior: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'CollisionBehavior'))(),
+				CoverFlowView: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'CoverFlowView'))(),
+				DocumentViewer: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'DocumentViewer'))(),
+				DynamicItemBehavior: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'DynamicItemBehavior'))(),
+				GravityBehavior: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'GravityBehavior'))(),
+				NavigationWindow: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'NavigationWindow'))(),
+				PushBehavior: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'PushBehavior'))(),
+				SnapBehavior: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'SnapBehavior'))(),
+				SplitWindow: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'SplitWindow'))(),
+				StatusBar: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'StatusBar'))(),
+				TabbedBar: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'TabbedBar'))(),
+				Toolbar: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'Toolbar'))(),
+				ViewAttachmentBehavior: require(path.join(sdk, 'Titanium', 'UI', 'iOS', 'ViewAttachmentBehavior'))()
+			}),
+			iPad: _.extend(require(path.join(sdk, 'Titanium', 'UI', 'iPad'))(), {
+				Popover: require(path.join(sdk, 'Titanium', 'UI', 'iPad', 'Popover'))()
+			}),
+			iPhone: _.extend(require(path.join(sdk, 'Titanium', 'UI', 'iPhone'))(), {
+				ActivityIndicatorStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'ActivityIndicatorStyle'))(),
+				AlertDialogStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'AlertDialogStyle'))(),
+				AnimationStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'AnimationStyle'))(),
+				ListViewCellSelectionStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'ListViewCellSelectionStyle'))(),
+				ListViewScrollPosition: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'ListViewScrollPosition'))(),
+				ListViewSeparatorStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'ListViewSeparatorStyle'))(),
+				ListViewStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'ListViewStyle'))(),
+				ProgressBarStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'ProgressBarStyle'))(),
+				RowAnimationStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'RowAnimationStyle'))(),
+				ScrollIndicatorStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'ScrollIndicatorStyle'))(),
+				StatusBar: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'StatusBar'))(),
+				SystemButton: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'SystemButton'))(),
+				SystemButtonStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'SystemButtonStyle'))(),
+				SystemIcon: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'SystemIcon'))(),
+				TableViewCellSelectionStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'TableViewCellSelectionStyle'))(),
+				TableViewScrollPosition: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'TableViewScrollPosition'))(),
+				TableViewSeparatorStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'TableViewSeparatorStyle'))(),
+				TableViewStyle: require(path.join(sdk, 'Titanium', 'UI', 'iPhone', 'TableViewStyle'))()
+			}),
+			MobileWeb: _.extend(require(path.join(sdk, 'Titanium', 'UI', 'MobileWeb'))(), {
+				NavigationGroup: require(path.join(sdk, 'Titanium', 'UI', 'MobileWeb', 'NavigationGroup'))(),
+				TableViewSeparatorStyle: require(path.join(sdk, 'Titanium', 'UI', 'MobileWeb', 'TableViewSeparatorStyle'))()
+			}),
+			ActivityIndicatorStyle: require(path.join(sdk, 'Titanium', 'UI', 'ActivityIndicatorStyle'))()
+		}),
+		Utils: require(path.join(sdk, 'Titanium', 'Utils'))(),
+		XML: _.extend(require(path.join(sdk, 'Titanium', 'XML'))(), {
+			Attr: require(path.join(sdk, 'Titanium', 'XML', 'Attr'))(),
+			CDATASection: require(path.join(sdk, 'Titanium', 'XML', 'CDATASection'))(),
+			CharacterData: require(path.join(sdk, 'Titanium', 'XML', 'CharacterData'))(),
+			Comment: require(path.join(sdk, 'Titanium', 'XML', 'Comment'))(),
+			Document: require(path.join(sdk, 'Titanium', 'XML', 'Document'))(),
+			DocumentFragment: require(path.join(sdk, 'Titanium', 'XML', 'DocumentFragment'))(),
+			DocumentType: require(path.join(sdk, 'Titanium', 'XML', 'DocumentType'))(),
+			DOMImplementation: require(path.join(sdk, 'Titanium', 'XML', 'DOMImplementation'))(),
+			Element: require(path.join(sdk, 'Titanium', 'XML', 'Element'))(),
+			Entity: require(path.join(sdk, 'Titanium', 'XML', 'Entity'))(),
+			EntityReference: require(path.join(sdk, 'Titanium', 'XML', 'EntityReference'))(),
+			NamedNodeMap: require(path.join(sdk, 'Titanium', 'XML', 'NamedNodeMap'))(),
+			Node: require(path.join(sdk, 'Titanium', 'XML', 'Node'))(),
+			NodeList: require(path.join(sdk, 'Titanium', 'XML', 'NodeList'))(),
+			Notation: require(path.join(sdk, 'Titanium', 'XML', 'Notation'))(),
+			ProcessingInstruction: require(path.join(sdk, 'Titanium', 'XML', 'ProcessingInstruction'))(),
+			Text: require(path.join(sdk, 'Titanium', 'XML', 'Text'))()
+		}),
+		Yahoo: require(path.join(sdk, 'Titanium', 'Yahoo'))()
+	});
+};

--- a/lib/titanium/6.0.4.GA/APSConnectionDelegate.js
+++ b/lib/titanium/6.0.4.GA/APSConnectionDelegate.js
@@ -1,0 +1,24 @@
+var crypto = require('crypto');
+function APSConnectionDelegate(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new APSConnectionDelegate(properties);
+};

--- a/lib/titanium/6.0.4.GA/AcceptDict.js
+++ b/lib/titanium/6.0.4.GA/AcceptDict.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function AcceptDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'timeout',
+			'error',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.timeout = undefined;
+	} else {
+		this.timeout = __SLAG_PROPERTIES.timeout || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new AcceptDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/AcceptedCallbackArgs.js
+++ b/lib/titanium/6.0.4.GA/AcceptedCallbackArgs.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function AcceptedCallbackArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'socket',
+			'inbound',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.socket = undefined;
+	} else {
+		this.socket = __SLAG_PROPERTIES.socket || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.inbound = undefined;
+	} else {
+		this.inbound = __SLAG_PROPERTIES.inbound || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new AcceptedCallbackArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/ActivityResult.js
+++ b/lib/titanium/6.0.4.GA/ActivityResult.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function ActivityResult(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'requestCode',
+			'resultCode',
+			'intent',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.requestCode = undefined;
+	} else {
+		this.requestCode = __SLAG_PROPERTIES.requestCode || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.resultCode = undefined;
+	} else {
+		this.resultCode = __SLAG_PROPERTIES.resultCode || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.intent = undefined;
+	} else {
+		this.intent = __SLAG_PROPERTIES.intent || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ActivityResult(properties);
+};

--- a/lib/titanium/6.0.4.GA/AnimationOption.js
+++ b/lib/titanium/6.0.4.GA/AnimationOption.js
@@ -1,0 +1,32 @@
+var crypto = require('crypto');
+function animationOption(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new animationOption(properties);
+};

--- a/lib/titanium/6.0.4.GA/Attribute.js
+++ b/lib/titanium/6.0.4.GA/Attribute.js
@@ -1,0 +1,53 @@
+var crypto = require('crypto');
+function Attribute(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'type',
+			'value',
+			'range',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.range = undefined;
+	} else {
+		this.range = __SLAG_PROPERTIES.range || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Attribute(properties);
+};

--- a/lib/titanium/6.0.4.GA/BarItemType.js
+++ b/lib/titanium/6.0.4.GA/BarItemType.js
@@ -1,0 +1,72 @@
+var crypto = require('crypto');
+function BarItemType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'title',
+			'image',
+			'width',
+			'enabled',
+			'accessibilityLabel',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enabled = undefined;
+	} else {
+		this.enabled = __SLAG_PROPERTIES.enabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new BarItemType(properties);
+};

--- a/lib/titanium/6.0.4.GA/BoundaryIdentifier.js
+++ b/lib/titanium/6.0.4.GA/BoundaryIdentifier.js
@@ -1,0 +1,50 @@
+var crypto = require('crypto');
+function BoundaryIdentifier(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'identifier',
+			'point1',
+			'point2',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.identifier = undefined;
+	} else {
+		this.identifier = __SLAG_PROPERTIES.identifier || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.point1 = undefined;
+	} else {
+		this.point1 = __SLAG_PROPERTIES.point1 || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.point2 = undefined;
+	} else {
+		this.point2 = __SLAG_PROPERTIES.point2 || {
+			x: 0,
+			y: 0
+		};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new BoundaryIdentifier(properties);
+};

--- a/lib/titanium/6.0.4.GA/CalendarPermissionResponse.js
+++ b/lib/titanium/6.0.4.GA/CalendarPermissionResponse.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function CalendarPermissionResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CalendarPermissionResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CameraMediaItemType.js
+++ b/lib/titanium/6.0.4.GA/CameraMediaItemType.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function CameraMediaItemType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'media',
+			'mediaType',
+			'cropRect',
+			'previewRect',
+			'livePhoto',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.media = undefined;
+	} else {
+		this.media = __SLAG_PROPERTIES.media || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaType = undefined;
+	} else {
+		this.mediaType = __SLAG_PROPERTIES.mediaType || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cropRect = undefined;
+	} else {
+		this.cropRect = __SLAG_PROPERTIES.cropRect || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewRect = undefined;
+	} else {
+		this.previewRect = __SLAG_PROPERTIES.previewRect || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.livePhoto = undefined;
+	} else {
+		this.livePhoto = __SLAG_PROPERTIES.livePhoto || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CameraMediaItemType(properties);
+};

--- a/lib/titanium/6.0.4.GA/CameraOptionsType.js
+++ b/lib/titanium/6.0.4.GA/CameraOptionsType.js
@@ -1,0 +1,166 @@
+var crypto = require('crypto');
+function CameraOptionsType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'cancel',
+			'autohide',
+			'animated',
+			'saveToPhotoGallery',
+			'allowEditing',
+			'mediaTypes',
+			'videoMaximumDuration',
+			'videoQuality',
+			'whichCamera',
+			'showControls',
+			'overlay',
+			'transform',
+			'inPopOver',
+			'popoverView',
+			'arrowDirection',
+			'autorotate',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancel = undefined;
+	} else {
+		this.cancel = __SLAG_PROPERTIES.cancel || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autohide = undefined;
+	} else {
+		this.autohide = __SLAG_PROPERTIES.autohide || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.saveToPhotoGallery = undefined;
+	} else {
+		this.saveToPhotoGallery = __SLAG_PROPERTIES.saveToPhotoGallery || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowEditing = undefined;
+	} else {
+		this.allowEditing = __SLAG_PROPERTIES.allowEditing || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaTypes = undefined;
+	} else {
+		this.mediaTypes = __SLAG_PROPERTIES.mediaTypes || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.videoMaximumDuration = undefined;
+	} else {
+		this.videoMaximumDuration = __SLAG_PROPERTIES.videoMaximumDuration || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.videoQuality = undefined;
+	} else {
+		this.videoQuality = __SLAG_PROPERTIES.videoQuality || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.whichCamera = undefined;
+	} else {
+		this.whichCamera = __SLAG_PROPERTIES.whichCamera || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showControls = undefined;
+	} else {
+		this.showControls = __SLAG_PROPERTIES.showControls || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overlay = undefined;
+	} else {
+		this.overlay = __SLAG_PROPERTIES.overlay || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.inPopOver = undefined;
+	} else {
+		this.inPopOver = __SLAG_PROPERTIES.inPopOver || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.popoverView = undefined;
+	} else {
+		this.popoverView = __SLAG_PROPERTIES.popoverView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.arrowDirection = undefined;
+	} else {
+		this.arrowDirection = __SLAG_PROPERTIES.arrowDirection || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autorotate = undefined;
+	} else {
+		this.autorotate = __SLAG_PROPERTIES.autorotate || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CameraOptionsType(properties);
+};

--- a/lib/titanium/6.0.4.GA/ClipboardItemsType.js
+++ b/lib/titanium/6.0.4.GA/ClipboardItemsType.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function ClipboardItemsType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'items',
+			'options',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = __SLAG_PROPERTIES.items || [];
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.options = undefined;
+	} else {
+		this.options = __SLAG_PROPERTIES.options || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ClipboardItemsType(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudACLsCheckResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudACLsCheckResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudACLsCheckResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'permission',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.permission = undefined;
+	} else {
+		this.permission = __SLAG_PROPERTIES.permission || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudACLsCheckResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudACLsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudACLsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudACLsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'acls',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.acls = undefined;
+	} else {
+		this.acls = __SLAG_PROPERTIES.acls || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudACLsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudChatGroupsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudChatGroupsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudChatGroupsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'chat_groups',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.chat_groups = undefined;
+	} else {
+		this.chat_groups = __SLAG_PROPERTIES.chat_groups || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudChatGroupsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudChatsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudChatsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudChatsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'chats',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.chats = undefined;
+	} else {
+		this.chats = __SLAG_PROPERTIES.chats || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudChatsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudCheckinsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudCheckinsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudCheckinsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'checkins',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.checkins = undefined;
+	} else {
+		this.checkins = __SLAG_PROPERTIES.checkins || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudCheckinsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudClientsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudClientsResponse.js
@@ -1,0 +1,96 @@
+var crypto = require('crypto');
+function CloudClientsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'ip_address',
+			'location',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ip_address = undefined;
+	} else {
+		this.ip_address = __SLAG_PROPERTIES.ip_address || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.location = undefined;
+	} else {
+		this.location = __SLAG_PROPERTIES.location || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudClientsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudEmailsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudEmailsResponse.js
@@ -1,0 +1,76 @@
+var crypto = require('crypto');
+function CloudEmailsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudEmailsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudEventOccurrencesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudEventOccurrencesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudEventOccurrencesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'event_occurrences',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.event_occurrences = undefined;
+	} else {
+		this.event_occurrences = __SLAG_PROPERTIES.event_occurrences || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudEventOccurrencesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudEventsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudEventsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudEventsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'events',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.events = undefined;
+	} else {
+		this.events = __SLAG_PROPERTIES.events || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudEventsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudFilesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudFilesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudFilesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'files',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.files = undefined;
+	} else {
+		this.files = __SLAG_PROPERTIES.files || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudFilesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudFriendRequestsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudFriendRequestsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudFriendRequestsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'friend_requests',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.friend_requests = undefined;
+	} else {
+		this.friend_requests = __SLAG_PROPERTIES.friend_requests || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudFriendRequestsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudFriendsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudFriendsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudFriendsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'users',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.users = undefined;
+	} else {
+		this.users = __SLAG_PROPERTIES.users || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudFriendsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudGeoFenceResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudGeoFenceResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudGeoFenceResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'geo_fences',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.geo_fences = undefined;
+	} else {
+		this.geo_fences = __SLAG_PROPERTIES.geo_fences || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudGeoFenceResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudKeyValuesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudKeyValuesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudKeyValuesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'keyvalues',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyvalues = undefined;
+	} else {
+		this.keyvalues = __SLAG_PROPERTIES.keyvalues || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudKeyValuesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudLikesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudLikesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudLikesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'likes',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.likes = undefined;
+	} else {
+		this.likes = __SLAG_PROPERTIES.likes || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudLikesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudMessagesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudMessagesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudMessagesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'messages',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.messages = undefined;
+	} else {
+		this.messages = __SLAG_PROPERTIES.messages || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudMessagesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudObjectsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudObjectsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudObjectsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'classname',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.classname = undefined;
+	} else {
+		this.classname = __SLAG_PROPERTIES.classname || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudObjectsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPhotoCollectionsPhotosResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPhotoCollectionsPhotosResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPhotoCollectionsPhotosResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'photos',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.photos = undefined;
+	} else {
+		this.photos = __SLAG_PROPERTIES.photos || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPhotoCollectionsPhotosResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPhotoCollectionsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPhotoCollectionsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPhotoCollectionsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'collections',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.collections = undefined;
+	} else {
+		this.collections = __SLAG_PROPERTIES.collections || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPhotoCollectionsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPhotosResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPhotosResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPhotosResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'photos',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.photos = undefined;
+	} else {
+		this.photos = __SLAG_PROPERTIES.photos || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPhotosResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPlacesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPlacesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPlacesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'places',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.places = undefined;
+	} else {
+		this.places = __SLAG_PROPERTIES.places || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPlacesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPostsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPostsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPostsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'posts',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.posts = undefined;
+	} else {
+		this.posts = __SLAG_PROPERTIES.posts || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPostsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushNotificationConfig.js
+++ b/lib/titanium/6.0.4.GA/CloudPushNotificationConfig.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function CloudPushNotificationConfig(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushNotificationConfig(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushNotificationErrorArg.js
+++ b/lib/titanium/6.0.4.GA/CloudPushNotificationErrorArg.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+function CloudPushNotificationErrorArg(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'error',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushNotificationErrorArg(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushNotificationSuccessArg.js
+++ b/lib/titanium/6.0.4.GA/CloudPushNotificationSuccessArg.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+function CloudPushNotificationSuccessArg(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'deviceToken',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.deviceToken = undefined;
+	} else {
+		this.deviceToken = __SLAG_PROPERTIES.deviceToken || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushNotificationSuccessArg(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushNotificationsQueryChannelResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPushNotificationsQueryChannelResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPushNotificationsQueryChannelResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'push_channels',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.push_channels = undefined;
+	} else {
+		this.push_channels = __SLAG_PROPERTIES.push_channels || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushNotificationsQueryChannelResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushNotificationsQueryResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPushNotificationsQueryResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPushNotificationsQueryResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'subscriptions',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subscriptions = undefined;
+	} else {
+		this.subscriptions = __SLAG_PROPERTIES.subscriptions || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushNotificationsQueryResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushNotificationsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPushNotificationsResponse.js
@@ -1,0 +1,76 @@
+var crypto = require('crypto');
+function CloudPushNotificationsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushNotificationsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushNotificationsShowChannelResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPushNotificationsShowChannelResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPushNotificationsShowChannelResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'devices',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.devices = undefined;
+	} else {
+		this.devices = __SLAG_PROPERTIES.devices || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushNotificationsShowChannelResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudPushSchedulesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudPushSchedulesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudPushSchedulesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'push_schedules',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.push_schedules = undefined;
+	} else {
+		this.push_schedules = __SLAG_PROPERTIES.push_schedules || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudPushSchedulesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudResponse.js
@@ -1,0 +1,76 @@
+var crypto = require('crypto');
+function CloudResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudReviewsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudReviewsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudReviewsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'reviews',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.reviews = undefined;
+	} else {
+		this.reviews = __SLAG_PROPERTIES.reviews || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudReviewsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudSocialIntegrationsResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudSocialIntegrationsResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudSocialIntegrationsResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'users',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.users = undefined;
+	} else {
+		this.users = __SLAG_PROPERTIES.users || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudSocialIntegrationsResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudStatusesResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudStatusesResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudStatusesResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'statuses',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.statuses = undefined;
+	} else {
+		this.statuses = __SLAG_PROPERTIES.statuses || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudStatusesResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudStreamProgress.js
+++ b/lib/titanium/6.0.4.GA/CloudStreamProgress.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function CloudStreamProgress(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'progress',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.progress = undefined;
+	} else {
+		this.progress = __SLAG_PROPERTIES.progress || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudStreamProgress(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudUsersResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudUsersResponse.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function CloudUsersResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'users',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.users = undefined;
+	} else {
+		this.users = __SLAG_PROPERTIES.users || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudUsersResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudUsersSecureDialog.js
+++ b/lib/titanium/6.0.4.GA/CloudUsersSecureDialog.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+function CloudUsersSecureDialog(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'title',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudUsersSecureDialog(properties);
+};

--- a/lib/titanium/6.0.4.GA/CloudUsersSecureResponse.js
+++ b/lib/titanium/6.0.4.GA/CloudUsersSecureResponse.js
@@ -1,0 +1,96 @@
+var crypto = require('crypto');
+function CloudUsersSecureResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'meta',
+			'code',
+			'message',
+			'accessToken',
+			'expiresIn',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.meta = undefined;
+	} else {
+		this.meta = __SLAG_PROPERTIES.meta || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessToken = undefined;
+	} else {
+		this.accessToken = __SLAG_PROPERTIES.accessToken || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.expiresIn = undefined;
+	} else {
+		this.expiresIn = __SLAG_PROPERTIES.expiresIn || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CloudUsersSecureResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/ConnectedCallbackArgs.js
+++ b/lib/titanium/6.0.4.GA/ConnectedCallbackArgs.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+function ConnectedCallbackArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'socket',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.socket = undefined;
+	} else {
+		this.socket = __SLAG_PROPERTIES.socket || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ConnectedCallbackArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/ContactsAuthorizationResponse.js
+++ b/lib/titanium/6.0.4.GA/ContactsAuthorizationResponse.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function ContactsAuthorizationResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ContactsAuthorizationResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/CoverFlowImageType.js
+++ b/lib/titanium/6.0.4.GA/CoverFlowImageType.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function CoverFlowImageType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'image',
+			'width',
+			'height',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CoverFlowImageType(properties);
+};

--- a/lib/titanium/6.0.4.GA/CreateBufferArgs.js
+++ b/lib/titanium/6.0.4.GA/CreateBufferArgs.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function CreateBufferArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'value',
+			'length',
+			'type',
+			'byteOrder',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = __SLAG_PROPERTIES.length || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.byteOrder = undefined;
+	} else {
+		this.byteOrder = __SLAG_PROPERTIES.byteOrder || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CreateBufferArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/CreateStreamArgs.js
+++ b/lib/titanium/6.0.4.GA/CreateStreamArgs.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function CreateStreamArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'source',
+			'mode',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mode = undefined;
+	} else {
+		this.mode = __SLAG_PROPERTIES.mode || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CreateStreamArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/CropRectType.js
+++ b/lib/titanium/6.0.4.GA/CropRectType.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function CropRectType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'x',
+			'y',
+			'width',
+			'height',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.x = undefined;
+	} else {
+		this.x = __SLAG_PROPERTIES.x || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.y = undefined;
+	} else {
+		this.y = __SLAG_PROPERTIES.y || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new CropRectType(properties);
+};

--- a/lib/titanium/6.0.4.GA/DecodeNumberDict.js
+++ b/lib/titanium/6.0.4.GA/DecodeNumberDict.js
@@ -1,0 +1,64 @@
+var crypto = require('crypto');
+function DecodeNumberDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'source',
+			'type',
+			'position',
+			'byteOrder',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.position = undefined;
+	} else {
+		this.position = __SLAG_PROPERTIES.position || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.byteOrder = undefined;
+	} else {
+		this.byteOrder = __SLAG_PROPERTIES.byteOrder || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new DecodeNumberDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/DecodeStringDict.js
+++ b/lib/titanium/6.0.4.GA/DecodeStringDict.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function DecodeStringDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'source',
+			'position',
+			'length',
+			'charset',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.position = undefined;
+	} else {
+		this.position = __SLAG_PROPERTIES.position || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = __SLAG_PROPERTIES.length || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.charset = undefined;
+	} else {
+		this.charset = __SLAG_PROPERTIES.charset || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new DecodeStringDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/Dictionary.js
+++ b/lib/titanium/6.0.4.GA/Dictionary.js
@@ -1,0 +1,24 @@
+var crypto = require('crypto');
+function Dictionary(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Dictionary(properties);
+};

--- a/lib/titanium/6.0.4.GA/Dimension.js
+++ b/lib/titanium/6.0.4.GA/Dimension.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function Dimension(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'height',
+			'width',
+			'x',
+			'y',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.x = undefined;
+	} else {
+		this.x = __SLAG_PROPERTIES.x || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.y = undefined;
+	} else {
+		this.y = __SLAG_PROPERTIES.y || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Dimension(properties);
+};

--- a/lib/titanium/6.0.4.GA/DocumentViewerOptions.js
+++ b/lib/titanium/6.0.4.GA/DocumentViewerOptions.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function DocumentViewerOptions(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'view',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.view = undefined;
+	} else {
+		this.view = __SLAG_PROPERTIES.view || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new DocumentViewerOptions(properties);
+};

--- a/lib/titanium/6.0.4.GA/EncodeNumberDict.js
+++ b/lib/titanium/6.0.4.GA/EncodeNumberDict.js
@@ -1,0 +1,75 @@
+var crypto = require('crypto');
+function EncodeNumberDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'source',
+			'dest',
+			'type',
+			'position',
+			'byteOrder',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.dest = undefined;
+	} else {
+		this.dest = __SLAG_PROPERTIES.dest || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.position = undefined;
+	} else {
+		this.position = __SLAG_PROPERTIES.position || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.byteOrder = undefined;
+	} else {
+		this.byteOrder = __SLAG_PROPERTIES.byteOrder || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new EncodeNumberDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/EncodeStringDict.js
+++ b/lib/titanium/6.0.4.GA/EncodeStringDict.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function EncodeStringDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'source',
+			'dest',
+			'destPosition',
+			'sourcePosition',
+			'sourceLength',
+			'charset',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.dest = undefined;
+	} else {
+		this.dest = __SLAG_PROPERTIES.dest || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.destPosition = undefined;
+	} else {
+		this.destPosition = __SLAG_PROPERTIES.destPosition || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sourcePosition = undefined;
+	} else {
+		this.sourcePosition = __SLAG_PROPERTIES.sourcePosition || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sourceLength = undefined;
+	} else {
+		this.sourceLength = __SLAG_PROPERTIES.sourceLength || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.charset = undefined;
+	} else {
+		this.charset = __SLAG_PROPERTIES.charset || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new EncodeStringDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/ErrorCallbackArgs.js
+++ b/lib/titanium/6.0.4.GA/ErrorCallbackArgs.js
@@ -1,0 +1,70 @@
+var crypto = require('crypto');
+function ErrorCallbackArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'socket',
+			'errorCode',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.socket = undefined;
+	} else {
+		this.socket = __SLAG_PROPERTIES.socket || {};
+	}
+	if (__SLAG_PROPERTIES.errorCode) {
+		throw new Error('ErrorCallbackArgs.errorCode was deprecated, since 3.1.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ErrorCallbackArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/ErrorResponse.js
+++ b/lib/titanium/6.0.4.GA/ErrorResponse.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function ErrorResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ErrorResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/EventsAuthorizationResponse.js
+++ b/lib/titanium/6.0.4.GA/EventsAuthorizationResponse.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function EventsAuthorizationResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new EventsAuthorizationResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/FacebookDialogResponsev1.js
+++ b/lib/titanium/6.0.4.GA/FacebookDialogResponsev1.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function FacebookDialogResponsev1(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'cancelled',
+			'result',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancelled = undefined;
+	} else {
+		this.cancelled = __SLAG_PROPERTIES.cancelled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.result = undefined;
+	} else {
+		this.result = __SLAG_PROPERTIES.result || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new FacebookDialogResponsev1(properties);
+};

--- a/lib/titanium/6.0.4.GA/FacebookGraphResponsev1.js
+++ b/lib/titanium/6.0.4.GA/FacebookGraphResponsev1.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function FacebookGraphResponsev1(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'path',
+			'result',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.path = undefined;
+	} else {
+		this.path = __SLAG_PROPERTIES.path || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.result = undefined;
+	} else {
+		this.result = __SLAG_PROPERTIES.result || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new FacebookGraphResponsev1(properties);
+};

--- a/lib/titanium/6.0.4.GA/FacebookRESTResponsev1.js
+++ b/lib/titanium/6.0.4.GA/FacebookRESTResponsev1.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function FacebookRESTResponsev1(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'method',
+			'result',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.method = undefined;
+	} else {
+		this.method = __SLAG_PROPERTIES.method || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.result = undefined;
+	} else {
+		this.result = __SLAG_PROPERTIES.result || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new FacebookRESTResponsev1(properties);
+};

--- a/lib/titanium/6.0.4.GA/FailureResponse.js
+++ b/lib/titanium/6.0.4.GA/FailureResponse.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function FailureResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new FailureResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/Font.js
+++ b/lib/titanium/6.0.4.GA/Font.js
@@ -1,0 +1,68 @@
+var crypto = require('crypto');
+function Font(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'fontFamily',
+			'fontSize',
+			'fontWeight',
+			'fontStyle',
+			'textStyle',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fontFamily = undefined;
+	} else {
+		this.fontFamily = __SLAG_PROPERTIES.fontFamily || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fontSize = undefined;
+	} else {
+		this.fontSize = __SLAG_PROPERTIES.fontSize || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fontWeight = undefined;
+	} else {
+		this.fontWeight = __SLAG_PROPERTIES.fontWeight || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fontStyle = undefined;
+	} else {
+		this.fontStyle = __SLAG_PROPERTIES.fontStyle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textStyle = undefined;
+	} else {
+		this.textStyle = __SLAG_PROPERTIES.textStyle || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Font(properties);
+};

--- a/lib/titanium/6.0.4.GA/ForwardGeocodeResponse.js
+++ b/lib/titanium/6.0.4.GA/ForwardGeocodeResponse.js
@@ -1,0 +1,148 @@
+var crypto = require('crypto');
+function ForwardGeocodeResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'accuracy',
+			'longitude',
+			'latitude',
+			'street',
+			'street1',
+			'city',
+			'region1',
+			'region2',
+			'postalCode',
+			'country',
+			'countryCode',
+			'country_code',
+			'displayAddress',
+			'address',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accuracy = undefined;
+	} else {
+		this.accuracy = __SLAG_PROPERTIES.accuracy || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitude = undefined;
+	} else {
+		this.longitude = __SLAG_PROPERTIES.longitude || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitude = undefined;
+	} else {
+		this.latitude = __SLAG_PROPERTIES.latitude || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.street = undefined;
+	} else {
+		this.street = __SLAG_PROPERTIES.street || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.street1 = undefined;
+	} else {
+		this.street1 = __SLAG_PROPERTIES.street1 || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.city = undefined;
+	} else {
+		this.city = __SLAG_PROPERTIES.city || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.region1 = undefined;
+	} else {
+		this.region1 = __SLAG_PROPERTIES.region1 || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.region2 = undefined;
+	} else {
+		this.region2 = __SLAG_PROPERTIES.region2 || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.postalCode = undefined;
+	} else {
+		this.postalCode = __SLAG_PROPERTIES.postalCode || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.country = undefined;
+	} else {
+		this.country = __SLAG_PROPERTIES.country || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.countryCode = undefined;
+	} else {
+		this.countryCode = __SLAG_PROPERTIES.countryCode || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.country_code = undefined;
+	} else {
+		this.country_code = __SLAG_PROPERTIES.country_code || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.displayAddress = undefined;
+	} else {
+		this.displayAddress = __SLAG_PROPERTIES.displayAddress || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.address = undefined;
+	} else {
+		this.address = __SLAG_PROPERTIES.address || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ForwardGeocodeResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/GeocodedAddress.js
+++ b/lib/titanium/6.0.4.GA/GeocodedAddress.js
@@ -1,0 +1,131 @@
+var crypto = require('crypto');
+function GeocodedAddress(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'street',
+			'street1',
+			'city',
+			'region1',
+			'region2',
+			'postalCode',
+			'zipcode',
+			'country',
+			'countryCode',
+			'country_code',
+			'longitude',
+			'latitude',
+			'displayAddress',
+			'address',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.street = undefined;
+	} else {
+		this.street = __SLAG_PROPERTIES.street || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.street1 = undefined;
+	} else {
+		this.street1 = __SLAG_PROPERTIES.street1 || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.city = undefined;
+	} else {
+		this.city = __SLAG_PROPERTIES.city || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.region1 = undefined;
+	} else {
+		this.region1 = __SLAG_PROPERTIES.region1 || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.region2 = undefined;
+	} else {
+		this.region2 = __SLAG_PROPERTIES.region2 || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.postalCode = undefined;
+	} else {
+		this.postalCode = __SLAG_PROPERTIES.postalCode || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zipcode = undefined;
+	} else {
+		this.zipcode = __SLAG_PROPERTIES.zipcode || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.country = undefined;
+	} else {
+		this.country = __SLAG_PROPERTIES.country || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.countryCode = undefined;
+	} else {
+		this.countryCode = __SLAG_PROPERTIES.countryCode || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.country_code = undefined;
+	} else {
+		this.country_code = __SLAG_PROPERTIES.country_code || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitude = undefined;
+	} else {
+		this.longitude = __SLAG_PROPERTIES.longitude || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitude = undefined;
+	} else {
+		this.latitude = __SLAG_PROPERTIES.latitude || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.displayAddress = undefined;
+	} else {
+		this.displayAddress = __SLAG_PROPERTIES.displayAddress || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.address = undefined;
+	} else {
+		this.address = __SLAG_PROPERTIES.address || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new GeocodedAddress(properties);
+};

--- a/lib/titanium/6.0.4.GA/Global.js
+++ b/lib/titanium/6.0.4.GA/Global.js
@@ -1,0 +1,111 @@
+var crypto = require('crypto');
+function Global(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Global.prototype.alert = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Global.prototype.clearInterval = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Global.prototype.clearTimeout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Global.prototype.decodeURIComponent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Global.prototype.encodeURIComponent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Global.prototype.L = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Global.prototype.require = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Global.prototype.setInterval = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Global.prototype.setTimeout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+module.exports = function (properties) {
+	return new Global(properties);
+};

--- a/lib/titanium/6.0.4.GA/Global/JSON.js
+++ b/lib/titanium/6.0.4.GA/Global/JSON.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function JSON(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+JSON.prototype.stringify = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+JSON.prototype.parse = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+module.exports = function (properties) {
+	return new JSON(properties);
+};

--- a/lib/titanium/6.0.4.GA/Global/String.js
+++ b/lib/titanium/6.0.4.GA/Global/String.js
@@ -1,0 +1,69 @@
+var crypto = require('crypto');
+function String(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+String.prototype.format = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+String.prototype.formatCurrency = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+String.prototype.formatDate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+String.prototype.formatDecimal = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+String.prototype.formatTime = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+module.exports = function (properties) {
+	return new String(properties);
+};

--- a/lib/titanium/6.0.4.GA/Global/console.js
+++ b/lib/titanium/6.0.4.GA/Global/console.js
@@ -1,0 +1,69 @@
+var crypto = require('crypto');
+function console(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+console.prototype.log = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+console.prototype.info = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+console.prototype.warn = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+console.prototype.error = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+console.prototype.debug = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+module.exports = function (properties) {
+	return new console(properties);
+};

--- a/lib/titanium/6.0.4.GA/Gradient.js
+++ b/lib/titanium/6.0.4.GA/Gradient.js
@@ -1,0 +1,98 @@
+var crypto = require('crypto');
+function Gradient(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'type',
+			'startPoint',
+			'endPoint',
+			'startRadius',
+			'endRadius',
+			'colors',
+			'backfillStart',
+			'backfillEnd',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.startPoint = undefined;
+	} else {
+		this.startPoint = __SLAG_PROPERTIES.startPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.endPoint = undefined;
+	} else {
+		this.endPoint = __SLAG_PROPERTIES.endPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.startRadius = undefined;
+	} else {
+		this.startRadius = __SLAG_PROPERTIES.startRadius || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.endRadius = undefined;
+	} else {
+		this.endRadius = __SLAG_PROPERTIES.endRadius || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.colors = undefined;
+	} else {
+		this.colors = __SLAG_PROPERTIES.colors || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backfillStart = undefined;
+	} else {
+		this.backfillStart = __SLAG_PROPERTIES.backfillStart || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backfillEnd = undefined;
+	} else {
+		this.backfillEnd = __SLAG_PROPERTIES.backfillEnd || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Gradient(properties);
+};

--- a/lib/titanium/6.0.4.GA/GradientColorRef.js
+++ b/lib/titanium/6.0.4.GA/GradientColorRef.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function GradientColorRef(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'color',
+			'offset',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.offset = undefined;
+	} else {
+		this.offset = __SLAG_PROPERTIES.offset || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new GradientColorRef(properties);
+};

--- a/lib/titanium/6.0.4.GA/HeadingData.js
+++ b/lib/titanium/6.0.4.GA/HeadingData.js
@@ -1,0 +1,92 @@
+var crypto = require('crypto');
+function HeadingData(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'accuracy',
+			'magneticHeading',
+			'trueHeading',
+			'timestamp',
+			'x',
+			'y',
+			'z',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accuracy = undefined;
+	} else {
+		this.accuracy = __SLAG_PROPERTIES.accuracy || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.magneticHeading = undefined;
+	} else {
+		this.magneticHeading = __SLAG_PROPERTIES.magneticHeading || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.trueHeading = undefined;
+	} else {
+		this.trueHeading = __SLAG_PROPERTIES.trueHeading || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.timestamp = undefined;
+	} else {
+		this.timestamp = __SLAG_PROPERTIES.timestamp || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.x = undefined;
+	} else {
+		this.x = __SLAG_PROPERTIES.x || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.y = undefined;
+	} else {
+		this.y = __SLAG_PROPERTIES.y || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.z = undefined;
+	} else {
+		this.z = __SLAG_PROPERTIES.z || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new HeadingData(properties);
+};

--- a/lib/titanium/6.0.4.GA/HeadingResponse.js
+++ b/lib/titanium/6.0.4.GA/HeadingResponse.js
@@ -1,0 +1,54 @@
+var crypto = require('crypto');
+function HeadingResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'heading',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.heading = undefined;
+	} else {
+		this.heading = __SLAG_PROPERTIES.heading || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new HeadingResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/ImageAsCroppedDict.js
+++ b/lib/titanium/6.0.4.GA/ImageAsCroppedDict.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function ImageAsCroppedDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'width',
+			'height',
+			'x',
+			'y',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.x = undefined;
+	} else {
+		this.x = __SLAG_PROPERTIES.x || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.y = undefined;
+	} else {
+		this.y = __SLAG_PROPERTIES.y || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ImageAsCroppedDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/ItemTemplate.js
+++ b/lib/titanium/6.0.4.GA/ItemTemplate.js
@@ -1,0 +1,53 @@
+var crypto = require('crypto');
+function ItemTemplate(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'properties',
+			'events',
+			'childTemplates',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.properties = undefined;
+	} else {
+		this.properties = __SLAG_PROPERTIES.properties || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.events = undefined;
+	} else {
+		this.events = __SLAG_PROPERTIES.events || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childTemplates = undefined;
+	} else {
+		this.childTemplates = __SLAG_PROPERTIES.childTemplates || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ItemTemplate(properties);
+};

--- a/lib/titanium/6.0.4.GA/LaunchOptionsType.js
+++ b/lib/titanium/6.0.4.GA/LaunchOptionsType.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function LaunchOptionsType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'source',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new LaunchOptionsType(properties);
+};

--- a/lib/titanium/6.0.4.GA/ListDataItem.js
+++ b/lib/titanium/6.0.4.GA/ListDataItem.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function ListDataItem(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'template',
+			'properties',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.template = undefined;
+	} else {
+		this.template = __SLAG_PROPERTIES.template || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.properties = undefined;
+	} else {
+		this.properties = __SLAG_PROPERTIES.properties || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ListDataItem(properties);
+};

--- a/lib/titanium/6.0.4.GA/ListViewAnimationProperties.js
+++ b/lib/titanium/6.0.4.GA/ListViewAnimationProperties.js
@@ -1,0 +1,53 @@
+var crypto = require('crypto');
+function ListViewAnimationProperties(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'animationStyle',
+			'position',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animationStyle = undefined;
+	} else {
+		this.animationStyle = __SLAG_PROPERTIES.animationStyle || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.position = undefined;
+	} else {
+		this.position = __SLAG_PROPERTIES.position || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ListViewAnimationProperties(properties);
+};

--- a/lib/titanium/6.0.4.GA/ListViewContentInsetOption.js
+++ b/lib/titanium/6.0.4.GA/ListViewContentInsetOption.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function ListViewContentInsetOption(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'duration',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ListViewContentInsetOption(properties);
+};

--- a/lib/titanium/6.0.4.GA/ListViewEdgeInsets.js
+++ b/lib/titanium/6.0.4.GA/ListViewEdgeInsets.js
@@ -1,0 +1,50 @@
+var crypto = require('crypto');
+function ListViewEdgeInsets(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'top',
+			'left',
+			'right',
+			'bottom',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ListViewEdgeInsets(properties);
+};

--- a/lib/titanium/6.0.4.GA/ListViewIndexEntry.js
+++ b/lib/titanium/6.0.4.GA/ListViewIndexEntry.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function ListViewIndexEntry(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'title',
+			'index',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.index = undefined;
+	} else {
+		this.index = __SLAG_PROPERTIES.index || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ListViewIndexEntry(properties);
+};

--- a/lib/titanium/6.0.4.GA/ListViewMarkerProps.js
+++ b/lib/titanium/6.0.4.GA/ListViewMarkerProps.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function ListViewMarkerProps(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'sectionIndex',
+			'itemIndex',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sectionIndex = undefined;
+	} else {
+		this.sectionIndex = __SLAG_PROPERTIES.sectionIndex || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.itemIndex = undefined;
+	} else {
+		this.itemIndex = __SLAG_PROPERTIES.itemIndex || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ListViewMarkerProps(properties);
+};

--- a/lib/titanium/6.0.4.GA/LocationAuthorizationResponse.js
+++ b/lib/titanium/6.0.4.GA/LocationAuthorizationResponse.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function LocationAuthorizationResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new LocationAuthorizationResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/LocationCoordinates.js
+++ b/lib/titanium/6.0.4.GA/LocationCoordinates.js
@@ -1,0 +1,112 @@
+var crypto = require('crypto');
+function LocationCoordinates(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'latitude',
+			'longitude',
+			'altitude',
+			'accuracy',
+			'altitudeAccuracy',
+			'heading',
+			'speed',
+			'timestamp',
+			'floor',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitude = undefined;
+	} else {
+		this.latitude = __SLAG_PROPERTIES.latitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitude = undefined;
+	} else {
+		this.longitude = __SLAG_PROPERTIES.longitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.altitude = undefined;
+	} else {
+		this.altitude = __SLAG_PROPERTIES.altitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accuracy = undefined;
+	} else {
+		this.accuracy = __SLAG_PROPERTIES.accuracy || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.altitudeAccuracy = undefined;
+	} else {
+		this.altitudeAccuracy = __SLAG_PROPERTIES.altitudeAccuracy || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.heading = undefined;
+	} else {
+		this.heading = __SLAG_PROPERTIES.heading || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.speed = undefined;
+	} else {
+		this.speed = __SLAG_PROPERTIES.speed || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.timestamp = undefined;
+	} else {
+		this.timestamp = __SLAG_PROPERTIES.timestamp || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.floor = undefined;
+	} else {
+		this.floor = __SLAG_PROPERTIES.floor || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new LocationCoordinates(properties);
+};

--- a/lib/titanium/6.0.4.GA/LocationCoordinatesFloor.js
+++ b/lib/titanium/6.0.4.GA/LocationCoordinatesFloor.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+function LocationCoordinatesFloor(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'level',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.level = undefined;
+	} else {
+		this.level = __SLAG_PROPERTIES.level || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new LocationCoordinatesFloor(properties);
+};

--- a/lib/titanium/6.0.4.GA/LocationProviderDict.js
+++ b/lib/titanium/6.0.4.GA/LocationProviderDict.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function LocationProviderDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'accuracy',
+			'name',
+			'power',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accuracy = undefined;
+	} else {
+		this.accuracy = __SLAG_PROPERTIES.accuracy || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.power = undefined;
+	} else {
+		this.power = __SLAG_PROPERTIES.power || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new LocationProviderDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/LocationResults.js
+++ b/lib/titanium/6.0.4.GA/LocationResults.js
@@ -1,0 +1,72 @@
+var crypto = require('crypto');
+function LocationResults(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'provider',
+			'coords',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.provider = undefined;
+	} else {
+		this.provider = __SLAG_PROPERTIES.provider || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.coords = undefined;
+	} else {
+		this.coords = __SLAG_PROPERTIES.coords || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new LocationResults(properties);
+};

--- a/lib/titanium/6.0.4.GA/MapLocationType.js
+++ b/lib/titanium/6.0.4.GA/MapLocationType.js
@@ -1,0 +1,86 @@
+var crypto = require('crypto');
+function MapLocationType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'longitude',
+			'latitude',
+			'longitudeDelta',
+			'latitudeDelta',
+			'animate',
+			'regionFit',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitude = undefined;
+	} else {
+		this.longitude = __SLAG_PROPERTIES.longitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitude = undefined;
+	} else {
+		this.latitude = __SLAG_PROPERTIES.latitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitudeDelta = undefined;
+	} else {
+		this.longitudeDelta = __SLAG_PROPERTIES.longitudeDelta || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitudeDelta = undefined;
+	} else {
+		this.latitudeDelta = __SLAG_PROPERTIES.latitudeDelta || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animate = undefined;
+	} else {
+		this.animate = __SLAG_PROPERTIES.animate || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.regionFit = undefined;
+	} else {
+		this.regionFit = __SLAG_PROPERTIES.regionFit || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MapLocationType(properties);
+};

--- a/lib/titanium/6.0.4.GA/MapPointType.js
+++ b/lib/titanium/6.0.4.GA/MapPointType.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function MapPointType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'longitude',
+			'latitude',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitude = undefined;
+	} else {
+		this.longitude = __SLAG_PROPERTIES.longitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitude = undefined;
+	} else {
+		this.latitude = __SLAG_PROPERTIES.latitude || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MapPointType(properties);
+};

--- a/lib/titanium/6.0.4.GA/MapRegionType.js
+++ b/lib/titanium/6.0.4.GA/MapRegionType.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function MapRegionType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'longitude',
+			'latitude',
+			'longitudeDelta',
+			'latitudeDelta',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitude = undefined;
+	} else {
+		this.longitude = __SLAG_PROPERTIES.longitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitude = undefined;
+	} else {
+		this.latitude = __SLAG_PROPERTIES.latitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitudeDelta = undefined;
+	} else {
+		this.longitudeDelta = __SLAG_PROPERTIES.longitudeDelta || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitudeDelta = undefined;
+	} else {
+		this.latitudeDelta = __SLAG_PROPERTIES.latitudeDelta || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MapRegionType(properties);
+};

--- a/lib/titanium/6.0.4.GA/MapRouteType.js
+++ b/lib/titanium/6.0.4.GA/MapRouteType.js
@@ -1,0 +1,69 @@
+var crypto = require('crypto');
+function MapRouteType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'name',
+			'points',
+			'color',
+			'width',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.points = undefined;
+	} else {
+		this.points = __SLAG_PROPERTIES.points || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MapRouteType(properties);
+};

--- a/lib/titanium/6.0.4.GA/MatrixCreationDict.js
+++ b/lib/titanium/6.0.4.GA/MatrixCreationDict.js
@@ -1,0 +1,52 @@
+var crypto = require('crypto');
+function MatrixCreationDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'scale',
+			'rotate',
+			'anchorPoint',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scale = undefined;
+	} else {
+		this.scale = __SLAG_PROPERTIES.scale || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotate = undefined;
+	} else {
+		this.rotate = __SLAG_PROPERTIES.rotate || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MatrixCreationDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/MediaAuthorizationResponse.js
+++ b/lib/titanium/6.0.4.GA/MediaAuthorizationResponse.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function MediaAuthorizationResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MediaAuthorizationResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/MediaQueryInfoType.js
+++ b/lib/titanium/6.0.4.GA/MediaQueryInfoType.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function MediaQueryInfoType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'value',
+			'exact',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.exact = undefined;
+	} else {
+		this.exact = __SLAG_PROPERTIES.exact || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MediaQueryInfoType(properties);
+};

--- a/lib/titanium/6.0.4.GA/MediaQueryType.js
+++ b/lib/titanium/6.0.4.GA/MediaQueryType.js
@@ -1,0 +1,80 @@
+var crypto = require('crypto');
+function MediaQueryType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'grouping',
+			'mediaType',
+			'title',
+			'albumTitle',
+			'artist',
+			'albumArtist',
+			'genre',
+			'composer',
+			'isCompilation',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.grouping = undefined;
+	} else {
+		this.grouping = __SLAG_PROPERTIES.grouping || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaType = undefined;
+	} else {
+		this.mediaType = __SLAG_PROPERTIES.mediaType || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.albumTitle = undefined;
+	} else {
+		this.albumTitle = __SLAG_PROPERTIES.albumTitle || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.artist = undefined;
+	} else {
+		this.artist = __SLAG_PROPERTIES.artist || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.albumArtist = undefined;
+	} else {
+		this.albumArtist = __SLAG_PROPERTIES.albumArtist || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.genre = undefined;
+	} else {
+		this.genre = __SLAG_PROPERTIES.genre || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.composer = undefined;
+	} else {
+		this.composer = __SLAG_PROPERTIES.composer || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isCompilation = undefined;
+	} else {
+		this.isCompilation = __SLAG_PROPERTIES.isCompilation || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MediaQueryType(properties);
+};

--- a/lib/titanium/6.0.4.GA/MediaScannerResponse.js
+++ b/lib/titanium/6.0.4.GA/MediaScannerResponse.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function MediaScannerResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'path',
+			'uri',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.path = undefined;
+	} else {
+		this.path = __SLAG_PROPERTIES.path || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.uri = undefined;
+	} else {
+		this.uri = __SLAG_PROPERTIES.uri || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MediaScannerResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/MenuPopupHideParams.js
+++ b/lib/titanium/6.0.4.GA/MenuPopupHideParams.js
@@ -1,0 +1,32 @@
+var crypto = require('crypto');
+function MenuPopupHideParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MenuPopupHideParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/MenuPopupShowParams.js
+++ b/lib/titanium/6.0.4.GA/MenuPopupShowParams.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function MenuPopupShowParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'view',
+			'animated',
+			'arrowDirection',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.view = undefined;
+	} else {
+		this.view = __SLAG_PROPERTIES.view || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.arrowDirection = undefined;
+	} else {
+		this.arrowDirection = __SLAG_PROPERTIES.arrowDirection || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MenuPopupShowParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/MessageReply.js
+++ b/lib/titanium/6.0.4.GA/MessageReply.js
@@ -1,0 +1,50 @@
+var crypto = require('crypto');
+function MessageReply(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'message',
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MessageReply(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules.js
+++ b/lib/titanium/6.0.4.GA/Modules.js
@@ -1,0 +1,24 @@
+var crypto = require('crypto');
+function Modules(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Modules(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud.js
@@ -1,0 +1,300 @@
+var crypto = require('crypto');
+function Cloud(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'debug',
+			'ondatastream',
+			'onsendstream',
+			'useSecure',
+			'sessionId',
+			'accessToken',
+			'expiresIn',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.debug = undefined;
+	} else {
+		this.debug = __SLAG_PROPERTIES.debug || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ondatastream = undefined;
+	} else {
+		this.ondatastream = __SLAG_PROPERTIES.ondatastream || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onsendstream = undefined;
+	} else {
+		this.onsendstream = __SLAG_PROPERTIES.onsendstream || {};
+	}
+	if (__SLAG_PROPERTIES.useSecure) {
+		throw new Error('Modules.Cloud.useSecure was deprecated, since 2.0');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sessionId = undefined;
+	} else {
+		this.sessionId = __SLAG_PROPERTIES.sessionId || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessToken = undefined;
+	} else {
+		this.accessToken = __SLAG_PROPERTIES.accessToken || '';
+	}
+	if (__SLAG_PROPERTIES.expiresIn) {
+		throw new Error('Modules.Cloud.expiresIn is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.expiresIn = undefined;
+	} else {
+		this.expiresIn = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Cloud.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Cloud.prototype.hasStoredSession = function () {
+	throw new Error('Modules.Cloud.hasStoredSession was deprecated, since 2.1.2');
+};
+Cloud.prototype.retrieveStoredSession = function () {
+	throw new Error('Modules.Cloud.retrieveStoredSession was deprecated, since 2.1.2');
+};
+Cloud.prototype.sendRequest = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Cloud.prototype.createX509CertificatePinningSecurityManager = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var X509CertificatePinningSecurityManager = require('./Cloud/X509CertificatePinningSecurityManager');
+	return X509CertificatePinningSecurityManager(__SLAG_PROPERTY);
+};
+Cloud.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Cloud.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Cloud.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Cloud.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Cloud.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Cloud.prototype.getDebug = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.debug;
+};
+Cloud.prototype.setDebug = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.debug = __SLAG__PROPERTY;
+};
+Cloud.prototype.getOndatastream = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ondatastream;
+};
+Cloud.prototype.setOndatastream = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ondatastream = __SLAG__PROPERTY;
+};
+Cloud.prototype.getOnsendstream = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onsendstream;
+};
+Cloud.prototype.setOnsendstream = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onsendstream = __SLAG__PROPERTY;
+};
+Cloud.prototype.getUseSecure = function () {
+	throw new Error('Modules.Cloud.getUseSecure was deprecated, since 2.0');
+};
+Cloud.prototype.setUseSecure = function () {
+	throw new Error('Modules.Cloud.setUseSecure was deprecated, since 2.0');
+};
+Cloud.prototype.getSessionId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sessionId;
+};
+Cloud.prototype.setSessionId = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.sessionId = __SLAG__PROPERTY;
+};
+Cloud.prototype.getAccessToken = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessToken;
+};
+Cloud.prototype.setAccessToken = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessToken = __SLAG__PROPERTY;
+};
+Cloud.prototype.getExpiresIn = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.expiresIn;
+};
+module.exports = function (properties) {
+	return new Cloud(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/ACLs.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/ACLs.js
@@ -1,0 +1,154 @@
+var crypto = require('crypto');
+function ACLs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.ACLs.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.ACLs';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ACLs.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ACLs.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ACLs.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ACLs.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ACLs.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ACLs.prototype.addUser = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ACLs.prototype.removeUser = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ACLs.prototype.checkUser = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ACLs.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ACLs.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ACLs.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ACLs.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ACLs.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ACLs(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Chats.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Chats.js
@@ -1,0 +1,136 @@
+var crypto = require('crypto');
+function Chats(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Chats.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Chats';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Chats.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Chats.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Chats.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Chats.prototype.getChatGroups = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Chats.prototype.queryChatGroups = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Chats.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Chats.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Chats.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Chats.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Chats.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Chats.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Chats(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Checkins.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Checkins.js
@@ -1,0 +1,127 @@
+var crypto = require('crypto');
+function Checkins(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Checkins.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Checkins';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Checkins.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Checkins.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Checkins.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Checkins.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Checkins.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Checkins.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Checkins.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Checkins.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Checkins.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Checkins.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Checkins(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Clients.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Clients.js
@@ -1,0 +1,100 @@
+var crypto = require('crypto');
+function Clients(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Clients.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Clients';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Clients.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Clients.prototype.geolocate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clients.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Clients.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Clients.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Clients.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Clients.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Clients(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Emails.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Emails.js
@@ -1,0 +1,100 @@
+var crypto = require('crypto');
+function Emails(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Emails.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Emails';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Emails.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Emails.prototype.send = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Emails.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Emails.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Emails.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Emails.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Emails.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Emails(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Events.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Events.js
@@ -1,0 +1,172 @@
+var crypto = require('crypto');
+function Events(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Events.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Events';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Events.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Events.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.showOccurrences = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.queryOccurrences = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.search = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.searchOccurrences = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Events.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Events.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Events.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Events.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Events.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Events(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Files.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Files.js
@@ -1,0 +1,136 @@
+var crypto = require('crypto');
+function Files(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Files.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Files';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Files.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Files.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Files.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Files.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Files.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Files.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Files.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Files.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Files.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Files.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Files.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Files(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Friends.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Friends.js
@@ -1,0 +1,136 @@
+var crypto = require('crypto');
+function Friends(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Friends.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Friends';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Friends.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Friends.prototype.add = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Friends.prototype.requests = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Friends.prototype.approve = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Friends.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Friends.prototype.search = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Friends.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Friends.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Friends.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Friends.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Friends.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Friends(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/GeoFences.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/GeoFences.js
@@ -1,0 +1,127 @@
+var crypto = require('crypto');
+function GeoFences(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.GeoFences.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.GeoFences';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+GeoFences.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+GeoFences.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GeoFences.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GeoFences.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GeoFences.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GeoFences.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+GeoFences.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+GeoFences.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+GeoFences.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+GeoFences.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new GeoFences(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/KeyValues.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/KeyValues.js
@@ -1,0 +1,136 @@
+var crypto = require('crypto');
+function KeyValues(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.KeyValues.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.KeyValues';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+KeyValues.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+KeyValues.prototype.append = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+KeyValues.prototype.get = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+KeyValues.prototype.increment = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+KeyValues.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+KeyValues.prototype.set = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+KeyValues.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+KeyValues.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+KeyValues.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+KeyValues.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+KeyValues.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new KeyValues(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Likes.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Likes.js
@@ -1,0 +1,104 @@
+var crypto = require('crypto');
+function Likes(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Likes.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Likes';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Likes.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Likes.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Likes.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Likes.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Likes.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Likes.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Likes.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Likes(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Messages.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Messages.js
@@ -1,0 +1,172 @@
+var crypto = require('crypto');
+function Messages(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Messages.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Messages';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Messages.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Messages.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.reply = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.showInbox = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.showSent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.showThreads = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.showThread = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.removeThread = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Messages.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Messages.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Messages.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Messages.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Messages.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Messages(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Objects.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Objects.js
@@ -1,0 +1,136 @@
+var crypto = require('crypto');
+function Objects(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Objects.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Objects';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Objects.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Objects.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Objects.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Objects.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Objects.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Objects.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Objects.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Objects.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Objects.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Objects.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Objects.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Objects(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/PhotoCollections.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/PhotoCollections.js
@@ -1,0 +1,154 @@
+var crypto = require('crypto');
+function PhotoCollections(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.PhotoCollections.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.PhotoCollections';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PhotoCollections.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PhotoCollections.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PhotoCollections.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PhotoCollections.prototype.search = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PhotoCollections.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PhotoCollections.prototype.showPhotos = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PhotoCollections.prototype.showSubCollections = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PhotoCollections.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PhotoCollections.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PhotoCollections.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PhotoCollections.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PhotoCollections.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+PhotoCollections.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PhotoCollections(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Photos.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Photos.js
@@ -1,0 +1,145 @@
+var crypto = require('crypto');
+function Photos(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Photos.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Photos';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Photos.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Photos.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Photos.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Photos.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Photos.prototype.search = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Photos.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Photos.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Photos.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Photos.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Photos.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Photos.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Photos.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Photos(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Places.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Places.js
@@ -1,0 +1,145 @@
+var crypto = require('crypto');
+function Places(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Places.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Places';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Places.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Places.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Places.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Places.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Places.prototype.search = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Places.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Places.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Places.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Places.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Places.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Places.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Places.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Places(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Posts.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Posts.js
@@ -1,0 +1,136 @@
+var crypto = require('crypto');
+function Posts(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Posts.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Posts';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Posts.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Posts.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Posts.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Posts.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Posts.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Posts.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Posts.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Posts.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Posts.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Posts.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Posts.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Posts(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/PushNotifications.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/PushNotifications.js
@@ -1,0 +1,186 @@
+var crypto = require('crypto');
+function PushNotifications(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.PushNotifications.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.PushNotifications';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PushNotifications.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PushNotifications.prototype.notify = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.notifyTokens = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.resetBadge = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.setBadge = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.subscribe = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.subscribeToken = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.unsubscribe = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.unsubscribeToken = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.updateSubscription = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.queryChannels = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.showChannels = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.query = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushNotifications.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PushNotifications.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PushNotifications.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PushNotifications.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+PushNotifications.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PushNotifications(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/PushSchedules.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/PushSchedules.js
@@ -1,0 +1,114 @@
+var crypto = require('crypto');
+function PushSchedules(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.PushSchedules.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.PushSchedules';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PushSchedules.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PushSchedules.prototype.create = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushSchedules.prototype.remove = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushSchedules.prototype.query = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushSchedules.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PushSchedules.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PushSchedules.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PushSchedules.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+PushSchedules.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PushSchedules(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Reviews.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Reviews.js
@@ -1,0 +1,136 @@
+var crypto = require('crypto');
+function Reviews(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Reviews.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Reviews';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Reviews.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Reviews.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reviews.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reviews.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reviews.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reviews.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reviews.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Reviews.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Reviews.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Reviews.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Reviews.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Reviews(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/SocialIntegrations.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/SocialIntegrations.js
@@ -1,0 +1,127 @@
+var crypto = require('crypto');
+function SocialIntegrations(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.SocialIntegrations.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.SocialIntegrations';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SocialIntegrations.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SocialIntegrations.prototype.externalAccountLink = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SocialIntegrations.prototype.externalAccountLogin = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SocialIntegrations.prototype.externalAccountUnlink = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SocialIntegrations.prototype.searchFacebookFriends = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SocialIntegrations.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SocialIntegrations.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SocialIntegrations.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SocialIntegrations.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+SocialIntegrations.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SocialIntegrations(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Statuses.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Statuses.js
@@ -1,0 +1,145 @@
+var crypto = require('crypto');
+function Statuses(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Statuses.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Statuses';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Statuses.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Statuses.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Statuses.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Statuses.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Statuses.prototype.delete = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Statuses.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Statuses.prototype.search = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Statuses.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Statuses.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Statuses.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Statuses.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Statuses.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Statuses(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/Cloud/Users.js
+++ b/lib/titanium/6.0.4.GA/Modules/Cloud/Users.js
@@ -1,0 +1,199 @@
+var crypto = require('crypto');
+function Users(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.Cloud.Users.apiName is read only property');
+	}
+	this.apiName = 'Modules.Cloud.Users';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Users.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Users.prototype.create = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.login = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.logout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.query = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.search = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.showMe = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.update = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.requestResetPassword = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.resendConfirmation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Users.prototype.secureCreate = function () {
+	throw new Error('Modules.Cloud.Users.secureCreate was deprecated, since 3.2.3');
+};
+Users.prototype.secureLogin = function () {
+	throw new Error('Modules.Cloud.Users.secureLogin was deprecated, since 3.2.3');
+};
+Users.prototype.secureStatus = function () {
+	throw new Error('Modules.Cloud.Users.secureStatus was deprecated, since 3.2.3');
+};
+Users.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Users.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Users.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Users.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Users.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Users(properties);
+};

--- a/lib/titanium/6.0.4.GA/Modules/CloudPush.js
+++ b/lib/titanium/6.0.4.GA/Modules/CloudPush.js
@@ -1,0 +1,254 @@
+var crypto = require('crypto');
+function CloudPush(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'enabled',
+			'showTrayNotification',
+			'showAppOnTrayClick',
+			'showTrayNotificationsWhenFocused',
+			'focusAppOnPush',
+			'singleCallback',
+			'SUCCESS',
+			'SERVICE_MISSING',
+			'SERVICE_VERSION_UPDATE_REQUIRED',
+			'SERVICE_DISABLED',
+			'SERVICE_INVALID',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Modules.CloudPush.apiName is read only property');
+	}
+	this.apiName = 'Modules.CloudPush';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.enabled) {
+		throw new Error('Modules.CloudPush.enabled was deprecated, since 3.2.0');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showTrayNotification = undefined;
+	} else {
+		this.showTrayNotification = __SLAG_PROPERTIES.showTrayNotification || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showAppOnTrayClick = undefined;
+	} else {
+		this.showAppOnTrayClick = __SLAG_PROPERTIES.showAppOnTrayClick || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showTrayNotificationsWhenFocused = undefined;
+	} else {
+		this.showTrayNotificationsWhenFocused = __SLAG_PROPERTIES.showTrayNotificationsWhenFocused || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusAppOnPush = undefined;
+	} else {
+		this.focusAppOnPush = __SLAG_PROPERTIES.focusAppOnPush || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.singleCallback = undefined;
+	} else {
+		this.singleCallback = __SLAG_PROPERTIES.singleCallback || true;
+	}
+	if (__SLAG_PROPERTIES.SUCCESS) {
+		throw new Error('Modules.CloudPush.SUCCESS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SUCCESS = undefined;
+	} else {
+		this.SUCCESS = 0;
+	}
+	if (__SLAG_PROPERTIES.SERVICE_MISSING) {
+		throw new Error('Modules.CloudPush.SERVICE_MISSING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SERVICE_MISSING = undefined;
+	} else {
+		this.SERVICE_MISSING = 0;
+	}
+	if (__SLAG_PROPERTIES.SERVICE_VERSION_UPDATE_REQUIRED) {
+		throw new Error('Modules.CloudPush.SERVICE_VERSION_UPDATE_REQUIRED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SERVICE_VERSION_UPDATE_REQUIRED = undefined;
+	} else {
+		this.SERVICE_VERSION_UPDATE_REQUIRED = 0;
+	}
+	if (__SLAG_PROPERTIES.SERVICE_DISABLED) {
+		throw new Error('Modules.CloudPush.SERVICE_DISABLED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SERVICE_DISABLED = undefined;
+	} else {
+		this.SERVICE_DISABLED = 0;
+	}
+	if (__SLAG_PROPERTIES.SERVICE_INVALID) {
+		throw new Error('Modules.CloudPush.SERVICE_INVALID is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SERVICE_INVALID = undefined;
+	} else {
+		this.SERVICE_INVALID = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+CloudPush.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CloudPush.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CloudPush.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CloudPush.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+CloudPush.prototype.retrieveDeviceToken = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CloudPush.prototype.clearStatus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CloudPush.prototype.isGooglePlayServicesAvailable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+CloudPush.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+CloudPush.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+CloudPush.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+CloudPush.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+CloudPush.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+CloudPush.prototype.getEnabled = function () {
+	throw new Error('Modules.CloudPush.getEnabled was deprecated, since 3.2.0');
+};
+CloudPush.prototype.setEnabled = function () {
+	throw new Error('Modules.CloudPush.setEnabled was deprecated, since 3.2.0');
+};
+CloudPush.prototype.getShowTrayNotification = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showTrayNotification;
+};
+CloudPush.prototype.setShowTrayNotification = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showTrayNotification = __SLAG__PROPERTY;
+};
+CloudPush.prototype.getShowAppOnTrayClick = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showAppOnTrayClick;
+};
+CloudPush.prototype.setShowAppOnTrayClick = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showAppOnTrayClick = __SLAG__PROPERTY;
+};
+CloudPush.prototype.getShowTrayNotificationsWhenFocused = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showTrayNotificationsWhenFocused;
+};
+CloudPush.prototype.setShowTrayNotificationsWhenFocused = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showTrayNotificationsWhenFocused = __SLAG__PROPERTY;
+};
+CloudPush.prototype.getFocusAppOnPush = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusAppOnPush;
+};
+CloudPush.prototype.setFocusAppOnPush = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusAppOnPush = __SLAG__PROPERTY;
+};
+CloudPush.prototype.getSingleCallback = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.singleCallback;
+};
+CloudPush.prototype.setSingleCallback = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.singleCallback = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new CloudPush(properties);
+};

--- a/lib/titanium/6.0.4.GA/MovieSize.js
+++ b/lib/titanium/6.0.4.GA/MovieSize.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function MovieSize(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'width',
+			'height',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MovieSize(properties);
+};

--- a/lib/titanium/6.0.4.GA/MusicLibraryOptionsType.js
+++ b/lib/titanium/6.0.4.GA/MusicLibraryOptionsType.js
@@ -1,0 +1,68 @@
+var crypto = require('crypto');
+function MusicLibraryOptionsType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'cancel',
+			'autohide',
+			'animated',
+			'mediaTypes',
+			'allowMultipleSelections',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancel = undefined;
+	} else {
+		this.cancel = __SLAG_PROPERTIES.cancel || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autohide = undefined;
+	} else {
+		this.autohide = __SLAG_PROPERTIES.autohide || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaTypes = undefined;
+	} else {
+		this.mediaTypes = __SLAG_PROPERTIES.mediaTypes || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowMultipleSelections = undefined;
+	} else {
+		this.allowMultipleSelections = __SLAG_PROPERTIES.allowMultipleSelections || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MusicLibraryOptionsType(properties);
+};

--- a/lib/titanium/6.0.4.GA/MusicLibraryResponseType.js
+++ b/lib/titanium/6.0.4.GA/MusicLibraryResponseType.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function MusicLibraryResponseType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'representative',
+			'items',
+			'types',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.representative = undefined;
+	} else {
+		this.representative = __SLAG_PROPERTIES.representative || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = __SLAG_PROPERTIES.items || [];
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.types = undefined;
+	} else {
+		this.types = __SLAG_PROPERTIES.types || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new MusicLibraryResponseType(properties);
+};

--- a/lib/titanium/6.0.4.GA/NotificationParams.js
+++ b/lib/titanium/6.0.4.GA/NotificationParams.js
@@ -1,0 +1,98 @@
+var crypto = require('crypto');
+function NotificationParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'alertAction',
+			'alertBody',
+			'alertTitle',
+			'alertLaunchImage',
+			'badge',
+			'category',
+			'date',
+			'repeat',
+			'sound',
+			'timezone',
+			'userInfo',
+			'region',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alertAction = undefined;
+	} else {
+		this.alertAction = __SLAG_PROPERTIES.alertAction || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alertBody = undefined;
+	} else {
+		this.alertBody = __SLAG_PROPERTIES.alertBody || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alertTitle = undefined;
+	} else {
+		this.alertTitle = __SLAG_PROPERTIES.alertTitle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alertLaunchImage = undefined;
+	} else {
+		this.alertLaunchImage = __SLAG_PROPERTIES.alertLaunchImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.badge = undefined;
+	} else {
+		this.badge = __SLAG_PROPERTIES.badge || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.category = undefined;
+	} else {
+		this.category = __SLAG_PROPERTIES.category || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.date = undefined;
+	} else {
+		this.date = __SLAG_PROPERTIES.date || new Date();
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.repeat = undefined;
+	} else {
+		this.repeat = __SLAG_PROPERTIES.repeat || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sound = undefined;
+	} else {
+		this.sound = __SLAG_PROPERTIES.sound || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.timezone = undefined;
+	} else {
+		this.timezone = __SLAG_PROPERTIES.timezone || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.userInfo = undefined;
+	} else {
+		this.userInfo = __SLAG_PROPERTIES.userInfo || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.region = undefined;
+	} else {
+		this.region = __SLAG_PROPERTIES.region || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new NotificationParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/PhotoGalleryOptionsType.js
+++ b/lib/titanium/6.0.4.GA/PhotoGalleryOptionsType.js
@@ -1,0 +1,98 @@
+var crypto = require('crypto');
+function PhotoGalleryOptionsType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'cancel',
+			'autohide',
+			'animated',
+			'allowEditing',
+			'mediaTypes',
+			'popoverView',
+			'arrowDirection',
+			'allowMultiple',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancel = undefined;
+	} else {
+		this.cancel = __SLAG_PROPERTIES.cancel || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autohide = undefined;
+	} else {
+		this.autohide = __SLAG_PROPERTIES.autohide || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowEditing = undefined;
+	} else {
+		this.allowEditing = __SLAG_PROPERTIES.allowEditing || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaTypes = undefined;
+	} else {
+		this.mediaTypes = __SLAG_PROPERTIES.mediaTypes || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.popoverView = undefined;
+	} else {
+		this.popoverView = __SLAG_PROPERTIES.popoverView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.arrowDirection = undefined;
+	} else {
+		this.arrowDirection = __SLAG_PROPERTIES.arrowDirection || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowMultiple = undefined;
+	} else {
+		this.allowMultiple = __SLAG_PROPERTIES.allowMultiple || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PhotoGalleryOptionsType(properties);
+};

--- a/lib/titanium/6.0.4.GA/PlayerQueue.js
+++ b/lib/titanium/6.0.4.GA/PlayerQueue.js
@@ -1,0 +1,36 @@
+var crypto = require('crypto');
+function PlayerQueue(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'items',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = __SLAG_PROPERTIES.items || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PlayerQueue(properties);
+};

--- a/lib/titanium/6.0.4.GA/Point.js
+++ b/lib/titanium/6.0.4.GA/Point.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function Point(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'x',
+			'y',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.x = undefined;
+	} else {
+		this.x = __SLAG_PROPERTIES.x || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.y = undefined;
+	} else {
+		this.y = __SLAG_PROPERTIES.y || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Point(properties);
+};

--- a/lib/titanium/6.0.4.GA/PopoverParams.js
+++ b/lib/titanium/6.0.4.GA/PopoverParams.js
@@ -1,0 +1,61 @@
+var crypto = require('crypto');
+function PopoverParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'rect',
+			'view',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = __SLAG_PROPERTIES.rect || {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.view = undefined;
+	} else {
+		this.view = __SLAG_PROPERTIES.view || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PopoverParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/PreviewImageError.js
+++ b/lib/titanium/6.0.4.GA/PreviewImageError.js
@@ -1,0 +1,48 @@
+var crypto = require('crypto');
+function PreviewImageError(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'message',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if (__SLAG_PROPERTIES.message) {
+		throw new Error('PreviewImageError.message was deprecated, since 3.1.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PreviewImageError(properties);
+};

--- a/lib/titanium/6.0.4.GA/PreviewImageOptions.js
+++ b/lib/titanium/6.0.4.GA/PreviewImageOptions.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function PreviewImageOptions(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'image',
+			'success',
+			'error',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PreviewImageOptions(properties);
+};

--- a/lib/titanium/6.0.4.GA/PreviewRectType.js
+++ b/lib/titanium/6.0.4.GA/PreviewRectType.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function PreviewRectType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'width',
+			'height',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PreviewRectType(properties);
+};

--- a/lib/titanium/6.0.4.GA/PumpCallbackArgs.js
+++ b/lib/titanium/6.0.4.GA/PumpCallbackArgs.js
@@ -1,0 +1,104 @@
+var crypto = require('crypto');
+function PumpCallbackArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'source',
+			'buffer',
+			'bytesProcessed',
+			'totalBytesProcessed',
+			'errorState',
+			'errorDescription',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.buffer = undefined;
+	} else {
+		this.buffer = __SLAG_PROPERTIES.buffer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bytesProcessed = undefined;
+	} else {
+		this.bytesProcessed = __SLAG_PROPERTIES.bytesProcessed || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.totalBytesProcessed = undefined;
+	} else {
+		this.totalBytesProcessed = __SLAG_PROPERTIES.totalBytesProcessed || 0;
+	}
+	if (__SLAG_PROPERTIES.errorState) {
+		throw new Error('PumpCallbackArgs.errorState was deprecated, since 3.1.0');
+	}
+	if (__SLAG_PROPERTIES.errorDescription) {
+		throw new Error('PumpCallbackArgs.errorDescription was deprecated, since 3.1.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PumpCallbackArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/PushNotificationConfig.js
+++ b/lib/titanium/6.0.4.GA/PushNotificationConfig.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function PushNotificationConfig(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'types',
+			'success',
+			'error',
+			'callback',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.types = undefined;
+	} else {
+		this.types = __SLAG_PROPERTIES.types || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.callback = undefined;
+	} else {
+		this.callback = __SLAG_PROPERTIES.callback || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PushNotificationConfig(properties);
+};

--- a/lib/titanium/6.0.4.GA/PushNotificationData.js
+++ b/lib/titanium/6.0.4.GA/PushNotificationData.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function PushNotificationData(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'data',
+			'inBackground',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.inBackground = undefined;
+	} else {
+		this.inBackground = __SLAG_PROPERTIES.inBackground || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PushNotificationData(properties);
+};

--- a/lib/titanium/6.0.4.GA/PushNotificationErrorArg.js
+++ b/lib/titanium/6.0.4.GA/PushNotificationErrorArg.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function PushNotificationErrorArg(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'type',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PushNotificationErrorArg(properties);
+};

--- a/lib/titanium/6.0.4.GA/PushNotificationSuccessArg.js
+++ b/lib/titanium/6.0.4.GA/PushNotificationSuccessArg.js
@@ -1,0 +1,76 @@
+var crypto = require('crypto');
+function PushNotificationSuccessArg(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'type',
+			'deviceToken',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.deviceToken = undefined;
+	} else {
+		this.deviceToken = __SLAG_PROPERTIES.deviceToken || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new PushNotificationSuccessArg(properties);
+};

--- a/lib/titanium/6.0.4.GA/ReadCallbackArgs.js
+++ b/lib/titanium/6.0.4.GA/ReadCallbackArgs.js
@@ -1,0 +1,84 @@
+var crypto = require('crypto');
+function ReadCallbackArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'source',
+			'bytesProcessed',
+			'errorState',
+			'errorDescription',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bytesProcessed = undefined;
+	} else {
+		this.bytesProcessed = __SLAG_PROPERTIES.bytesProcessed || 0;
+	}
+	if (__SLAG_PROPERTIES.errorState) {
+		throw new Error('ReadCallbackArgs.errorState was deprecated, since 3.1.0');
+	}
+	if (__SLAG_PROPERTIES.errorDescription) {
+		throw new Error('ReadCallbackArgs.errorDescription was deprecated, since 3.1.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ReadCallbackArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/ReadyStatePayload.js
+++ b/lib/titanium/6.0.4.GA/ReadyStatePayload.js
@@ -1,0 +1,35 @@
+var crypto = require('crypto');
+function ReadyStatePayload(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'readyState',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.readyState = undefined;
+	} else {
+		this.readyState = __SLAG_PROPERTIES.readyState || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ReadyStatePayload(properties);
+};

--- a/lib/titanium/6.0.4.GA/ReferenceInsets.js
+++ b/lib/titanium/6.0.4.GA/ReferenceInsets.js
@@ -1,0 +1,50 @@
+var crypto = require('crypto');
+function ReferenceInsets(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'top',
+			'left',
+			'right',
+			'bottom',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ReferenceInsets(properties);
+};

--- a/lib/titanium/6.0.4.GA/RequestCameraAccessResult.js
+++ b/lib/titanium/6.0.4.GA/RequestCameraAccessResult.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function RequestCameraAccessResult(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new RequestCameraAccessResult(properties);
+};

--- a/lib/titanium/6.0.4.GA/RequestMusicLibraryAccessResult.js
+++ b/lib/titanium/6.0.4.GA/RequestMusicLibraryAccessResult.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function RequestMusicLibraryAccessResult(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new RequestMusicLibraryAccessResult(properties);
+};

--- a/lib/titanium/6.0.4.GA/RequestPermissionAccessResult.js
+++ b/lib/titanium/6.0.4.GA/RequestPermissionAccessResult.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function RequestPermissionAccessResult(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new RequestPermissionAccessResult(properties);
+};

--- a/lib/titanium/6.0.4.GA/RequestPhotoGalleryAccessResult.js
+++ b/lib/titanium/6.0.4.GA/RequestPhotoGalleryAccessResult.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function RequestPhotoGalleryAccessResult(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new RequestPhotoGalleryAccessResult(properties);
+};

--- a/lib/titanium/6.0.4.GA/RequestStorageAccessResult.js
+++ b/lib/titanium/6.0.4.GA/RequestStorageAccessResult.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function RequestStorageAccessResult(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new RequestStorageAccessResult(properties);
+};

--- a/lib/titanium/6.0.4.GA/ReverseGeocodeResponse.js
+++ b/lib/titanium/6.0.4.GA/ReverseGeocodeResponse.js
@@ -1,0 +1,66 @@
+var crypto = require('crypto');
+function ReverseGeocodeResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'places',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.places = undefined;
+	} else {
+		this.places = __SLAG_PROPERTIES.places || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ReverseGeocodeResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/RouteDescription.js
+++ b/lib/titanium/6.0.4.GA/RouteDescription.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function RouteDescription(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'inputs',
+			'outputs',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.inputs = undefined;
+	} else {
+		this.inputs = __SLAG_PROPERTIES.inputs || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.outputs = undefined;
+	} else {
+		this.outputs = __SLAG_PROPERTIES.outputs || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new RouteDescription(properties);
+};

--- a/lib/titanium/6.0.4.GA/RowActionType.js
+++ b/lib/titanium/6.0.4.GA/RowActionType.js
@@ -1,0 +1,50 @@
+var crypto = require('crypto');
+function RowActionType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'title',
+			'identifier',
+			'style',
+			'color',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.identifier = undefined;
+	} else {
+		this.identifier = __SLAG_PROPERTIES.identifier || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new RowActionType(properties);
+};

--- a/lib/titanium/6.0.4.GA/ScreenshotResult.js
+++ b/lib/titanium/6.0.4.GA/ScreenshotResult.js
@@ -1,0 +1,35 @@
+var crypto = require('crypto');
+function ScreenshotResult(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'media',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.media = undefined;
+	} else {
+		this.media = __SLAG_PROPERTIES.media || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ScreenshotResult(properties);
+};

--- a/lib/titanium/6.0.4.GA/SecurityManagerProtocol.js
+++ b/lib/titanium/6.0.4.GA/SecurityManagerProtocol.js
@@ -1,0 +1,51 @@
+var crypto = require('crypto');
+function SecurityManagerProtocol(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SecurityManagerProtocol.prototype.willHandleURL = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+SecurityManagerProtocol.prototype.connectionDelegateForUrl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+SecurityManagerProtocol.prototype.getTrustManagers = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+SecurityManagerProtocol.prototype.getKeyManagers = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+module.exports = function (properties) {
+	return new SecurityManagerProtocol(properties);
+};

--- a/lib/titanium/6.0.4.GA/ServiceIntentOptions.js
+++ b/lib/titanium/6.0.4.GA/ServiceIntentOptions.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function ServiceIntentOptions(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'url',
+			'startMode',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.startMode = undefined;
+	} else {
+		this.startMode = __SLAG_PROPERTIES.startMode || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ServiceIntentOptions(properties);
+};

--- a/lib/titanium/6.0.4.GA/ShortcutParams.js
+++ b/lib/titanium/6.0.4.GA/ShortcutParams.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function ShortcutParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'itemtype',
+			'title',
+			'subtitle',
+			'icon',
+			'userInfo',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.itemtype = undefined;
+	} else {
+		this.itemtype = __SLAG_PROPERTIES.itemtype || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subtitle = undefined;
+	} else {
+		this.subtitle = __SLAG_PROPERTIES.subtitle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.icon = undefined;
+	} else {
+		this.icon = __SLAG_PROPERTIES.icon || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.userInfo = undefined;
+	} else {
+		this.userInfo = __SLAG_PROPERTIES.userInfo || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ShortcutParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/SuccessResponse.js
+++ b/lib/titanium/6.0.4.GA/SuccessResponse.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function SuccessResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new SuccessResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/TabIconInsets.js
+++ b/lib/titanium/6.0.4.GA/TabIconInsets.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function TabIconInsets(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'top',
+			'left',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new TabIconInsets(properties);
+};

--- a/lib/titanium/6.0.4.GA/TableViewAnimationProperties.js
+++ b/lib/titanium/6.0.4.GA/TableViewAnimationProperties.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function TableViewAnimationProperties(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'animationStyle',
+			'position',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animationStyle = undefined;
+	} else {
+		this.animationStyle = __SLAG_PROPERTIES.animationStyle || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.position = undefined;
+	} else {
+		this.position = __SLAG_PROPERTIES.position || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new TableViewAnimationProperties(properties);
+};

--- a/lib/titanium/6.0.4.GA/TableViewContentInsetOption.js
+++ b/lib/titanium/6.0.4.GA/TableViewContentInsetOption.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function TableViewContentInsetOption(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'duration',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new TableViewContentInsetOption(properties);
+};

--- a/lib/titanium/6.0.4.GA/TableViewEdgeInsets.js
+++ b/lib/titanium/6.0.4.GA/TableViewEdgeInsets.js
@@ -1,0 +1,50 @@
+var crypto = require('crypto');
+function TableViewEdgeInsets(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'top',
+			'left',
+			'right',
+			'bottom',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new TableViewEdgeInsets(properties);
+};

--- a/lib/titanium/6.0.4.GA/TableViewIndexEntry.js
+++ b/lib/titanium/6.0.4.GA/TableViewIndexEntry.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function TableViewIndexEntry(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'title',
+			'index',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.index = undefined;
+	} else {
+		this.index = __SLAG_PROPERTIES.index || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new TableViewIndexEntry(properties);
+};

--- a/lib/titanium/6.0.4.GA/TextAreaPadding.js
+++ b/lib/titanium/6.0.4.GA/TextAreaPadding.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function TextAreaPadding(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'left',
+			'right',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new TextAreaPadding(properties);
+};

--- a/lib/titanium/6.0.4.GA/TextFieldPadding.js
+++ b/lib/titanium/6.0.4.GA/TextFieldPadding.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function TextFieldPadding(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'left',
+			'right',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new TextFieldPadding(properties);
+};

--- a/lib/titanium/6.0.4.GA/ThumbnailResponse.js
+++ b/lib/titanium/6.0.4.GA/ThumbnailResponse.js
@@ -1,0 +1,71 @@
+var crypto = require('crypto');
+function ThumbnailResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'image',
+			'time',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.time = undefined;
+	} else {
+		this.time = __SLAG_PROPERTIES.time || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ThumbnailResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium.js
+++ b/lib/titanium/6.0.4.GA/Titanium.js
@@ -1,0 +1,239 @@
+var crypto = require('crypto');
+function Titanium(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'userAgent',
+			'version',
+			'buildDate',
+			'buildHash',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.apiName is read only property');
+	}
+	this.apiName = 'Ti';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.userAgent = undefined;
+	} else {
+		this.userAgent = __SLAG_PROPERTIES.userAgent || '';
+	}
+	if (__SLAG_PROPERTIES.version) {
+		throw new Error('Ti.version is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.version = undefined;
+	} else {
+		this.version = '';
+	}
+	if (__SLAG_PROPERTIES.buildDate) {
+		throw new Error('Ti.buildDate is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.buildDate = undefined;
+	} else {
+		this.buildDate = '';
+	}
+	if (__SLAG_PROPERTIES.buildHash) {
+		throw new Error('Ti.buildHash is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.buildHash = undefined;
+	} else {
+		this.buildHash = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Titanium.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Titanium.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Titanium.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Titanium.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Titanium.prototype.createBuffer = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Buffer = require('./Titanium/Buffer');
+	return Buffer(__SLAG_PROPERTY);
+};
+Titanium.prototype.createProxy = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Proxy = require('./Titanium/Proxy');
+	return Proxy(__SLAG_PROPERTY);
+};
+Titanium.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Titanium.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Titanium.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Titanium.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Titanium.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Titanium.prototype.getUserAgent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.userAgent;
+};
+Titanium.prototype.setUserAgent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.userAgent = __SLAG__PROPERTY;
+};
+Titanium.prototype.getVersion = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.version;
+};
+Titanium.prototype.getBuildDate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.buildDate;
+};
+Titanium.prototype.getBuildHash = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.buildHash;
+};
+module.exports = function (properties) {
+	return new Titanium(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/API.js
+++ b/lib/titanium/6.0.4.GA/Titanium/API.js
@@ -1,0 +1,141 @@
+var crypto = require('crypto');
+function API(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.API.apiName is read only property');
+	}
+	this.apiName = 'Ti.API';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+API.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+API.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+API.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+API.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+API.prototype.debug = function (__SLAG_PARAMETER) {
+	console.info(__SLAG_PARAMETER);
+};
+API.prototype.error = function (__SLAG_PARAMETER) {
+	console.error(__SLAG_PARAMETER);
+};
+API.prototype.info = function (__SLAG_PARAMETER) {
+	console.info(__SLAG_PARAMETER);
+};
+API.prototype.log = function (__SLAG_PARAMETER) {
+	console.log(__SLAG_PARAMETER);
+};
+API.prototype.timestamp = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+API.prototype.trace = function (__SLAG_PARAMETER) {
+	console.trace(__SLAG_PARAMETER);
+};
+API.prototype.warn = function (__SLAG_PARAMETER) {
+	console.warn(__SLAG_PARAMETER);
+};
+API.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+API.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+API.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+API.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+API.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new API(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Accelerometer.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Accelerometer.js
@@ -1,0 +1,118 @@
+var crypto = require('crypto');
+function Accelerometer(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Accelerometer.apiName is read only property');
+	}
+	this.apiName = 'Ti.Accelerometer';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Accelerometer.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Accelerometer.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Accelerometer.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Accelerometer.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Accelerometer.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Accelerometer.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Accelerometer.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Accelerometer.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Accelerometer.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Accelerometer(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Analytics.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Analytics.js
@@ -1,0 +1,146 @@
+var crypto = require('crypto');
+function Analytics(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'lastEvent',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Analytics.apiName is read only property');
+	}
+	this.apiName = 'Ti.Analytics';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.lastEvent) {
+		throw new Error('Ti.Analytics.lastEvent is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastEvent = undefined;
+	} else {
+		this.lastEvent = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Analytics.prototype.addEvent = function () {
+	throw new Error('Ti.Analytics.addEvent was deprecated, since 2.0.0');
+};
+Analytics.prototype.featureEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Analytics.prototype.filterEvents = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Analytics.prototype.navEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Analytics.prototype.settingsEvent = function () {
+	throw new Error('Ti.Analytics.settingsEvent was deprecated, since 2.0.0');
+};
+Analytics.prototype.timedEvent = function () {
+	throw new Error('Ti.Analytics.timedEvent was deprecated, since 2.0.0');
+};
+Analytics.prototype.userEvent = function () {
+	throw new Error('Ti.Analytics.userEvent was deprecated, since 2.0.0');
+};
+Analytics.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Analytics.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Analytics.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Analytics.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Analytics.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Analytics.prototype.getLastEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastEvent;
+};
+module.exports = function (properties) {
+	return new Analytics(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android.js
@@ -1,0 +1,2081 @@
+var crypto = require('crypto');
+function Android(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ACTION_AIRPLANE_MODE_CHANGED',
+			'ACTION_ALL_APPS',
+			'ACTION_ANSWER',
+			'ACTION_ATTACH_DATA',
+			'ACTION_BATTERY_CHANGED',
+			'ACTION_BATTERY_LOW',
+			'ACTION_BATTERY_OKAY',
+			'ACTION_BOOT_COMPLETED',
+			'ACTION_BUG_REPORT',
+			'ACTION_CALL',
+			'ACTION_CALL_BUTTON',
+			'ACTION_CAMERA_BUTTON',
+			'ACTION_CHOOSER',
+			'ACTION_CLOSE_SYSTEM_DIALOGS',
+			'ACTION_CONFIGURATION_CHANGED',
+			'ACTION_CREATE_SHORTCUT',
+			'ACTION_DATE_CHANGED',
+			'ACTION_DEFAULT',
+			'ACTION_DELETE',
+			'ACTION_DEVICE_STORAGE_LOW',
+			'ACTION_DIAL',
+			'ACTION_EDIT',
+			'ACTION_GET_CONTENT',
+			'ACTION_GTALK_SERVICE_CONNECTED',
+			'ACTION_GTALK_SERVICE_DISCONNECTED',
+			'ACTION_HEADSET_PLUG',
+			'ACTION_INPUT_METHOD_CHANGED',
+			'ACTION_INSERT',
+			'ACTION_INSERT_OR_EDIT',
+			'ACTION_MAIN',
+			'ACTION_MANAGE_PACKAGE_STORAGE',
+			'ACTION_MEDIA_BAD_REMOVAL',
+			'ACTION_MEDIA_BUTTON',
+			'ACTION_MEDIA_CHECKING',
+			'ACTION_MEDIA_EJECT',
+			'ACTION_MEDIA_MOUNTED',
+			'ACTION_MEDIA_NOFS',
+			'ACTION_MEDIA_REMOVED',
+			'ACTION_MEDIA_SCANNER_FINISHED',
+			'ACTION_MEDIA_SCANNER_SCAN_FILE',
+			'ACTION_MEDIA_SCANNER_STARTED',
+			'ACTION_MEDIA_SHARED',
+			'ACTION_MEDIA_UNMOUNTABLE',
+			'ACTION_MEDIA_UNMOUNTED',
+			'ACTION_NEW_OUTGOING_CALL',
+			'ACTION_PACKAGE_ADDED',
+			'ACTION_PACKAGE_CHANGED',
+			'ACTION_PACKAGE_DATA_CLEARED',
+			'ACTION_PACKAGE_INSTALL',
+			'ACTION_PACKAGE_REMOVED',
+			'ACTION_PACKAGE_REPLACED',
+			'ACTION_PACKAGE_RESTARTED',
+			'ACTION_PICK',
+			'ACTION_PICK_ACTIVITY',
+			'ACTION_POWER_CONNECTED',
+			'ACTION_POWER_DISCONNECTED',
+			'ACTION_POWER_USAGE_SUMMARY',
+			'ACTION_PROVIDER_CHANGED',
+			'ACTION_REBOOT',
+			'ACTION_RUN',
+			'ACTION_SCREEN_OFF',
+			'ACTION_SCREEN_ON',
+			'ACTION_SEARCH',
+			'ACTION_SEARCH_LONG_PRESS',
+			'ACTION_SEND',
+			'ACTION_SENDTO',
+			'ACTION_SEND_MULTIPLE',
+			'ACTION_SET_WALLPAPER',
+			'ACTION_SHUTDOWN',
+			'ACTION_SYNC',
+			'ACTION_SYSTEM_TUTORIAL',
+			'ACTION_TIME_CHANGED',
+			'ACTION_TIME_TICK',
+			'ACTION_UID_REMOVED',
+			'ACTION_UMS_CONNECTED',
+			'ACTION_UMS_DISCONNECTED',
+			'ACTION_USER_PRESENT',
+			'ACTION_VIEW',
+			'ACTION_VOICE_COMMAND',
+			'ACTION_WALLPAPER_CHANGED',
+			'ACTION_WEB_SEARCH',
+			'CATEGORY_ALTERNATIVE',
+			'CATEGORY_BROWSABLE',
+			'CATEGORY_DEFAULT',
+			'CATEGORY_DEVELOPMENT_PREFERENCE',
+			'CATEGORY_EMBED',
+			'CATEGORY_FRAMEWORK_INSTRUMENTATION_TEST',
+			'CATEGORY_HOME',
+			'CATEGORY_INFO',
+			'CATEGORY_LAUNCHER',
+			'CATEGORY_MONKEY',
+			'CATEGORY_OPENABLE',
+			'CATEGORY_PREFERENCE',
+			'CATEGORY_SAMPLE_CODE',
+			'CATEGORY_SELECTED_ALTERNATIVE',
+			'CATEGORY_TAB',
+			'CATEGORY_TEST',
+			'CATEGORY_UNIT_TEST',
+			'EXTRA_ALARM_COUNT',
+			'EXTRA_BCC',
+			'EXTRA_CC',
+			'EXTRA_DATA_REMOVED',
+			'EXTRA_DONT_KILL_APP',
+			'EXTRA_EMAIL',
+			'EXTRA_INTENT',
+			'EXTRA_KEY_EVENT',
+			'EXTRA_PHONE_NUMBER',
+			'EXTRA_REPLACING',
+			'EXTRA_SHORTCUT_ICON',
+			'EXTRA_SHORTCUT_ICON_RESOURCE',
+			'EXTRA_SHORTCUT_INTENT',
+			'EXTRA_SHORTCUT_NAME',
+			'EXTRA_STREAM',
+			'EXTRA_SUBJECT',
+			'EXTRA_TEMPLATE',
+			'EXTRA_TEXT',
+			'EXTRA_TITLE',
+			'EXTRA_UID',
+			'FILL_IN_ACTION',
+			'FILL_IN_CATEGORIES',
+			'FILL_IN_COMPONENT',
+			'FILL_IN_DATA',
+			'FILL_IN_PACKAGE',
+			'FLAG_ACTIVITY_BROUGHT_TO_FRONT',
+			'FLAG_ACTIVITY_CLEAR_TOP',
+			'FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET',
+			'FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS',
+			'FLAG_ACTIVITY_FORWARD_RESULT',
+			'FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY',
+			'FLAG_ACTIVITY_MULTIPLE_TASK',
+			'FLAG_ACTIVITY_NEW_TASK',
+			'FLAG_ACTIVITY_NO_ANIMATION',
+			'FLAG_ACTIVITY_NO_HISTORY',
+			'FLAG_ACTIVITY_NO_USER_ACTION',
+			'FLAG_ACTIVITY_PREVIOUS_IS_TOP',
+			'FLAG_ACTIVITY_REORDER_TO_FRONT',
+			'FLAG_ACTIVITY_RESET_TASK_IF_NEEDED',
+			'FLAG_ACTIVITY_SINGLE_TOP',
+			'FLAG_DEBUG_LOG_RESOLUTION',
+			'FLAG_FROM_BACKGROUND',
+			'FLAG_GRANT_READ_URI_PERMISSION',
+			'FLAG_GRANT_WRITE_URI_PERMISSION',
+			'FLAG_RECEIVER_REGISTERED_ONLY',
+			'FLAG_CANCEL_CURRENT',
+			'FLAG_NO_CREATE',
+			'FLAG_ONE_SHOT',
+			'FLAG_UPDATE_CURRENT',
+			'CATEGORY_ALARM',
+			'CATEGORY_CALL',
+			'CATEGORY_EMAIL',
+			'CATEGORY_ERROR',
+			'CATEGORY_EVENT',
+			'CATEGORY_MESSAGE',
+			'CATEGORY_PROGRESS',
+			'CATEGORY_PROMO',
+			'CATEGORY_RECOMMENDATION',
+			'CATEGORY_SERVICE',
+			'CATEGORY_SOCIAL',
+			'CATEGORY_STATUS',
+			'CATEGORY_TRANSPORT',
+			'DEFAULT_ALL',
+			'DEFAULT_LIGHTS',
+			'DEFAULT_SOUND',
+			'DEFAULT_VIBRATE',
+			'FLAG_AUTO_CANCEL',
+			'FLAG_INSISTENT',
+			'FLAG_NO_CLEAR',
+			'FLAG_ONGOING_EVENT',
+			'FLAG_ONLY_ALERT_ONCE',
+			'FLAG_SHOW_LIGHTS',
+			'PRIORITY_MAX',
+			'PRIORITY_HIGH',
+			'PRIORITY_DEFAULT',
+			'PRIORITY_LOW',
+			'PRIORITY_MIN',
+			'VISIBILITY_PRIVATE',
+			'VISIBILITY_PUBLIC',
+			'VISIBILITY_SECRET',
+			'PENDING_INTENT_FOR_ACTIVITY',
+			'PENDING_INTENT_FOR_BROADCAST',
+			'PENDING_INTENT_FOR_SERVICE',
+			'PENDING_INTENT_MAX_VALUE',
+			'R',
+			'RESULT_CANCELED',
+			'RESULT_FIRST_USER',
+			'RESULT_OK',
+			'SCREEN_ORIENTATION_BEHIND',
+			'SCREEN_ORIENTATION_LANDSCAPE',
+			'SCREEN_ORIENTATION_NOSENSOR',
+			'SCREEN_ORIENTATION_PORTRAIT',
+			'SCREEN_ORIENTATION_SENSOR',
+			'SCREEN_ORIENTATION_UNSPECIFIED',
+			'SCREEN_ORIENTATION_USER',
+			'SHOW_AS_ACTION_ALWAYS',
+			'SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW',
+			'SHOW_AS_ACTION_IF_ROOM',
+			'SHOW_AS_ACTION_NEVER',
+			'SHOW_AS_ACTION_WITH_TEXT',
+			'NAVIGATION_MODE_STANDARD',
+			'NAVIGATION_MODE_TABS',
+			'START_NOT_STICKY',
+			'START_REDELIVER_INTENT',
+			'STREAM_ALARM',
+			'STREAM_DEFAULT',
+			'STREAM_MUSIC',
+			'STREAM_NOTIFICATION',
+			'STREAM_RING',
+			'STREAM_SYSTEM',
+			'STREAM_VOICE_CALL',
+			'URI_INTENT_SCHEME',
+			'currentActivity',
+			'currentService',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ACTION_AIRPLANE_MODE_CHANGED) {
+		throw new Error('Ti.Android.ACTION_AIRPLANE_MODE_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_AIRPLANE_MODE_CHANGED = undefined;
+	} else {
+		this.ACTION_AIRPLANE_MODE_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_ALL_APPS) {
+		throw new Error('Ti.Android.ACTION_ALL_APPS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_ALL_APPS = undefined;
+	} else {
+		this.ACTION_ALL_APPS = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_ANSWER) {
+		throw new Error('Ti.Android.ACTION_ANSWER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_ANSWER = undefined;
+	} else {
+		this.ACTION_ANSWER = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_ATTACH_DATA) {
+		throw new Error('Ti.Android.ACTION_ATTACH_DATA is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_ATTACH_DATA = undefined;
+	} else {
+		this.ACTION_ATTACH_DATA = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_BATTERY_CHANGED) {
+		throw new Error('Ti.Android.ACTION_BATTERY_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_BATTERY_CHANGED = undefined;
+	} else {
+		this.ACTION_BATTERY_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_BATTERY_LOW) {
+		throw new Error('Ti.Android.ACTION_BATTERY_LOW is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_BATTERY_LOW = undefined;
+	} else {
+		this.ACTION_BATTERY_LOW = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_BATTERY_OKAY) {
+		throw new Error('Ti.Android.ACTION_BATTERY_OKAY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_BATTERY_OKAY = undefined;
+	} else {
+		this.ACTION_BATTERY_OKAY = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_BOOT_COMPLETED) {
+		throw new Error('Ti.Android.ACTION_BOOT_COMPLETED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_BOOT_COMPLETED = undefined;
+	} else {
+		this.ACTION_BOOT_COMPLETED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_BUG_REPORT) {
+		throw new Error('Ti.Android.ACTION_BUG_REPORT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_BUG_REPORT = undefined;
+	} else {
+		this.ACTION_BUG_REPORT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_CALL) {
+		throw new Error('Ti.Android.ACTION_CALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_CALL = undefined;
+	} else {
+		this.ACTION_CALL = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_CALL_BUTTON) {
+		throw new Error('Ti.Android.ACTION_CALL_BUTTON is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_CALL_BUTTON = undefined;
+	} else {
+		this.ACTION_CALL_BUTTON = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_CAMERA_BUTTON) {
+		throw new Error('Ti.Android.ACTION_CAMERA_BUTTON is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_CAMERA_BUTTON = undefined;
+	} else {
+		this.ACTION_CAMERA_BUTTON = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_CHOOSER) {
+		throw new Error('Ti.Android.ACTION_CHOOSER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_CHOOSER = undefined;
+	} else {
+		this.ACTION_CHOOSER = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_CLOSE_SYSTEM_DIALOGS) {
+		throw new Error('Ti.Android.ACTION_CLOSE_SYSTEM_DIALOGS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_CLOSE_SYSTEM_DIALOGS = undefined;
+	} else {
+		this.ACTION_CLOSE_SYSTEM_DIALOGS = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_CONFIGURATION_CHANGED) {
+		throw new Error('Ti.Android.ACTION_CONFIGURATION_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_CONFIGURATION_CHANGED = undefined;
+	} else {
+		this.ACTION_CONFIGURATION_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_CREATE_SHORTCUT) {
+		throw new Error('Ti.Android.ACTION_CREATE_SHORTCUT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_CREATE_SHORTCUT = undefined;
+	} else {
+		this.ACTION_CREATE_SHORTCUT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_DATE_CHANGED) {
+		throw new Error('Ti.Android.ACTION_DATE_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_DATE_CHANGED = undefined;
+	} else {
+		this.ACTION_DATE_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_DEFAULT) {
+		throw new Error('Ti.Android.ACTION_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_DEFAULT = undefined;
+	} else {
+		this.ACTION_DEFAULT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_DELETE) {
+		throw new Error('Ti.Android.ACTION_DELETE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_DELETE = undefined;
+	} else {
+		this.ACTION_DELETE = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_DEVICE_STORAGE_LOW) {
+		throw new Error('Ti.Android.ACTION_DEVICE_STORAGE_LOW is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_DEVICE_STORAGE_LOW = undefined;
+	} else {
+		this.ACTION_DEVICE_STORAGE_LOW = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_DIAL) {
+		throw new Error('Ti.Android.ACTION_DIAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_DIAL = undefined;
+	} else {
+		this.ACTION_DIAL = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_EDIT) {
+		throw new Error('Ti.Android.ACTION_EDIT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_EDIT = undefined;
+	} else {
+		this.ACTION_EDIT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_GET_CONTENT) {
+		throw new Error('Ti.Android.ACTION_GET_CONTENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_GET_CONTENT = undefined;
+	} else {
+		this.ACTION_GET_CONTENT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_GTALK_SERVICE_CONNECTED) {
+		throw new Error('Ti.Android.ACTION_GTALK_SERVICE_CONNECTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_GTALK_SERVICE_CONNECTED = undefined;
+	} else {
+		this.ACTION_GTALK_SERVICE_CONNECTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_GTALK_SERVICE_DISCONNECTED) {
+		throw new Error('Ti.Android.ACTION_GTALK_SERVICE_DISCONNECTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_GTALK_SERVICE_DISCONNECTED = undefined;
+	} else {
+		this.ACTION_GTALK_SERVICE_DISCONNECTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_HEADSET_PLUG) {
+		throw new Error('Ti.Android.ACTION_HEADSET_PLUG is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_HEADSET_PLUG = undefined;
+	} else {
+		this.ACTION_HEADSET_PLUG = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_INPUT_METHOD_CHANGED) {
+		throw new Error('Ti.Android.ACTION_INPUT_METHOD_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_INPUT_METHOD_CHANGED = undefined;
+	} else {
+		this.ACTION_INPUT_METHOD_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_INSERT) {
+		throw new Error('Ti.Android.ACTION_INSERT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_INSERT = undefined;
+	} else {
+		this.ACTION_INSERT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_INSERT_OR_EDIT) {
+		throw new Error('Ti.Android.ACTION_INSERT_OR_EDIT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_INSERT_OR_EDIT = undefined;
+	} else {
+		this.ACTION_INSERT_OR_EDIT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MAIN) {
+		throw new Error('Ti.Android.ACTION_MAIN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MAIN = undefined;
+	} else {
+		this.ACTION_MAIN = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MANAGE_PACKAGE_STORAGE) {
+		throw new Error('Ti.Android.ACTION_MANAGE_PACKAGE_STORAGE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MANAGE_PACKAGE_STORAGE = undefined;
+	} else {
+		this.ACTION_MANAGE_PACKAGE_STORAGE = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_BAD_REMOVAL) {
+		throw new Error('Ti.Android.ACTION_MEDIA_BAD_REMOVAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_BAD_REMOVAL = undefined;
+	} else {
+		this.ACTION_MEDIA_BAD_REMOVAL = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_BUTTON) {
+		throw new Error('Ti.Android.ACTION_MEDIA_BUTTON is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_BUTTON = undefined;
+	} else {
+		this.ACTION_MEDIA_BUTTON = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_CHECKING) {
+		throw new Error('Ti.Android.ACTION_MEDIA_CHECKING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_CHECKING = undefined;
+	} else {
+		this.ACTION_MEDIA_CHECKING = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_EJECT) {
+		throw new Error('Ti.Android.ACTION_MEDIA_EJECT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_EJECT = undefined;
+	} else {
+		this.ACTION_MEDIA_EJECT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_MOUNTED) {
+		throw new Error('Ti.Android.ACTION_MEDIA_MOUNTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_MOUNTED = undefined;
+	} else {
+		this.ACTION_MEDIA_MOUNTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_NOFS) {
+		throw new Error('Ti.Android.ACTION_MEDIA_NOFS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_NOFS = undefined;
+	} else {
+		this.ACTION_MEDIA_NOFS = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_REMOVED) {
+		throw new Error('Ti.Android.ACTION_MEDIA_REMOVED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_REMOVED = undefined;
+	} else {
+		this.ACTION_MEDIA_REMOVED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_SCANNER_FINISHED) {
+		throw new Error('Ti.Android.ACTION_MEDIA_SCANNER_FINISHED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_SCANNER_FINISHED = undefined;
+	} else {
+		this.ACTION_MEDIA_SCANNER_FINISHED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_SCANNER_SCAN_FILE) {
+		throw new Error('Ti.Android.ACTION_MEDIA_SCANNER_SCAN_FILE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_SCANNER_SCAN_FILE = undefined;
+	} else {
+		this.ACTION_MEDIA_SCANNER_SCAN_FILE = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_SCANNER_STARTED) {
+		throw new Error('Ti.Android.ACTION_MEDIA_SCANNER_STARTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_SCANNER_STARTED = undefined;
+	} else {
+		this.ACTION_MEDIA_SCANNER_STARTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_SHARED) {
+		throw new Error('Ti.Android.ACTION_MEDIA_SHARED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_SHARED = undefined;
+	} else {
+		this.ACTION_MEDIA_SHARED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_UNMOUNTABLE) {
+		throw new Error('Ti.Android.ACTION_MEDIA_UNMOUNTABLE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_UNMOUNTABLE = undefined;
+	} else {
+		this.ACTION_MEDIA_UNMOUNTABLE = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_MEDIA_UNMOUNTED) {
+		throw new Error('Ti.Android.ACTION_MEDIA_UNMOUNTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_MEDIA_UNMOUNTED = undefined;
+	} else {
+		this.ACTION_MEDIA_UNMOUNTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_NEW_OUTGOING_CALL) {
+		throw new Error('Ti.Android.ACTION_NEW_OUTGOING_CALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_NEW_OUTGOING_CALL = undefined;
+	} else {
+		this.ACTION_NEW_OUTGOING_CALL = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PACKAGE_ADDED) {
+		throw new Error('Ti.Android.ACTION_PACKAGE_ADDED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PACKAGE_ADDED = undefined;
+	} else {
+		this.ACTION_PACKAGE_ADDED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PACKAGE_CHANGED) {
+		throw new Error('Ti.Android.ACTION_PACKAGE_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PACKAGE_CHANGED = undefined;
+	} else {
+		this.ACTION_PACKAGE_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PACKAGE_DATA_CLEARED) {
+		throw new Error('Ti.Android.ACTION_PACKAGE_DATA_CLEARED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PACKAGE_DATA_CLEARED = undefined;
+	} else {
+		this.ACTION_PACKAGE_DATA_CLEARED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PACKAGE_INSTALL) {
+		throw new Error('Ti.Android.ACTION_PACKAGE_INSTALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PACKAGE_INSTALL = undefined;
+	} else {
+		this.ACTION_PACKAGE_INSTALL = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PACKAGE_REMOVED) {
+		throw new Error('Ti.Android.ACTION_PACKAGE_REMOVED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PACKAGE_REMOVED = undefined;
+	} else {
+		this.ACTION_PACKAGE_REMOVED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PACKAGE_REPLACED) {
+		throw new Error('Ti.Android.ACTION_PACKAGE_REPLACED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PACKAGE_REPLACED = undefined;
+	} else {
+		this.ACTION_PACKAGE_REPLACED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PACKAGE_RESTARTED) {
+		throw new Error('Ti.Android.ACTION_PACKAGE_RESTARTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PACKAGE_RESTARTED = undefined;
+	} else {
+		this.ACTION_PACKAGE_RESTARTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PICK) {
+		throw new Error('Ti.Android.ACTION_PICK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PICK = undefined;
+	} else {
+		this.ACTION_PICK = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PICK_ACTIVITY) {
+		throw new Error('Ti.Android.ACTION_PICK_ACTIVITY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PICK_ACTIVITY = undefined;
+	} else {
+		this.ACTION_PICK_ACTIVITY = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_POWER_CONNECTED) {
+		throw new Error('Ti.Android.ACTION_POWER_CONNECTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_POWER_CONNECTED = undefined;
+	} else {
+		this.ACTION_POWER_CONNECTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_POWER_DISCONNECTED) {
+		throw new Error('Ti.Android.ACTION_POWER_DISCONNECTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_POWER_DISCONNECTED = undefined;
+	} else {
+		this.ACTION_POWER_DISCONNECTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_POWER_USAGE_SUMMARY) {
+		throw new Error('Ti.Android.ACTION_POWER_USAGE_SUMMARY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_POWER_USAGE_SUMMARY = undefined;
+	} else {
+		this.ACTION_POWER_USAGE_SUMMARY = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_PROVIDER_CHANGED) {
+		throw new Error('Ti.Android.ACTION_PROVIDER_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_PROVIDER_CHANGED = undefined;
+	} else {
+		this.ACTION_PROVIDER_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_REBOOT) {
+		throw new Error('Ti.Android.ACTION_REBOOT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_REBOOT = undefined;
+	} else {
+		this.ACTION_REBOOT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_RUN) {
+		throw new Error('Ti.Android.ACTION_RUN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_RUN = undefined;
+	} else {
+		this.ACTION_RUN = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SCREEN_OFF) {
+		throw new Error('Ti.Android.ACTION_SCREEN_OFF is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SCREEN_OFF = undefined;
+	} else {
+		this.ACTION_SCREEN_OFF = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SCREEN_ON) {
+		throw new Error('Ti.Android.ACTION_SCREEN_ON is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SCREEN_ON = undefined;
+	} else {
+		this.ACTION_SCREEN_ON = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SEARCH) {
+		throw new Error('Ti.Android.ACTION_SEARCH is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SEARCH = undefined;
+	} else {
+		this.ACTION_SEARCH = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SEARCH_LONG_PRESS) {
+		throw new Error('Ti.Android.ACTION_SEARCH_LONG_PRESS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SEARCH_LONG_PRESS = undefined;
+	} else {
+		this.ACTION_SEARCH_LONG_PRESS = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SEND) {
+		throw new Error('Ti.Android.ACTION_SEND is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SEND = undefined;
+	} else {
+		this.ACTION_SEND = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SENDTO) {
+		throw new Error('Ti.Android.ACTION_SENDTO is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SENDTO = undefined;
+	} else {
+		this.ACTION_SENDTO = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SEND_MULTIPLE) {
+		throw new Error('Ti.Android.ACTION_SEND_MULTIPLE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SEND_MULTIPLE = undefined;
+	} else {
+		this.ACTION_SEND_MULTIPLE = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SET_WALLPAPER) {
+		throw new Error('Ti.Android.ACTION_SET_WALLPAPER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SET_WALLPAPER = undefined;
+	} else {
+		this.ACTION_SET_WALLPAPER = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SHUTDOWN) {
+		throw new Error('Ti.Android.ACTION_SHUTDOWN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SHUTDOWN = undefined;
+	} else {
+		this.ACTION_SHUTDOWN = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SYNC) {
+		throw new Error('Ti.Android.ACTION_SYNC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SYNC = undefined;
+	} else {
+		this.ACTION_SYNC = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_SYSTEM_TUTORIAL) {
+		throw new Error('Ti.Android.ACTION_SYSTEM_TUTORIAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_SYSTEM_TUTORIAL = undefined;
+	} else {
+		this.ACTION_SYSTEM_TUTORIAL = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_TIME_CHANGED) {
+		throw new Error('Ti.Android.ACTION_TIME_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_TIME_CHANGED = undefined;
+	} else {
+		this.ACTION_TIME_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_TIME_TICK) {
+		throw new Error('Ti.Android.ACTION_TIME_TICK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_TIME_TICK = undefined;
+	} else {
+		this.ACTION_TIME_TICK = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_UID_REMOVED) {
+		throw new Error('Ti.Android.ACTION_UID_REMOVED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_UID_REMOVED = undefined;
+	} else {
+		this.ACTION_UID_REMOVED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_UMS_CONNECTED) {
+		throw new Error('Ti.Android.ACTION_UMS_CONNECTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_UMS_CONNECTED = undefined;
+	} else {
+		this.ACTION_UMS_CONNECTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_UMS_DISCONNECTED) {
+		throw new Error('Ti.Android.ACTION_UMS_DISCONNECTED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_UMS_DISCONNECTED = undefined;
+	} else {
+		this.ACTION_UMS_DISCONNECTED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_USER_PRESENT) {
+		throw new Error('Ti.Android.ACTION_USER_PRESENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_USER_PRESENT = undefined;
+	} else {
+		this.ACTION_USER_PRESENT = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_VIEW) {
+		throw new Error('Ti.Android.ACTION_VIEW is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_VIEW = undefined;
+	} else {
+		this.ACTION_VIEW = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_VOICE_COMMAND) {
+		throw new Error('Ti.Android.ACTION_VOICE_COMMAND is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_VOICE_COMMAND = undefined;
+	} else {
+		this.ACTION_VOICE_COMMAND = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_WALLPAPER_CHANGED) {
+		throw new Error('Ti.Android.ACTION_WALLPAPER_CHANGED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_WALLPAPER_CHANGED = undefined;
+	} else {
+		this.ACTION_WALLPAPER_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.ACTION_WEB_SEARCH) {
+		throw new Error('Ti.Android.ACTION_WEB_SEARCH is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION_WEB_SEARCH = undefined;
+	} else {
+		this.ACTION_WEB_SEARCH = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_ALTERNATIVE) {
+		throw new Error('Ti.Android.CATEGORY_ALTERNATIVE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_ALTERNATIVE = undefined;
+	} else {
+		this.CATEGORY_ALTERNATIVE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_BROWSABLE) {
+		throw new Error('Ti.Android.CATEGORY_BROWSABLE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_BROWSABLE = undefined;
+	} else {
+		this.CATEGORY_BROWSABLE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_DEFAULT) {
+		throw new Error('Ti.Android.CATEGORY_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_DEFAULT = undefined;
+	} else {
+		this.CATEGORY_DEFAULT = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_DEVELOPMENT_PREFERENCE) {
+		throw new Error('Ti.Android.CATEGORY_DEVELOPMENT_PREFERENCE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_DEVELOPMENT_PREFERENCE = undefined;
+	} else {
+		this.CATEGORY_DEVELOPMENT_PREFERENCE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_EMBED) {
+		throw new Error('Ti.Android.CATEGORY_EMBED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_EMBED = undefined;
+	} else {
+		this.CATEGORY_EMBED = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_FRAMEWORK_INSTRUMENTATION_TEST) {
+		throw new Error('Ti.Android.CATEGORY_FRAMEWORK_INSTRUMENTATION_TEST is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_FRAMEWORK_INSTRUMENTATION_TEST = undefined;
+	} else {
+		this.CATEGORY_FRAMEWORK_INSTRUMENTATION_TEST = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_HOME) {
+		throw new Error('Ti.Android.CATEGORY_HOME is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_HOME = undefined;
+	} else {
+		this.CATEGORY_HOME = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_INFO) {
+		throw new Error('Ti.Android.CATEGORY_INFO is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_INFO = undefined;
+	} else {
+		this.CATEGORY_INFO = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_LAUNCHER) {
+		throw new Error('Ti.Android.CATEGORY_LAUNCHER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_LAUNCHER = undefined;
+	} else {
+		this.CATEGORY_LAUNCHER = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_MONKEY) {
+		throw new Error('Ti.Android.CATEGORY_MONKEY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_MONKEY = undefined;
+	} else {
+		this.CATEGORY_MONKEY = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_OPENABLE) {
+		throw new Error('Ti.Android.CATEGORY_OPENABLE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_OPENABLE = undefined;
+	} else {
+		this.CATEGORY_OPENABLE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_PREFERENCE) {
+		throw new Error('Ti.Android.CATEGORY_PREFERENCE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_PREFERENCE = undefined;
+	} else {
+		this.CATEGORY_PREFERENCE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_SAMPLE_CODE) {
+		throw new Error('Ti.Android.CATEGORY_SAMPLE_CODE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_SAMPLE_CODE = undefined;
+	} else {
+		this.CATEGORY_SAMPLE_CODE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_SELECTED_ALTERNATIVE) {
+		throw new Error('Ti.Android.CATEGORY_SELECTED_ALTERNATIVE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_SELECTED_ALTERNATIVE = undefined;
+	} else {
+		this.CATEGORY_SELECTED_ALTERNATIVE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_TAB) {
+		throw new Error('Ti.Android.CATEGORY_TAB is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_TAB = undefined;
+	} else {
+		this.CATEGORY_TAB = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_TEST) {
+		throw new Error('Ti.Android.CATEGORY_TEST is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_TEST = undefined;
+	} else {
+		this.CATEGORY_TEST = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_UNIT_TEST) {
+		throw new Error('Ti.Android.CATEGORY_UNIT_TEST is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_UNIT_TEST = undefined;
+	} else {
+		this.CATEGORY_UNIT_TEST = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_ALARM_COUNT) {
+		throw new Error('Ti.Android.EXTRA_ALARM_COUNT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_ALARM_COUNT = undefined;
+	} else {
+		this.EXTRA_ALARM_COUNT = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_BCC) {
+		throw new Error('Ti.Android.EXTRA_BCC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_BCC = undefined;
+	} else {
+		this.EXTRA_BCC = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_CC) {
+		throw new Error('Ti.Android.EXTRA_CC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_CC = undefined;
+	} else {
+		this.EXTRA_CC = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_DATA_REMOVED) {
+		throw new Error('Ti.Android.EXTRA_DATA_REMOVED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_DATA_REMOVED = undefined;
+	} else {
+		this.EXTRA_DATA_REMOVED = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_DONT_KILL_APP) {
+		throw new Error('Ti.Android.EXTRA_DONT_KILL_APP is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_DONT_KILL_APP = undefined;
+	} else {
+		this.EXTRA_DONT_KILL_APP = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_EMAIL) {
+		throw new Error('Ti.Android.EXTRA_EMAIL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_EMAIL = undefined;
+	} else {
+		this.EXTRA_EMAIL = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_INTENT) {
+		throw new Error('Ti.Android.EXTRA_INTENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_INTENT = undefined;
+	} else {
+		this.EXTRA_INTENT = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_KEY_EVENT) {
+		throw new Error('Ti.Android.EXTRA_KEY_EVENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_KEY_EVENT = undefined;
+	} else {
+		this.EXTRA_KEY_EVENT = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_PHONE_NUMBER) {
+		throw new Error('Ti.Android.EXTRA_PHONE_NUMBER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_PHONE_NUMBER = undefined;
+	} else {
+		this.EXTRA_PHONE_NUMBER = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_REPLACING) {
+		throw new Error('Ti.Android.EXTRA_REPLACING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_REPLACING = undefined;
+	} else {
+		this.EXTRA_REPLACING = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_SHORTCUT_ICON) {
+		throw new Error('Ti.Android.EXTRA_SHORTCUT_ICON is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_SHORTCUT_ICON = undefined;
+	} else {
+		this.EXTRA_SHORTCUT_ICON = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_SHORTCUT_ICON_RESOURCE) {
+		throw new Error('Ti.Android.EXTRA_SHORTCUT_ICON_RESOURCE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_SHORTCUT_ICON_RESOURCE = undefined;
+	} else {
+		this.EXTRA_SHORTCUT_ICON_RESOURCE = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_SHORTCUT_INTENT) {
+		throw new Error('Ti.Android.EXTRA_SHORTCUT_INTENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_SHORTCUT_INTENT = undefined;
+	} else {
+		this.EXTRA_SHORTCUT_INTENT = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_SHORTCUT_NAME) {
+		throw new Error('Ti.Android.EXTRA_SHORTCUT_NAME is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_SHORTCUT_NAME = undefined;
+	} else {
+		this.EXTRA_SHORTCUT_NAME = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_STREAM) {
+		throw new Error('Ti.Android.EXTRA_STREAM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_STREAM = undefined;
+	} else {
+		this.EXTRA_STREAM = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_SUBJECT) {
+		throw new Error('Ti.Android.EXTRA_SUBJECT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_SUBJECT = undefined;
+	} else {
+		this.EXTRA_SUBJECT = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_TEMPLATE) {
+		throw new Error('Ti.Android.EXTRA_TEMPLATE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_TEMPLATE = undefined;
+	} else {
+		this.EXTRA_TEMPLATE = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_TEXT) {
+		throw new Error('Ti.Android.EXTRA_TEXT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_TEXT = undefined;
+	} else {
+		this.EXTRA_TEXT = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_TITLE) {
+		throw new Error('Ti.Android.EXTRA_TITLE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_TITLE = undefined;
+	} else {
+		this.EXTRA_TITLE = '';
+	}
+	if (__SLAG_PROPERTIES.EXTRA_UID) {
+		throw new Error('Ti.Android.EXTRA_UID is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTRA_UID = undefined;
+	} else {
+		this.EXTRA_UID = '';
+	}
+	if (__SLAG_PROPERTIES.FILL_IN_ACTION) {
+		throw new Error('Ti.Android.FILL_IN_ACTION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FILL_IN_ACTION = undefined;
+	} else {
+		this.FILL_IN_ACTION = 0;
+	}
+	if (__SLAG_PROPERTIES.FILL_IN_CATEGORIES) {
+		throw new Error('Ti.Android.FILL_IN_CATEGORIES is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FILL_IN_CATEGORIES = undefined;
+	} else {
+		this.FILL_IN_CATEGORIES = 0;
+	}
+	if (__SLAG_PROPERTIES.FILL_IN_COMPONENT) {
+		throw new Error('Ti.Android.FILL_IN_COMPONENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FILL_IN_COMPONENT = undefined;
+	} else {
+		this.FILL_IN_COMPONENT = 0;
+	}
+	if (__SLAG_PROPERTIES.FILL_IN_DATA) {
+		throw new Error('Ti.Android.FILL_IN_DATA is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FILL_IN_DATA = undefined;
+	} else {
+		this.FILL_IN_DATA = 0;
+	}
+	if (__SLAG_PROPERTIES.FILL_IN_PACKAGE) {
+		throw new Error('Ti.Android.FILL_IN_PACKAGE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FILL_IN_PACKAGE = undefined;
+	} else {
+		this.FILL_IN_PACKAGE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_BROUGHT_TO_FRONT) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_BROUGHT_TO_FRONT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_BROUGHT_TO_FRONT = undefined;
+	} else {
+		this.FLAG_ACTIVITY_BROUGHT_TO_FRONT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_CLEAR_TOP) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_CLEAR_TOP is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_CLEAR_TOP = undefined;
+	} else {
+		this.FLAG_ACTIVITY_CLEAR_TOP = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET = undefined;
+	} else {
+		this.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS = undefined;
+	} else {
+		this.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_FORWARD_RESULT) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_FORWARD_RESULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_FORWARD_RESULT = undefined;
+	} else {
+		this.FLAG_ACTIVITY_FORWARD_RESULT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY = undefined;
+	} else {
+		this.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_MULTIPLE_TASK) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_MULTIPLE_TASK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_MULTIPLE_TASK = undefined;
+	} else {
+		this.FLAG_ACTIVITY_MULTIPLE_TASK = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_NEW_TASK) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_NEW_TASK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_NEW_TASK = undefined;
+	} else {
+		this.FLAG_ACTIVITY_NEW_TASK = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_NO_ANIMATION) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_NO_ANIMATION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_NO_ANIMATION = undefined;
+	} else {
+		this.FLAG_ACTIVITY_NO_ANIMATION = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_NO_HISTORY) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_NO_HISTORY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_NO_HISTORY = undefined;
+	} else {
+		this.FLAG_ACTIVITY_NO_HISTORY = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_NO_USER_ACTION) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_NO_USER_ACTION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_NO_USER_ACTION = undefined;
+	} else {
+		this.FLAG_ACTIVITY_NO_USER_ACTION = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_PREVIOUS_IS_TOP) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_PREVIOUS_IS_TOP is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_PREVIOUS_IS_TOP = undefined;
+	} else {
+		this.FLAG_ACTIVITY_PREVIOUS_IS_TOP = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_REORDER_TO_FRONT) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_REORDER_TO_FRONT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_REORDER_TO_FRONT = undefined;
+	} else {
+		this.FLAG_ACTIVITY_REORDER_TO_FRONT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED = undefined;
+	} else {
+		this.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ACTIVITY_SINGLE_TOP) {
+		throw new Error('Ti.Android.FLAG_ACTIVITY_SINGLE_TOP is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ACTIVITY_SINGLE_TOP = undefined;
+	} else {
+		this.FLAG_ACTIVITY_SINGLE_TOP = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_DEBUG_LOG_RESOLUTION) {
+		throw new Error('Ti.Android.FLAG_DEBUG_LOG_RESOLUTION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_DEBUG_LOG_RESOLUTION = undefined;
+	} else {
+		this.FLAG_DEBUG_LOG_RESOLUTION = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_FROM_BACKGROUND) {
+		throw new Error('Ti.Android.FLAG_FROM_BACKGROUND is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_FROM_BACKGROUND = undefined;
+	} else {
+		this.FLAG_FROM_BACKGROUND = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_GRANT_READ_URI_PERMISSION) {
+		throw new Error('Ti.Android.FLAG_GRANT_READ_URI_PERMISSION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_GRANT_READ_URI_PERMISSION = undefined;
+	} else {
+		this.FLAG_GRANT_READ_URI_PERMISSION = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_GRANT_WRITE_URI_PERMISSION) {
+		throw new Error('Ti.Android.FLAG_GRANT_WRITE_URI_PERMISSION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_GRANT_WRITE_URI_PERMISSION = undefined;
+	} else {
+		this.FLAG_GRANT_WRITE_URI_PERMISSION = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_RECEIVER_REGISTERED_ONLY) {
+		throw new Error('Ti.Android.FLAG_RECEIVER_REGISTERED_ONLY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_RECEIVER_REGISTERED_ONLY = undefined;
+	} else {
+		this.FLAG_RECEIVER_REGISTERED_ONLY = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_CANCEL_CURRENT) {
+		throw new Error('Ti.Android.FLAG_CANCEL_CURRENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_CANCEL_CURRENT = undefined;
+	} else {
+		this.FLAG_CANCEL_CURRENT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_NO_CREATE) {
+		throw new Error('Ti.Android.FLAG_NO_CREATE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_NO_CREATE = undefined;
+	} else {
+		this.FLAG_NO_CREATE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ONE_SHOT) {
+		throw new Error('Ti.Android.FLAG_ONE_SHOT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ONE_SHOT = undefined;
+	} else {
+		this.FLAG_ONE_SHOT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_UPDATE_CURRENT) {
+		throw new Error('Ti.Android.FLAG_UPDATE_CURRENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_UPDATE_CURRENT = undefined;
+	} else {
+		this.FLAG_UPDATE_CURRENT = 0;
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_ALARM) {
+		throw new Error('Ti.Android.CATEGORY_ALARM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_ALARM = undefined;
+	} else {
+		this.CATEGORY_ALARM = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_CALL) {
+		throw new Error('Ti.Android.CATEGORY_CALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_CALL = undefined;
+	} else {
+		this.CATEGORY_CALL = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_EMAIL) {
+		throw new Error('Ti.Android.CATEGORY_EMAIL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_EMAIL = undefined;
+	} else {
+		this.CATEGORY_EMAIL = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_ERROR) {
+		throw new Error('Ti.Android.CATEGORY_ERROR is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_ERROR = undefined;
+	} else {
+		this.CATEGORY_ERROR = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_EVENT) {
+		throw new Error('Ti.Android.CATEGORY_EVENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_EVENT = undefined;
+	} else {
+		this.CATEGORY_EVENT = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_MESSAGE) {
+		throw new Error('Ti.Android.CATEGORY_MESSAGE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_MESSAGE = undefined;
+	} else {
+		this.CATEGORY_MESSAGE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_PROGRESS) {
+		throw new Error('Ti.Android.CATEGORY_PROGRESS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_PROGRESS = undefined;
+	} else {
+		this.CATEGORY_PROGRESS = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_PROMO) {
+		throw new Error('Ti.Android.CATEGORY_PROMO is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_PROMO = undefined;
+	} else {
+		this.CATEGORY_PROMO = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_RECOMMENDATION) {
+		throw new Error('Ti.Android.CATEGORY_RECOMMENDATION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_RECOMMENDATION = undefined;
+	} else {
+		this.CATEGORY_RECOMMENDATION = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_SERVICE) {
+		throw new Error('Ti.Android.CATEGORY_SERVICE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_SERVICE = undefined;
+	} else {
+		this.CATEGORY_SERVICE = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_SOCIAL) {
+		throw new Error('Ti.Android.CATEGORY_SOCIAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_SOCIAL = undefined;
+	} else {
+		this.CATEGORY_SOCIAL = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_STATUS) {
+		throw new Error('Ti.Android.CATEGORY_STATUS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_STATUS = undefined;
+	} else {
+		this.CATEGORY_STATUS = '';
+	}
+	if (__SLAG_PROPERTIES.CATEGORY_TRANSPORT) {
+		throw new Error('Ti.Android.CATEGORY_TRANSPORT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CATEGORY_TRANSPORT = undefined;
+	} else {
+		this.CATEGORY_TRANSPORT = '';
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_ALL) {
+		throw new Error('Ti.Android.DEFAULT_ALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_ALL = undefined;
+	} else {
+		this.DEFAULT_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_LIGHTS) {
+		throw new Error('Ti.Android.DEFAULT_LIGHTS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_LIGHTS = undefined;
+	} else {
+		this.DEFAULT_LIGHTS = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_SOUND) {
+		throw new Error('Ti.Android.DEFAULT_SOUND is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_SOUND = undefined;
+	} else {
+		this.DEFAULT_SOUND = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_VIBRATE) {
+		throw new Error('Ti.Android.DEFAULT_VIBRATE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_VIBRATE = undefined;
+	} else {
+		this.DEFAULT_VIBRATE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_AUTO_CANCEL) {
+		throw new Error('Ti.Android.FLAG_AUTO_CANCEL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_AUTO_CANCEL = undefined;
+	} else {
+		this.FLAG_AUTO_CANCEL = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_INSISTENT) {
+		throw new Error('Ti.Android.FLAG_INSISTENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_INSISTENT = undefined;
+	} else {
+		this.FLAG_INSISTENT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_NO_CLEAR) {
+		throw new Error('Ti.Android.FLAG_NO_CLEAR is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_NO_CLEAR = undefined;
+	} else {
+		this.FLAG_NO_CLEAR = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ONGOING_EVENT) {
+		throw new Error('Ti.Android.FLAG_ONGOING_EVENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ONGOING_EVENT = undefined;
+	} else {
+		this.FLAG_ONGOING_EVENT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ONLY_ALERT_ONCE) {
+		throw new Error('Ti.Android.FLAG_ONLY_ALERT_ONCE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ONLY_ALERT_ONCE = undefined;
+	} else {
+		this.FLAG_ONLY_ALERT_ONCE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_SHOW_LIGHTS) {
+		throw new Error('Ti.Android.FLAG_SHOW_LIGHTS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_SHOW_LIGHTS = undefined;
+	} else {
+		this.FLAG_SHOW_LIGHTS = 0;
+	}
+	if (__SLAG_PROPERTIES.PRIORITY_MAX) {
+		throw new Error('Ti.Android.PRIORITY_MAX is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PRIORITY_MAX = undefined;
+	} else {
+		this.PRIORITY_MAX = 0;
+	}
+	if (__SLAG_PROPERTIES.PRIORITY_HIGH) {
+		throw new Error('Ti.Android.PRIORITY_HIGH is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PRIORITY_HIGH = undefined;
+	} else {
+		this.PRIORITY_HIGH = 0;
+	}
+	if (__SLAG_PROPERTIES.PRIORITY_DEFAULT) {
+		throw new Error('Ti.Android.PRIORITY_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PRIORITY_DEFAULT = undefined;
+	} else {
+		this.PRIORITY_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.PRIORITY_LOW) {
+		throw new Error('Ti.Android.PRIORITY_LOW is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PRIORITY_LOW = undefined;
+	} else {
+		this.PRIORITY_LOW = 0;
+	}
+	if (__SLAG_PROPERTIES.PRIORITY_MIN) {
+		throw new Error('Ti.Android.PRIORITY_MIN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PRIORITY_MIN = undefined;
+	} else {
+		this.PRIORITY_MIN = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_PRIVATE) {
+		throw new Error('Ti.Android.VISIBILITY_PRIVATE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_PRIVATE = undefined;
+	} else {
+		this.VISIBILITY_PRIVATE = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_PUBLIC) {
+		throw new Error('Ti.Android.VISIBILITY_PUBLIC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_PUBLIC = undefined;
+	} else {
+		this.VISIBILITY_PUBLIC = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_SECRET) {
+		throw new Error('Ti.Android.VISIBILITY_SECRET is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_SECRET = undefined;
+	} else {
+		this.VISIBILITY_SECRET = 0;
+	}
+	if (__SLAG_PROPERTIES.PENDING_INTENT_FOR_ACTIVITY) {
+		throw new Error('Ti.Android.PENDING_INTENT_FOR_ACTIVITY was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.PENDING_INTENT_FOR_BROADCAST) {
+		throw new Error('Ti.Android.PENDING_INTENT_FOR_BROADCAST was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.PENDING_INTENT_FOR_SERVICE) {
+		throw new Error('Ti.Android.PENDING_INTENT_FOR_SERVICE was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.PENDING_INTENT_MAX_VALUE) {
+		throw new Error('Ti.Android.PENDING_INTENT_MAX_VALUE was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.R) {
+		throw new Error('Ti.Android.R is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.R = undefined;
+	} else {
+		this.R = {};
+	}
+	if (__SLAG_PROPERTIES.RESULT_CANCELED) {
+		throw new Error('Ti.Android.RESULT_CANCELED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RESULT_CANCELED = undefined;
+	} else {
+		this.RESULT_CANCELED = 0;
+	}
+	if (__SLAG_PROPERTIES.RESULT_FIRST_USER) {
+		throw new Error('Ti.Android.RESULT_FIRST_USER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RESULT_FIRST_USER = undefined;
+	} else {
+		this.RESULT_FIRST_USER = 0;
+	}
+	if (__SLAG_PROPERTIES.RESULT_OK) {
+		throw new Error('Ti.Android.RESULT_OK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RESULT_OK = undefined;
+	} else {
+		this.RESULT_OK = 0;
+	}
+	if (__SLAG_PROPERTIES.SCREEN_ORIENTATION_BEHIND) {
+		throw new Error('Ti.Android.SCREEN_ORIENTATION_BEHIND is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCREEN_ORIENTATION_BEHIND = undefined;
+	} else {
+		this.SCREEN_ORIENTATION_BEHIND = 0;
+	}
+	if (__SLAG_PROPERTIES.SCREEN_ORIENTATION_LANDSCAPE) {
+		throw new Error('Ti.Android.SCREEN_ORIENTATION_LANDSCAPE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCREEN_ORIENTATION_LANDSCAPE = undefined;
+	} else {
+		this.SCREEN_ORIENTATION_LANDSCAPE = 0;
+	}
+	if (__SLAG_PROPERTIES.SCREEN_ORIENTATION_NOSENSOR) {
+		throw new Error('Ti.Android.SCREEN_ORIENTATION_NOSENSOR is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCREEN_ORIENTATION_NOSENSOR = undefined;
+	} else {
+		this.SCREEN_ORIENTATION_NOSENSOR = 0;
+	}
+	if (__SLAG_PROPERTIES.SCREEN_ORIENTATION_PORTRAIT) {
+		throw new Error('Ti.Android.SCREEN_ORIENTATION_PORTRAIT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCREEN_ORIENTATION_PORTRAIT = undefined;
+	} else {
+		this.SCREEN_ORIENTATION_PORTRAIT = 0;
+	}
+	if (__SLAG_PROPERTIES.SCREEN_ORIENTATION_SENSOR) {
+		throw new Error('Ti.Android.SCREEN_ORIENTATION_SENSOR is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCREEN_ORIENTATION_SENSOR = undefined;
+	} else {
+		this.SCREEN_ORIENTATION_SENSOR = 0;
+	}
+	if (__SLAG_PROPERTIES.SCREEN_ORIENTATION_UNSPECIFIED) {
+		throw new Error('Ti.Android.SCREEN_ORIENTATION_UNSPECIFIED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCREEN_ORIENTATION_UNSPECIFIED = undefined;
+	} else {
+		this.SCREEN_ORIENTATION_UNSPECIFIED = 0;
+	}
+	if (__SLAG_PROPERTIES.SCREEN_ORIENTATION_USER) {
+		throw new Error('Ti.Android.SCREEN_ORIENTATION_USER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCREEN_ORIENTATION_USER = undefined;
+	} else {
+		this.SCREEN_ORIENTATION_USER = 0;
+	}
+	if (__SLAG_PROPERTIES.SHOW_AS_ACTION_ALWAYS) {
+		throw new Error('Ti.Android.SHOW_AS_ACTION_ALWAYS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHOW_AS_ACTION_ALWAYS = undefined;
+	} else {
+		this.SHOW_AS_ACTION_ALWAYS = 0;
+	}
+	if (__SLAG_PROPERTIES.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW) {
+		throw new Error('Ti.Android.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW = undefined;
+	} else {
+		this.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW = 0;
+	}
+	if (__SLAG_PROPERTIES.SHOW_AS_ACTION_IF_ROOM) {
+		throw new Error('Ti.Android.SHOW_AS_ACTION_IF_ROOM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHOW_AS_ACTION_IF_ROOM = undefined;
+	} else {
+		this.SHOW_AS_ACTION_IF_ROOM = 0;
+	}
+	if (__SLAG_PROPERTIES.SHOW_AS_ACTION_NEVER) {
+		throw new Error('Ti.Android.SHOW_AS_ACTION_NEVER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHOW_AS_ACTION_NEVER = undefined;
+	} else {
+		this.SHOW_AS_ACTION_NEVER = 0;
+	}
+	if (__SLAG_PROPERTIES.SHOW_AS_ACTION_WITH_TEXT) {
+		throw new Error('Ti.Android.SHOW_AS_ACTION_WITH_TEXT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHOW_AS_ACTION_WITH_TEXT = undefined;
+	} else {
+		this.SHOW_AS_ACTION_WITH_TEXT = 0;
+	}
+	if (__SLAG_PROPERTIES.NAVIGATION_MODE_STANDARD) {
+		throw new Error('Ti.Android.NAVIGATION_MODE_STANDARD is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NAVIGATION_MODE_STANDARD = undefined;
+	} else {
+		this.NAVIGATION_MODE_STANDARD = 0;
+	}
+	if (__SLAG_PROPERTIES.NAVIGATION_MODE_TABS) {
+		throw new Error('Ti.Android.NAVIGATION_MODE_TABS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NAVIGATION_MODE_TABS = undefined;
+	} else {
+		this.NAVIGATION_MODE_TABS = 0;
+	}
+	if (__SLAG_PROPERTIES.START_NOT_STICKY) {
+		throw new Error('Ti.Android.START_NOT_STICKY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.START_NOT_STICKY = undefined;
+	} else {
+		this.START_NOT_STICKY = 0;
+	}
+	if (__SLAG_PROPERTIES.START_REDELIVER_INTENT) {
+		throw new Error('Ti.Android.START_REDELIVER_INTENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.START_REDELIVER_INTENT = undefined;
+	} else {
+		this.START_REDELIVER_INTENT = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_ALARM) {
+		throw new Error('Ti.Android.STREAM_ALARM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_ALARM = undefined;
+	} else {
+		this.STREAM_ALARM = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_DEFAULT) {
+		throw new Error('Ti.Android.STREAM_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_DEFAULT = undefined;
+	} else {
+		this.STREAM_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_MUSIC) {
+		throw new Error('Ti.Android.STREAM_MUSIC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_MUSIC = undefined;
+	} else {
+		this.STREAM_MUSIC = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_NOTIFICATION) {
+		throw new Error('Ti.Android.STREAM_NOTIFICATION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_NOTIFICATION = undefined;
+	} else {
+		this.STREAM_NOTIFICATION = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_RING) {
+		throw new Error('Ti.Android.STREAM_RING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_RING = undefined;
+	} else {
+		this.STREAM_RING = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_SYSTEM) {
+		throw new Error('Ti.Android.STREAM_SYSTEM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_SYSTEM = undefined;
+	} else {
+		this.STREAM_SYSTEM = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_VOICE_CALL) {
+		throw new Error('Ti.Android.STREAM_VOICE_CALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_VOICE_CALL = undefined;
+	} else {
+		this.STREAM_VOICE_CALL = 0;
+	}
+	if (__SLAG_PROPERTIES.URI_INTENT_SCHEME) {
+		throw new Error('Ti.Android.URI_INTENT_SCHEME is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URI_INTENT_SCHEME = undefined;
+	} else {
+		this.URI_INTENT_SCHEME = 0;
+	}
+	if (__SLAG_PROPERTIES.currentActivity) {
+		throw new Error('Ti.Android.currentActivity is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentActivity = undefined;
+	} else {
+		this.currentActivity = {};
+	}
+	if (__SLAG_PROPERTIES.currentService) {
+		throw new Error('Ti.Android.currentService is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentService = undefined;
+	} else {
+		this.currentService = {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Android.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Android.prototype.createIntentChooser = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Intent = require('./Android/Intent');
+	return Intent(__SLAG_PROPERTY);
+};
+Android.prototype.createPendingIntent = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var PendingIntent = require('./Android/PendingIntent');
+	return PendingIntent(__SLAG_PROPERTY);
+};
+Android.prototype.createService = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Service = require('./Android/Service');
+	return Service(__SLAG_PROPERTY);
+};
+Android.prototype.createServiceIntent = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Intent = require('./Android/Intent');
+	return Intent(__SLAG_PROPERTY);
+};
+Android.prototype.hasPermission = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Android.prototype.requestPermissions = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.isServiceRunning = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Android.prototype.registerBroadcastReceiver = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.unregisterBroadcastReceiver = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.startService = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.stopService = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.createBroadcastIntent = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Intent = require('./Android/Intent');
+	return Intent(__SLAG_PROPERTY);
+};
+Android.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Android.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Android.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Android.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Android.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Android.prototype.createBroadcastReceiver = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var BroadcastReceiver = require('./Android/BroadcastReceiver');
+	return BroadcastReceiver(__SLAG_PROPERTY);
+};
+Android.prototype.createIntent = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Intent = require('./Android/Intent');
+	return Intent(__SLAG_PROPERTY);
+};
+Android.prototype.createNotification = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Notification = require('./Android/Notification');
+	return Notification(__SLAG_PROPERTY);
+};
+Android.prototype.createRemoteViews = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var RemoteViews = require('./Android/RemoteViews');
+	return RemoteViews(__SLAG_PROPERTY);
+};
+module.exports = function (properties) {
+	return new Android(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/ActionBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/ActionBar.js
@@ -1,0 +1,239 @@
+var crypto = require('crypto');
+function ActionBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'backgroundImage',
+			'displayHomeAsUp',
+			'homeButtonEnabled',
+			'icon',
+			'logo',
+			'navigationMode',
+			'onHomeIconItemSelected',
+			'subtitle',
+			'title',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.ActionBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.ActionBar';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.displayHomeAsUp = undefined;
+	} else {
+		this.displayHomeAsUp = __SLAG_PROPERTIES.displayHomeAsUp || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.homeButtonEnabled = undefined;
+	} else {
+		this.homeButtonEnabled = __SLAG_PROPERTIES.homeButtonEnabled || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.icon = undefined;
+	} else {
+		this.icon = __SLAG_PROPERTIES.icon || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.logo = undefined;
+	} else {
+		this.logo = __SLAG_PROPERTIES.logo || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navigationMode = undefined;
+	} else {
+		this.navigationMode = __SLAG_PROPERTIES.navigationMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onHomeIconItemSelected = undefined;
+	} else {
+		this.onHomeIconItemSelected = __SLAG_PROPERTIES.onHomeIconItemSelected || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subtitle = undefined;
+	} else {
+		this.subtitle = __SLAG_PROPERTIES.subtitle || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ActionBar.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActionBar.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActionBar.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActionBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ActionBar.prototype.hide = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActionBar.prototype.setDisplayShowHomeEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActionBar.prototype.setDisplayShowTitleEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActionBar.prototype.show = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActionBar.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ActionBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ActionBar.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ActionBar.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ActionBar.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ActionBar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+ActionBar.prototype.setDisplayHomeAsUp = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.displayHomeAsUp = __SLAG__PROPERTY;
+};
+ActionBar.prototype.setHomeButtonEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.homeButtonEnabled = __SLAG__PROPERTY;
+};
+ActionBar.prototype.setIcon = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.icon = __SLAG__PROPERTY;
+};
+ActionBar.prototype.setLogo = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.logo = __SLAG__PROPERTY;
+};
+ActionBar.prototype.getNavigationMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navigationMode;
+};
+ActionBar.prototype.setNavigationMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navigationMode = __SLAG__PROPERTY;
+};
+ActionBar.prototype.setOnHomeIconItemSelected = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onHomeIconItemSelected = __SLAG__PROPERTY;
+};
+ActionBar.prototype.getSubtitle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.subtitle;
+};
+ActionBar.prototype.setSubtitle = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.subtitle = __SLAG__PROPERTY;
+};
+ActionBar.prototype.getTitle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+ActionBar.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ActionBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Activity.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Activity.js
@@ -1,0 +1,343 @@
+var crypto = require('crypto');
+function Activity(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'actionBar',
+			'intent',
+			'onCreate',
+			'onCreateOptionsMenu',
+			'onDestroy',
+			'onPause',
+			'onPrepareOptionsMenu',
+			'onRestart',
+			'onResume',
+			'onStart',
+			'onStop',
+			'requestedOrientation',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Activity.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Activity';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.actionBar) {
+		throw new Error('Ti.Android.Activity.actionBar is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.actionBar = undefined;
+	} else {
+		this.actionBar = {};
+	}
+	if (__SLAG_PROPERTIES.intent) {
+		throw new Error('Ti.Android.Activity.intent is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.intent = undefined;
+	} else {
+		this.intent = {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onCreate = undefined;
+	} else {
+		this.onCreate = __SLAG_PROPERTIES.onCreate || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onCreateOptionsMenu = undefined;
+	} else {
+		this.onCreateOptionsMenu = __SLAG_PROPERTIES.onCreateOptionsMenu || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onDestroy = undefined;
+	} else {
+		this.onDestroy = __SLAG_PROPERTIES.onDestroy || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onPause = undefined;
+	} else {
+		this.onPause = __SLAG_PROPERTIES.onPause || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onPrepareOptionsMenu = undefined;
+	} else {
+		this.onPrepareOptionsMenu = __SLAG_PROPERTIES.onPrepareOptionsMenu || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onRestart = undefined;
+	} else {
+		this.onRestart = __SLAG_PROPERTIES.onRestart || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onResume = undefined;
+	} else {
+		this.onResume = __SLAG_PROPERTIES.onResume || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onStart = undefined;
+	} else {
+		this.onStart = __SLAG_PROPERTIES.onStart || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onStop = undefined;
+	} else {
+		this.onStop = __SLAG_PROPERTIES.onStop || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.requestedOrientation = undefined;
+	} else {
+		this.requestedOrientation = __SLAG_PROPERTIES.requestedOrientation || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Activity.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Activity.prototype.finish = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.getString = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Activity.prototype.invalidateOptionsMenu = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.setRequestedOrientation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.requestedOrientation = __SLAG__PROPERTY;
+};
+Activity.prototype.setResult = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.startActivity = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.startActivityForResult = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.openOptionsMenu = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.sendBroadcast = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.sendBroadcastWithPermission = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Activity.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Activity.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Activity.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Activity.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Activity.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Activity.prototype.getActionBar = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.actionBar;
+};
+Activity.prototype.getIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.intent;
+};
+Activity.prototype.getOnCreate = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onCreate;
+};
+Activity.prototype.setOnCreate = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onCreate = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnCreateOptionsMenu = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onCreateOptionsMenu;
+};
+Activity.prototype.setOnCreateOptionsMenu = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onCreateOptionsMenu = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnDestroy = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onDestroy;
+};
+Activity.prototype.setOnDestroy = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onDestroy = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnPause = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onPause;
+};
+Activity.prototype.setOnPause = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onPause = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnPrepareOptionsMenu = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onPrepareOptionsMenu;
+};
+Activity.prototype.setOnPrepareOptionsMenu = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onPrepareOptionsMenu = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnRestart = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onRestart;
+};
+Activity.prototype.setOnRestart = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onRestart = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnResume = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onResume;
+};
+Activity.prototype.setOnResume = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onResume = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnStart = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onStart;
+};
+Activity.prototype.setOnStart = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onStart = __SLAG__PROPERTY;
+};
+Activity.prototype.getOnStop = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onStop;
+};
+Activity.prototype.setOnStop = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onStop = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Activity(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/BigPictureStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/BigPictureStyle.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function BigPictureStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bigLargeIcon',
+			'bigPicture',
+			'bigContentTitle',
+			'decodeRetries',
+			'summaryText',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bigLargeIcon = undefined;
+	} else {
+		this.bigLargeIcon = __SLAG_PROPERTIES.bigLargeIcon || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bigPicture = undefined;
+	} else {
+		this.bigPicture = __SLAG_PROPERTIES.bigPicture || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bigContentTitle = undefined;
+	} else {
+		this.bigContentTitle = __SLAG_PROPERTIES.bigContentTitle || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.decodeRetries = undefined;
+	} else {
+		this.decodeRetries = __SLAG_PROPERTIES.decodeRetries || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.summaryText = undefined;
+	} else {
+		this.summaryText = __SLAG_PROPERTIES.summaryText || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new BigPictureStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/BigTextStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/BigTextStyle.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function BigTextStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bigText',
+			'bigContentTitle',
+			'summaryText',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bigText = undefined;
+	} else {
+		this.bigText = __SLAG_PROPERTIES.bigText || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bigContentTitle = undefined;
+	} else {
+		this.bigContentTitle = __SLAG_PROPERTIES.bigContentTitle || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.summaryText = undefined;
+	} else {
+		this.summaryText = __SLAG_PROPERTIES.summaryText || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new BigTextStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/BroadcastReceiver.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/BroadcastReceiver.js
@@ -1,0 +1,129 @@
+var crypto = require('crypto');
+function BroadcastReceiver(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'onReceived',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.BroadcastReceiver.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.BroadcastReceiver';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onReceived = undefined;
+	} else {
+		this.onReceived = __SLAG_PROPERTIES.onReceived || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+BroadcastReceiver.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BroadcastReceiver.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BroadcastReceiver.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BroadcastReceiver.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+BroadcastReceiver.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+BroadcastReceiver.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+BroadcastReceiver.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+BroadcastReceiver.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+BroadcastReceiver.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+BroadcastReceiver.prototype.getOnReceived = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onReceived;
+};
+BroadcastReceiver.prototype.setOnReceived = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onReceived = __SLAG__PROPERTY;
+};
+BroadcastReceiver.prototype.getUrl = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+BroadcastReceiver.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new BroadcastReceiver(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Calendar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Calendar.js
@@ -1,0 +1,270 @@
+var crypto = require('crypto');
+function Calendar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'METHOD_ALERT',
+			'METHOD_DEFAULT',
+			'METHOD_EMAIL',
+			'METHOD_SMS',
+			'STATE_DISMISSED',
+			'STATE_FIRED',
+			'STATE_SCHEDULED',
+			'STATUS_CANCELED',
+			'STATUS_CONFIRMED',
+			'STATUS_TENTATIVE',
+			'VISIBILITY_CONFIDENTIAL',
+			'VISIBILITY_DEFAULT',
+			'VISIBILITY_PRIVATE',
+			'VISIBILITY_PUBLIC',
+			'allAlerts',
+			'allCalendars',
+			'selectableCalendars',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Calendar.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Calendar';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.METHOD_ALERT) {
+		throw new Error('Ti.Android.Calendar.METHOD_ALERT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_ALERT = undefined;
+	} else {
+		this.METHOD_ALERT = 0;
+	}
+	if (__SLAG_PROPERTIES.METHOD_DEFAULT) {
+		throw new Error('Ti.Android.Calendar.METHOD_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_DEFAULT = undefined;
+	} else {
+		this.METHOD_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.METHOD_EMAIL) {
+		throw new Error('Ti.Android.Calendar.METHOD_EMAIL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_EMAIL = undefined;
+	} else {
+		this.METHOD_EMAIL = 0;
+	}
+	if (__SLAG_PROPERTIES.METHOD_SMS) {
+		throw new Error('Ti.Android.Calendar.METHOD_SMS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_SMS = undefined;
+	} else {
+		this.METHOD_SMS = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_DISMISSED) {
+		throw new Error('Ti.Android.Calendar.STATE_DISMISSED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_DISMISSED = undefined;
+	} else {
+		this.STATE_DISMISSED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_FIRED) {
+		throw new Error('Ti.Android.Calendar.STATE_FIRED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_FIRED = undefined;
+	} else {
+		this.STATE_FIRED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_SCHEDULED) {
+		throw new Error('Ti.Android.Calendar.STATE_SCHEDULED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_SCHEDULED = undefined;
+	} else {
+		this.STATE_SCHEDULED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATUS_CANCELED) {
+		throw new Error('Ti.Android.Calendar.STATUS_CANCELED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATUS_CANCELED = undefined;
+	} else {
+		this.STATUS_CANCELED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATUS_CONFIRMED) {
+		throw new Error('Ti.Android.Calendar.STATUS_CONFIRMED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATUS_CONFIRMED = undefined;
+	} else {
+		this.STATUS_CONFIRMED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATUS_TENTATIVE) {
+		throw new Error('Ti.Android.Calendar.STATUS_TENTATIVE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATUS_TENTATIVE = undefined;
+	} else {
+		this.STATUS_TENTATIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_CONFIDENTIAL) {
+		throw new Error('Ti.Android.Calendar.VISIBILITY_CONFIDENTIAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_CONFIDENTIAL = undefined;
+	} else {
+		this.VISIBILITY_CONFIDENTIAL = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_DEFAULT) {
+		throw new Error('Ti.Android.Calendar.VISIBILITY_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_DEFAULT = undefined;
+	} else {
+		this.VISIBILITY_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_PRIVATE) {
+		throw new Error('Ti.Android.Calendar.VISIBILITY_PRIVATE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_PRIVATE = undefined;
+	} else {
+		this.VISIBILITY_PRIVATE = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_PUBLIC) {
+		throw new Error('Ti.Android.Calendar.VISIBILITY_PUBLIC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_PUBLIC = undefined;
+	} else {
+		this.VISIBILITY_PUBLIC = 0;
+	}
+	if (__SLAG_PROPERTIES.allAlerts) {
+		throw new Error('Ti.Android.Calendar.allAlerts is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allAlerts = undefined;
+	} else {
+		this.allAlerts = [];
+	}
+	if (__SLAG_PROPERTIES.allCalendars) {
+		throw new Error('Ti.Android.Calendar.allCalendars is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allCalendars = undefined;
+	} else {
+		this.allCalendars = [];
+	}
+	if (__SLAG_PROPERTIES.selectableCalendars) {
+		throw new Error('Ti.Android.Calendar.selectableCalendars is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectableCalendars = undefined;
+	} else {
+		this.selectableCalendars = [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Calendar.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Calendar.prototype.getCalendarById = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Calendar.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Calendar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Calendar.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Calendar.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Calendar.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Calendar.prototype.getAllAlerts = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allAlerts;
+};
+Calendar.prototype.getAllCalendars = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allCalendars;
+};
+Calendar.prototype.getSelectableCalendars = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectableCalendars;
+};
+module.exports = function (properties) {
+	return new Calendar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Alert.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Alert.js
@@ -1,0 +1,198 @@
+var crypto = require('crypto');
+function Alert(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'alarmTime',
+			'begin',
+			'end',
+			'eventId',
+			'id',
+			'minutes',
+			'state',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Calendar.Alert.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Calendar.Alert';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.alarmTime) {
+		throw new Error('Ti.Android.Calendar.Alert.alarmTime is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alarmTime = undefined;
+	} else {
+		this.alarmTime = new Date();
+	}
+	if (__SLAG_PROPERTIES.begin) {
+		throw new Error('Ti.Android.Calendar.Alert.begin is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.begin = undefined;
+	} else {
+		this.begin = new Date();
+	}
+	if (__SLAG_PROPERTIES.end) {
+		throw new Error('Ti.Android.Calendar.Alert.end is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.end = undefined;
+	} else {
+		this.end = new Date();
+	}
+	if (__SLAG_PROPERTIES.eventId) {
+		throw new Error('Ti.Android.Calendar.Alert.eventId is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.eventId = undefined;
+	} else {
+		this.eventId = 0;
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Android.Calendar.Alert.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.minutes) {
+		throw new Error('Ti.Android.Calendar.Alert.minutes is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minutes = undefined;
+	} else {
+		this.minutes = 0;
+	}
+	if (__SLAG_PROPERTIES.state) {
+		throw new Error('Ti.Android.Calendar.Alert.state is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.state = undefined;
+	} else {
+		this.state = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Alert.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Alert.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Alert.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Alert.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Alert.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Alert.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Alert.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Alert.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Alert.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Alert.prototype.getAlarmTime = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.alarmTime;
+};
+Alert.prototype.getBegin = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.begin;
+};
+Alert.prototype.getEnd = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.end;
+};
+Alert.prototype.getEventId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.eventId;
+};
+Alert.prototype.getId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Alert.prototype.getMinutes = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minutes;
+};
+Alert.prototype.getState = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.state;
+};
+module.exports = function (properties) {
+	return new Alert(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Calendar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Calendar.js
@@ -1,0 +1,190 @@
+var crypto = require('crypto');
+function Calendar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'hidden',
+			'id',
+			'name',
+			'selected',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Calendar.Calendar.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Calendar.Calendar';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.hidden) {
+		throw new Error('Ti.Android.Calendar.Calendar.hidden is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidden = undefined;
+	} else {
+		this.hidden = true;
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Android.Calendar.Calendar.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.Android.Calendar.Calendar.name is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if (__SLAG_PROPERTIES.selected) {
+		throw new Error('Ti.Android.Calendar.Calendar.selected is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selected = undefined;
+	} else {
+		this.selected = true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Calendar.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Calendar.prototype.createEvent = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Event = require('./Event');
+	return Event(__SLAG_PROPERTY);
+};
+Calendar.prototype.getEventById = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Calendar.prototype.getEventsBetweenDates = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getEventsInDate = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getEventsInMonth = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getEventsInYear = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Calendar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Calendar.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Calendar.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Calendar.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Calendar.prototype.getHidden = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidden;
+};
+Calendar.prototype.getId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Calendar.prototype.getName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+Calendar.prototype.getSelected = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selected;
+};
+module.exports = function (properties) {
+	return new Calendar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Event.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Event.js
@@ -1,0 +1,328 @@
+var crypto = require('crypto');
+function Event(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'alerts',
+			'allDay',
+			'begin',
+			'description',
+			'end',
+			'extendedProperties',
+			'hasAlarm',
+			'hasExtendedProperties',
+			'id',
+			'location',
+			'reminders',
+			'status',
+			'title',
+			'visibility',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Calendar.Event.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Calendar.Event';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.alerts) {
+		throw new Error('Ti.Android.Calendar.Event.alerts is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alerts = undefined;
+	} else {
+		this.alerts = [];
+	}
+	if (__SLAG_PROPERTIES.allDay) {
+		throw new Error('Ti.Android.Calendar.Event.allDay is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allDay = undefined;
+	} else {
+		this.allDay = true;
+	}
+	if (__SLAG_PROPERTIES.begin) {
+		throw new Error('Ti.Android.Calendar.Event.begin is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.begin = undefined;
+	} else {
+		this.begin = new Date();
+	}
+	if (__SLAG_PROPERTIES.description) {
+		throw new Error('Ti.Android.Calendar.Event.description is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.description = undefined;
+	} else {
+		this.description = '';
+	}
+	if (__SLAG_PROPERTIES.end) {
+		throw new Error('Ti.Android.Calendar.Event.end is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.end = undefined;
+	} else {
+		this.end = new Date();
+	}
+	if (__SLAG_PROPERTIES.extendedProperties) {
+		throw new Error('Ti.Android.Calendar.Event.extendedProperties is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.extendedProperties = undefined;
+	} else {
+		this.extendedProperties = {};
+	}
+	if (__SLAG_PROPERTIES.hasAlarm) {
+		throw new Error('Ti.Android.Calendar.Event.hasAlarm is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasAlarm = undefined;
+	} else {
+		this.hasAlarm = true;
+	}
+	if (__SLAG_PROPERTIES.hasExtendedProperties) {
+		throw new Error('Ti.Android.Calendar.Event.hasExtendedProperties is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasExtendedProperties = undefined;
+	} else {
+		this.hasExtendedProperties = true;
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Android.Calendar.Event.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.location) {
+		throw new Error('Ti.Android.Calendar.Event.location is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.location = undefined;
+	} else {
+		this.location = '';
+	}
+	if (__SLAG_PROPERTIES.reminders) {
+		throw new Error('Ti.Android.Calendar.Event.reminders is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.reminders = undefined;
+	} else {
+		this.reminders = [];
+	}
+	if (__SLAG_PROPERTIES.status) {
+		throw new Error('Ti.Android.Calendar.Event.status is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.status = undefined;
+	} else {
+		this.status = 0;
+	}
+	if (__SLAG_PROPERTIES.title) {
+		throw new Error('Ti.Android.Calendar.Event.title is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = '';
+	}
+	if (__SLAG_PROPERTIES.visibility) {
+		throw new Error('Ti.Android.Calendar.Event.visibility is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visibility = undefined;
+	} else {
+		this.visibility = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Event.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Event.prototype.createAlert = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Alert = require('./Alert');
+	return Alert(__SLAG_PROPERTY);
+};
+Event.prototype.createReminder = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Reminder = require('./Reminder');
+	return Reminder(__SLAG_PROPERTY);
+};
+Event.prototype.getExtendedProperty = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Event.prototype.setExtendedProperty = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Event.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Event.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Event.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Event.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Event.prototype.getAlerts = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.alerts;
+};
+Event.prototype.getAllDay = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allDay;
+};
+Event.prototype.getBegin = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.begin;
+};
+Event.prototype.getDescription = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.description;
+};
+Event.prototype.getEnd = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.end;
+};
+Event.prototype.getExtendedProperties = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.extendedProperties;
+};
+Event.prototype.getHasAlarm = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasAlarm;
+};
+Event.prototype.getHasExtendedProperties = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasExtendedProperties;
+};
+Event.prototype.getId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Event.prototype.getLocation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.location;
+};
+Event.prototype.getReminders = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.reminders;
+};
+Event.prototype.getStatus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.status;
+};
+Event.prototype.getTitle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+Event.prototype.getVisibility = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visibility;
+};
+module.exports = function (properties) {
+	return new Event(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Reminder.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Calendar/Reminder.js
@@ -1,0 +1,138 @@
+var crypto = require('crypto');
+function Reminder(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id',
+			'method',
+			'minutes',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Calendar.Reminder.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Calendar.Reminder';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Android.Calendar.Reminder.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.method) {
+		throw new Error('Ti.Android.Calendar.Reminder.method is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.method = undefined;
+	} else {
+		this.method = 0;
+	}
+	if (__SLAG_PROPERTIES.minutes) {
+		throw new Error('Ti.Android.Calendar.Reminder.minutes is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minutes = undefined;
+	} else {
+		this.minutes = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Reminder.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reminder.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reminder.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reminder.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Reminder.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Reminder.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Reminder.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Reminder.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Reminder.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Reminder.prototype.getId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Reminder.prototype.getMethod = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.method;
+};
+Reminder.prototype.getMinutes = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minutes;
+};
+module.exports = function (properties) {
+	return new Reminder(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Intent.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Intent.js
@@ -1,0 +1,281 @@
+var crypto = require('crypto');
+function Intent(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'action',
+			'className',
+			'data',
+			'flags',
+			'packageName',
+			'type',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Intent.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Intent';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.action = undefined;
+	} else {
+		this.action = __SLAG_PROPERTIES.action || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.className = undefined;
+	} else {
+		this.className = __SLAG_PROPERTIES.className || '';
+	}
+	if (__SLAG_PROPERTIES.data) {
+		throw new Error('Ti.Android.Intent.data is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.flags = undefined;
+	} else {
+		this.flags = __SLAG_PROPERTIES.flags || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.packageName = undefined;
+	} else {
+		this.packageName = __SLAG_PROPERTIES.packageName || '';
+	}
+	if (__SLAG_PROPERTIES.type) {
+		throw new Error('Ti.Android.Intent.type is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Intent.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Intent.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Intent.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Intent.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Intent.prototype.addCategory = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Intent.prototype.addFlags = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Intent.prototype.getBlobExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Intent.prototype.getBooleanExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Intent.prototype.getData = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+Intent.prototype.getDoubleExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Intent.prototype.getIntExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Intent.prototype.getLongExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Intent.prototype.getStringExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Intent.prototype.hasExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Intent.prototype.putExtra = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Intent.prototype.putExtraUri = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Intent.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Intent.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Intent.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Intent.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Intent.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Intent.prototype.getAction = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.action;
+};
+Intent.prototype.setAction = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.action = __SLAG__PROPERTY;
+};
+Intent.prototype.getClassName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.className;
+};
+Intent.prototype.setClassName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.className = __SLAG__PROPERTY;
+};
+Intent.prototype.getData = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+Intent.prototype.getFlags = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.flags;
+};
+Intent.prototype.setFlags = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.flags = __SLAG__PROPERTY;
+};
+Intent.prototype.getPackageName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.packageName;
+};
+Intent.prototype.setPackageName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.packageName = __SLAG__PROPERTY;
+};
+Intent.prototype.getType = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+Intent.prototype.getUrl = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+Intent.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Intent(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Menu.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Menu.js
@@ -1,0 +1,168 @@
+var crypto = require('crypto');
+function Menu(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'items',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Menu.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Menu';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.items) {
+		throw new Error('Ti.Android.Menu.items is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Menu.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Menu.prototype.add = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Menu.prototype.clear = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.close = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.findItem = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Menu.prototype.getItem = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Menu.prototype.hasVisibleItems = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Menu.prototype.removeGroup = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.removeItem = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.setGroupEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.setGroupVisible = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Menu.prototype.size = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Menu.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Menu.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Menu.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Menu.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Menu.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Menu.prototype.getItems = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+module.exports = function (properties) {
+	return new Menu(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/MenuItem.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/MenuItem.js
@@ -1,0 +1,313 @@
+var crypto = require('crypto');
+function MenuItem(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'actionView',
+			'actionViewExpanded',
+			'checkable',
+			'checked',
+			'enabled',
+			'groupId',
+			'icon',
+			'itemId',
+			'order',
+			'showAsAction',
+			'title',
+			'titleCondensed',
+			'visible',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.MenuItem.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.MenuItem';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.actionView = undefined;
+	} else {
+		this.actionView = __SLAG_PROPERTIES.actionView || {};
+	}
+	if (__SLAG_PROPERTIES.actionViewExpanded) {
+		throw new Error('Ti.Android.MenuItem.actionViewExpanded is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.actionViewExpanded = undefined;
+	} else {
+		this.actionViewExpanded = true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.checkable = undefined;
+	} else {
+		this.checkable = __SLAG_PROPERTIES.checkable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.checked = undefined;
+	} else {
+		this.checked = __SLAG_PROPERTIES.checked || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enabled = undefined;
+	} else {
+		this.enabled = __SLAG_PROPERTIES.enabled || true;
+	}
+	if (__SLAG_PROPERTIES.groupId) {
+		throw new Error('Ti.Android.MenuItem.groupId is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.groupId = undefined;
+	} else {
+		this.groupId = 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.icon = undefined;
+	} else {
+		this.icon = __SLAG_PROPERTIES.icon || 0;
+	}
+	if (__SLAG_PROPERTIES.itemId) {
+		throw new Error('Ti.Android.MenuItem.itemId is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.itemId = undefined;
+	} else {
+		this.itemId = 0;
+	}
+	if (__SLAG_PROPERTIES.order) {
+		throw new Error('Ti.Android.MenuItem.order is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.order = undefined;
+	} else {
+		this.order = 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showAsAction = undefined;
+	} else {
+		this.showAsAction = __SLAG_PROPERTIES.showAsAction || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleCondensed = undefined;
+	} else {
+		this.titleCondensed = __SLAG_PROPERTIES.titleCondensed || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+MenuItem.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MenuItem.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MenuItem.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MenuItem.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+MenuItem.prototype.collapseActionView = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MenuItem.prototype.expandActionView = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MenuItem.prototype.isActionViewExpanded = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+MenuItem.prototype.isCheckable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+MenuItem.prototype.isChecked = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+MenuItem.prototype.isEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+MenuItem.prototype.isVisible = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+MenuItem.prototype.setCheckable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.checkable = __SLAG__PROPERTY;
+};
+MenuItem.prototype.setChecked = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.checked = __SLAG__PROPERTY;
+};
+MenuItem.prototype.setEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enabled = __SLAG__PROPERTY;
+};
+MenuItem.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+MenuItem.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+MenuItem.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+MenuItem.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+MenuItem.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+MenuItem.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+MenuItem.prototype.getActionView = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.actionView;
+};
+MenuItem.prototype.setActionView = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.actionView = __SLAG__PROPERTY;
+};
+MenuItem.prototype.getGroupId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.groupId;
+};
+MenuItem.prototype.setIcon = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.icon = __SLAG__PROPERTY;
+};
+MenuItem.prototype.getItemId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.itemId;
+};
+MenuItem.prototype.getOrder = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.order;
+};
+MenuItem.prototype.setShowAsAction = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showAsAction = __SLAG__PROPERTY;
+};
+MenuItem.prototype.getTitle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+MenuItem.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+MenuItem.prototype.getTitleCondensed = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleCondensed;
+};
+MenuItem.prototype.setTitleCondensed = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleCondensed = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new MenuItem(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Notification.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Notification.js
@@ -1,0 +1,470 @@
+var crypto = require('crypto');
+function Notification(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'audioStreamType',
+			'category',
+			'contentIntent',
+			'contentText',
+			'contentTitle',
+			'contentView',
+			'defaults',
+			'deleteIntent',
+			'flags',
+			'icon',
+			'largeIcon',
+			'ledARGB',
+			'ledOffMS',
+			'ledOnMS',
+			'number',
+			'priority',
+			'sound',
+			'style',
+			'tickerText',
+			'visibility',
+			'when',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Notification.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Notification';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioStreamType = undefined;
+	} else {
+		this.audioStreamType = __SLAG_PROPERTIES.audioStreamType || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.category = undefined;
+	} else {
+		this.category = __SLAG_PROPERTIES.category || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentIntent = undefined;
+	} else {
+		this.contentIntent = __SLAG_PROPERTIES.contentIntent || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentText = undefined;
+	} else {
+		this.contentText = __SLAG_PROPERTIES.contentText || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentTitle = undefined;
+	} else {
+		this.contentTitle = __SLAG_PROPERTIES.contentTitle || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentView = undefined;
+	} else {
+		this.contentView = __SLAG_PROPERTIES.contentView || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.defaults = undefined;
+	} else {
+		this.defaults = __SLAG_PROPERTIES.defaults || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.deleteIntent = undefined;
+	} else {
+		this.deleteIntent = __SLAG_PROPERTIES.deleteIntent || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.flags = undefined;
+	} else {
+		this.flags = __SLAG_PROPERTIES.flags || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.icon = undefined;
+	} else {
+		this.icon = __SLAG_PROPERTIES.icon || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.largeIcon = undefined;
+	} else {
+		this.largeIcon = __SLAG_PROPERTIES.largeIcon || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ledARGB = undefined;
+	} else {
+		this.ledARGB = __SLAG_PROPERTIES.ledARGB || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ledOffMS = undefined;
+	} else {
+		this.ledOffMS = __SLAG_PROPERTIES.ledOffMS || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ledOnMS = undefined;
+	} else {
+		this.ledOnMS = __SLAG_PROPERTIES.ledOnMS || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.number = undefined;
+	} else {
+		this.number = __SLAG_PROPERTIES.number || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.priority = undefined;
+	} else {
+		this.priority = __SLAG_PROPERTIES.priority || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sound = undefined;
+	} else {
+		this.sound = __SLAG_PROPERTIES.sound || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tickerText = undefined;
+	} else {
+		this.tickerText = __SLAG_PROPERTIES.tickerText || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visibility = undefined;
+	} else {
+		this.visibility = __SLAG_PROPERTIES.visibility || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.when = undefined;
+	} else {
+		this.when = __SLAG_PROPERTIES.when || new Date();
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Notification.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Notification.prototype.setLatestEventInfo = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Notification.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Notification.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Notification.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Notification.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Notification.prototype.getAudioStreamType = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioStreamType;
+};
+Notification.prototype.setAudioStreamType = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audioStreamType = __SLAG__PROPERTY;
+};
+Notification.prototype.getCategory = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.category;
+};
+Notification.prototype.setCategory = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.category = __SLAG__PROPERTY;
+};
+Notification.prototype.getContentIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentIntent;
+};
+Notification.prototype.setContentIntent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentIntent = __SLAG__PROPERTY;
+};
+Notification.prototype.getContentText = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentText;
+};
+Notification.prototype.setContentText = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentText = __SLAG__PROPERTY;
+};
+Notification.prototype.getContentTitle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentTitle;
+};
+Notification.prototype.setContentTitle = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentTitle = __SLAG__PROPERTY;
+};
+Notification.prototype.setContentView = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentView = __SLAG__PROPERTY;
+};
+Notification.prototype.getDefaults = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.defaults;
+};
+Notification.prototype.setDefaults = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.defaults = __SLAG__PROPERTY;
+};
+Notification.prototype.getDeleteIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.deleteIntent;
+};
+Notification.prototype.setDeleteIntent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.deleteIntent = __SLAG__PROPERTY;
+};
+Notification.prototype.getFlags = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.flags;
+};
+Notification.prototype.setFlags = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.flags = __SLAG__PROPERTY;
+};
+Notification.prototype.getIcon = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.icon;
+};
+Notification.prototype.setIcon = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.icon = __SLAG__PROPERTY;
+};
+Notification.prototype.getLargeIcon = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.largeIcon;
+};
+Notification.prototype.setLargeIcon = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.largeIcon = __SLAG__PROPERTY;
+};
+Notification.prototype.getLedARGB = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ledARGB;
+};
+Notification.prototype.setLedARGB = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ledARGB = __SLAG__PROPERTY;
+};
+Notification.prototype.getLedOffMS = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ledOffMS;
+};
+Notification.prototype.setLedOffMS = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ledOffMS = __SLAG__PROPERTY;
+};
+Notification.prototype.getLedOnMS = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ledOnMS;
+};
+Notification.prototype.setLedOnMS = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ledOnMS = __SLAG__PROPERTY;
+};
+Notification.prototype.getNumber = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.number;
+};
+Notification.prototype.setNumber = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.number = __SLAG__PROPERTY;
+};
+Notification.prototype.getPriority = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.priority;
+};
+Notification.prototype.setPriority = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.priority = __SLAG__PROPERTY;
+};
+Notification.prototype.getSound = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sound;
+};
+Notification.prototype.setSound = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.sound = __SLAG__PROPERTY;
+};
+Notification.prototype.getStyle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+Notification.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+Notification.prototype.getTickerText = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tickerText;
+};
+Notification.prototype.setTickerText = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tickerText = __SLAG__PROPERTY;
+};
+Notification.prototype.getVisibility = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visibility;
+};
+Notification.prototype.setVisibility = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visibility = __SLAG__PROPERTY;
+};
+Notification.prototype.getWhen = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.when;
+};
+Notification.prototype.setWhen = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.when = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Notification(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/NotificationManager.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/NotificationManager.js
@@ -1,0 +1,207 @@
+var crypto = require('crypto');
+function NotificationManager(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'DEFAULT_ALL',
+			'DEFAULT_LIGHTS',
+			'DEFAULT_SOUND',
+			'DEFAULT_VIBRATE',
+			'FLAG_AUTO_CANCEL',
+			'FLAG_INSISTENT',
+			'FLAG_NO_CLEAR',
+			'FLAG_ONGOING_EVENT',
+			'FLAG_ONLY_ALERT_ONCE',
+			'FLAG_SHOW_LIGHTS',
+			'STREAM_DEFAULT',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.NotificationManager.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.NotificationManager';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_ALL) {
+		throw new Error('Ti.Android.NotificationManager.DEFAULT_ALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_ALL = undefined;
+	} else {
+		this.DEFAULT_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_LIGHTS) {
+		throw new Error('Ti.Android.NotificationManager.DEFAULT_LIGHTS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_LIGHTS = undefined;
+	} else {
+		this.DEFAULT_LIGHTS = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_SOUND) {
+		throw new Error('Ti.Android.NotificationManager.DEFAULT_SOUND is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_SOUND = undefined;
+	} else {
+		this.DEFAULT_SOUND = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT_VIBRATE) {
+		throw new Error('Ti.Android.NotificationManager.DEFAULT_VIBRATE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT_VIBRATE = undefined;
+	} else {
+		this.DEFAULT_VIBRATE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_AUTO_CANCEL) {
+		throw new Error('Ti.Android.NotificationManager.FLAG_AUTO_CANCEL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_AUTO_CANCEL = undefined;
+	} else {
+		this.FLAG_AUTO_CANCEL = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_INSISTENT) {
+		throw new Error('Ti.Android.NotificationManager.FLAG_INSISTENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_INSISTENT = undefined;
+	} else {
+		this.FLAG_INSISTENT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_NO_CLEAR) {
+		throw new Error('Ti.Android.NotificationManager.FLAG_NO_CLEAR is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_NO_CLEAR = undefined;
+	} else {
+		this.FLAG_NO_CLEAR = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ONGOING_EVENT) {
+		throw new Error('Ti.Android.NotificationManager.FLAG_ONGOING_EVENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ONGOING_EVENT = undefined;
+	} else {
+		this.FLAG_ONGOING_EVENT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_ONLY_ALERT_ONCE) {
+		throw new Error('Ti.Android.NotificationManager.FLAG_ONLY_ALERT_ONCE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_ONLY_ALERT_ONCE = undefined;
+	} else {
+		this.FLAG_ONLY_ALERT_ONCE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLAG_SHOW_LIGHTS) {
+		throw new Error('Ti.Android.NotificationManager.FLAG_SHOW_LIGHTS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLAG_SHOW_LIGHTS = undefined;
+	} else {
+		this.FLAG_SHOW_LIGHTS = 0;
+	}
+	if (__SLAG_PROPERTIES.STREAM_DEFAULT) {
+		throw new Error('Ti.Android.NotificationManager.STREAM_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STREAM_DEFAULT = undefined;
+	} else {
+		this.STREAM_DEFAULT = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+NotificationManager.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NotificationManager.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NotificationManager.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NotificationManager.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+NotificationManager.prototype.cancel = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NotificationManager.prototype.cancelAll = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NotificationManager.prototype.notify = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NotificationManager.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+NotificationManager.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+NotificationManager.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+NotificationManager.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+NotificationManager.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new NotificationManager(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/PendingIntent.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/PendingIntent.js
@@ -1,0 +1,147 @@
+var crypto = require('crypto');
+function PendingIntent(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'flags',
+			'intent',
+			'updateCurrentIntent',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.PendingIntent.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.PendingIntent';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.flags = undefined;
+	} else {
+		this.flags = __SLAG_PROPERTIES.flags || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.intent = undefined;
+	} else {
+		this.intent = __SLAG_PROPERTIES.intent || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.updateCurrentIntent = undefined;
+	} else {
+		this.updateCurrentIntent = __SLAG_PROPERTIES.updateCurrentIntent || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PendingIntent.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PendingIntent.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PendingIntent.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PendingIntent.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PendingIntent.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PendingIntent.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PendingIntent.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PendingIntent.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+PendingIntent.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+PendingIntent.prototype.getFlags = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.flags;
+};
+PendingIntent.prototype.setFlags = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.flags = __SLAG__PROPERTY;
+};
+PendingIntent.prototype.getIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.intent;
+};
+PendingIntent.prototype.setIntent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.intent = __SLAG__PROPERTY;
+};
+PendingIntent.prototype.getUpdateCurrentIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.updateCurrentIntent;
+};
+PendingIntent.prototype.setUpdateCurrentIntent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.updateCurrentIntent = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PendingIntent(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/R.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/R.js
@@ -1,0 +1,201 @@
+var crypto = require('crypto');
+function R(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'anim',
+			'array',
+			'attr',
+			'color',
+			'dimen',
+			'drawable',
+			'id',
+			'integer',
+			'layout',
+			'string',
+			'style',
+			'styleable',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.R.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.R';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.anim) {
+		throw new Error('Ti.Android.R.anim is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anim = undefined;
+	} else {
+		this.anim = {};
+	}
+	if (__SLAG_PROPERTIES.array) {
+		throw new Error('Ti.Android.R.array is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.array = undefined;
+	} else {
+		this.array = {};
+	}
+	if (__SLAG_PROPERTIES.attr) {
+		throw new Error('Ti.Android.R.attr is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attr = undefined;
+	} else {
+		this.attr = {};
+	}
+	if (__SLAG_PROPERTIES.color) {
+		throw new Error('Ti.Android.R.color is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = {};
+	}
+	if (__SLAG_PROPERTIES.dimen) {
+		throw new Error('Ti.Android.R.dimen is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.dimen = undefined;
+	} else {
+		this.dimen = {};
+	}
+	if (__SLAG_PROPERTIES.drawable) {
+		throw new Error('Ti.Android.R.drawable is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.drawable = undefined;
+	} else {
+		this.drawable = {};
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Android.R.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = {};
+	}
+	if (__SLAG_PROPERTIES.integer) {
+		throw new Error('Ti.Android.R.integer is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.integer = undefined;
+	} else {
+		this.integer = {};
+	}
+	if (__SLAG_PROPERTIES.layout) {
+		throw new Error('Ti.Android.R.layout is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = {};
+	}
+	if (__SLAG_PROPERTIES.string) {
+		throw new Error('Ti.Android.R.string is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.string = undefined;
+	} else {
+		this.string = {};
+	}
+	if (__SLAG_PROPERTIES.style) {
+		throw new Error('Ti.Android.R.style is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = {};
+	}
+	if (__SLAG_PROPERTIES.styleable) {
+		throw new Error('Ti.Android.R.styleable is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.styleable = undefined;
+	} else {
+		this.styleable = {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+R.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+R.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+R.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+R.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+R.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+R.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+R.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+R.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+R.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new R(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/RemoteViews.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/RemoteViews.js
@@ -1,0 +1,194 @@
+var crypto = require('crypto');
+function RemoteViews(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'layoutId',
+			'packageName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.RemoteViews.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.RemoteViews';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layoutId = undefined;
+	} else {
+		this.layoutId = __SLAG_PROPERTIES.layoutId || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.packageName = undefined;
+	} else {
+		this.packageName = __SLAG_PROPERTIES.packageName || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+RemoteViews.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+RemoteViews.prototype.setBoolean = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setChronometer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setDouble = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setImageViewResource = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setImageViewUri = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setInt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setOnClickPendingIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setProgressBar = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setString = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setTextColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setTextViewText = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setUri = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.setViewVisibility = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RemoteViews.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+RemoteViews.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+RemoteViews.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+RemoteViews.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+RemoteViews.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+RemoteViews.prototype.getLayoutId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layoutId;
+};
+RemoteViews.prototype.setLayoutId = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layoutId = __SLAG__PROPERTY;
+};
+RemoteViews.prototype.getPackageName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.packageName;
+};
+RemoteViews.prototype.setPackageName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.packageName = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new RemoteViews(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Android/Service.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Android/Service.js
@@ -1,0 +1,133 @@
+var crypto = require('crypto');
+function Service(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'intent',
+			'serviceInstanceId',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Android.Service.apiName is read only property');
+	}
+	this.apiName = 'Ti.Android.Service';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.intent) {
+		throw new Error('Ti.Android.Service.intent is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.intent = undefined;
+	} else {
+		this.intent = {};
+	}
+	if (__SLAG_PROPERTIES.serviceInstanceId) {
+		throw new Error('Ti.Android.Service.serviceInstanceId is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.serviceInstanceId = undefined;
+	} else {
+		this.serviceInstanceId = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Service.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Service.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Service.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Service.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Service.prototype.start = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Service.prototype.stop = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Service.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Service.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Service.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Service.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Service.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Service.prototype.getIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.intent;
+};
+Service.prototype.getServiceInstanceId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.serviceInstanceId;
+};
+module.exports = function (properties) {
+	return new Service(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App.js
@@ -1,0 +1,564 @@
+var crypto = require('crypto');
+function App(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'EVENT_ACCESSIBILITY_ANNOUNCEMENT',
+			'EVENT_ACCESSIBILITY_CHANGED',
+			'accessibilityEnabled',
+			'analytics',
+			'copyright',
+			'deployType',
+			'description',
+			'guid',
+			'forceSplashAsSnapshot',
+			'id',
+			'installId',
+			'idleTimerDisabled',
+			'name',
+			'proximityDetection',
+			'proximityState',
+			'disableNetworkActivityIndicator',
+			'publisher',
+			'sessionId',
+			'url',
+			'version',
+			'keyboardVisible',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.apiName is read only property');
+	}
+	this.apiName = 'Ti.App';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.EVENT_ACCESSIBILITY_ANNOUNCEMENT) {
+		throw new Error('Ti.App.EVENT_ACCESSIBILITY_ANNOUNCEMENT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EVENT_ACCESSIBILITY_ANNOUNCEMENT = undefined;
+	} else {
+		this.EVENT_ACCESSIBILITY_ANNOUNCEMENT = '';
+	}
+	if (__SLAG_PROPERTIES.EVENT_ACCESSIBILITY_CHANGED) {
+		throw new Error('Ti.App.EVENT_ACCESSIBILITY_CHANGED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EVENT_ACCESSIBILITY_CHANGED = undefined;
+	} else {
+		this.EVENT_ACCESSIBILITY_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.accessibilityEnabled) {
+		throw new Error('Ti.App.accessibilityEnabled is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityEnabled = undefined;
+	} else {
+		this.accessibilityEnabled = true;
+	}
+	if (__SLAG_PROPERTIES.analytics) {
+		throw new Error('Ti.App.analytics is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.analytics = undefined;
+	} else {
+		this.analytics = true;
+	}
+	if (__SLAG_PROPERTIES.copyright) {
+		throw new Error('Ti.App.copyright is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.copyright = undefined;
+	} else {
+		this.copyright = '';
+	}
+	if (__SLAG_PROPERTIES.deployType) {
+		throw new Error('Ti.App.deployType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.deployType = undefined;
+	} else {
+		this.deployType = '';
+	}
+	if (__SLAG_PROPERTIES.description) {
+		throw new Error('Ti.App.description is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.description = undefined;
+	} else {
+		this.description = '';
+	}
+	if (__SLAG_PROPERTIES.guid) {
+		throw new Error('Ti.App.guid is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.guid = undefined;
+	} else {
+		this.guid = '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.forceSplashAsSnapshot = undefined;
+	} else {
+		this.forceSplashAsSnapshot = __SLAG_PROPERTIES.forceSplashAsSnapshot || true;
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.App.id is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.installId) {
+		throw new Error('Ti.App.installId is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.installId = undefined;
+	} else {
+		this.installId = '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.idleTimerDisabled = undefined;
+	} else {
+		this.idleTimerDisabled = __SLAG_PROPERTIES.idleTimerDisabled || true;
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.App.name is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.proximityDetection = undefined;
+	} else {
+		this.proximityDetection = __SLAG_PROPERTIES.proximityDetection || true;
+	}
+	if (__SLAG_PROPERTIES.proximityState) {
+		throw new Error('Ti.App.proximityState is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.proximityState = undefined;
+	} else {
+		this.proximityState = true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disableNetworkActivityIndicator = undefined;
+	} else {
+		this.disableNetworkActivityIndicator = __SLAG_PROPERTIES.disableNetworkActivityIndicator || true;
+	}
+	if (__SLAG_PROPERTIES.publisher) {
+		throw new Error('Ti.App.publisher is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.publisher = undefined;
+	} else {
+		this.publisher = '';
+	}
+	if (__SLAG_PROPERTIES.sessionId) {
+		throw new Error('Ti.App.sessionId is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sessionId = undefined;
+	} else {
+		this.sessionId = '';
+	}
+	if (__SLAG_PROPERTIES.url) {
+		throw new Error('Ti.App.url is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = '';
+	}
+	if (__SLAG_PROPERTIES.version) {
+		throw new Error('Ti.App.version is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.version = undefined;
+	} else {
+		this.version = '';
+	}
+	if (__SLAG_PROPERTIES.keyboardVisible) {
+		throw new Error('Ti.App.keyboardVisible is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardVisible = undefined;
+	} else {
+		this.keyboardVisible = true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+App.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+App.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+App.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+App.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+App.prototype.fireSystemEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+App.prototype.getArguments = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+App.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+App.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+App.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+App.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+App.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+App.prototype.getAccessibilityEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityEnabled;
+};
+App.prototype.getAnalytics = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.analytics;
+};
+App.prototype.getCopyright = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.copyright;
+};
+App.prototype.getDeployType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.deployType;
+};
+App.prototype.getDescription = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.description;
+};
+App.prototype.getGuid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.guid;
+};
+App.prototype.getForceSplashAsSnapshot = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.forceSplashAsSnapshot;
+};
+App.prototype.setForceSplashAsSnapshot = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.forceSplashAsSnapshot = __SLAG__PROPERTY;
+};
+App.prototype.getId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+App.prototype.getInstallId = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.installId;
+};
+App.prototype.getIdleTimerDisabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.idleTimerDisabled;
+};
+App.prototype.setIdleTimerDisabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.idleTimerDisabled = __SLAG__PROPERTY;
+};
+App.prototype.getName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+App.prototype.getProximityDetection = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.proximityDetection;
+};
+App.prototype.setProximityDetection = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.proximityDetection = __SLAG__PROPERTY;
+};
+App.prototype.getProximityState = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.proximityState;
+};
+App.prototype.getDisableNetworkActivityIndicator = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disableNetworkActivityIndicator;
+};
+App.prototype.setDisableNetworkActivityIndicator = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disableNetworkActivityIndicator = __SLAG__PROPERTY;
+};
+App.prototype.getPublisher = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.publisher;
+};
+App.prototype.getSessionId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sessionId;
+};
+App.prototype.getUrl = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+App.prototype.getVersion = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.version;
+};
+App.prototype.getKeyboardVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardVisible;
+};
+module.exports = function (properties) {
+	return new App(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/Android.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/Android.js
@@ -1,0 +1,147 @@
+var crypto = require('crypto');
+function Android(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'R',
+			'appVersionCode',
+			'appVersionName',
+			'launchIntent',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.Android.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.Android';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.R) {
+		throw new Error('Ti.App.Android.R is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.R = undefined;
+	} else {
+		this.R = {};
+	}
+	if (__SLAG_PROPERTIES.appVersionCode) {
+		throw new Error('Ti.App.Android.appVersionCode is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.appVersionCode = undefined;
+	} else {
+		this.appVersionCode = 0;
+	}
+	if (__SLAG_PROPERTIES.appVersionName) {
+		throw new Error('Ti.App.Android.appVersionName is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.appVersionName = undefined;
+	} else {
+		this.appVersionName = '';
+	}
+	if (__SLAG_PROPERTIES.launchIntent) {
+		throw new Error('Ti.App.Android.launchIntent is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.launchIntent = undefined;
+	} else {
+		this.launchIntent = {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Android.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Android.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Android.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Android.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Android.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Android.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Android.prototype.getAppVersionCode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.appVersionCode;
+};
+Android.prototype.getAppVersionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.appVersionName;
+};
+Android.prototype.getLaunchIntent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.launchIntent;
+};
+module.exports = function (properties) {
+	return new Android(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/Android/R.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/Android/R.js
@@ -1,0 +1,93 @@
+var crypto = require('crypto');
+function R(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.Android.R.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.Android.R';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+R.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+R.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+R.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+R.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+R.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+R.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+R.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+R.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+R.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new R(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/Properties.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/Properties.js
@@ -1,0 +1,306 @@
+var crypto = require('crypto');
+function Properties(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.Properties.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.Properties';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.__SLAG_SIMULATE_PROPERTIES = {};
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Properties.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Properties.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Properties.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Properties.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Properties.prototype.getBool = function (__SLAG_PROPERTY, __SLAG_DEFAULT) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	if (this.__SLAG_SIMULATE_PROPERTIES.hasOwnProperty(__SLAG_PROPERTY)) {
+		return this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY];
+	} else {
+		return __SLAG_DEFAULT || null;
+	}
+};
+Properties.prototype.getDouble = function (__SLAG_PROPERTY, __SLAG_DEFAULT) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	if (this.__SLAG_SIMULATE_PROPERTIES.hasOwnProperty(__SLAG_PROPERTY)) {
+		return this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY];
+	} else {
+		return __SLAG_DEFAULT || null;
+	}
+};
+Properties.prototype.getInt = function (__SLAG_PROPERTY, __SLAG_DEFAULT) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	if (this.__SLAG_SIMULATE_PROPERTIES.hasOwnProperty(__SLAG_PROPERTY)) {
+		return this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY];
+	} else {
+		return __SLAG_DEFAULT || null;
+	}
+};
+Properties.prototype.getList = function (__SLAG_PROPERTY, __SLAG_DEFAULT) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	if (this.__SLAG_SIMULATE_PROPERTIES.hasOwnProperty(__SLAG_PROPERTY)) {
+		return this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY];
+	} else {
+		return __SLAG_DEFAULT || null;
+	}
+};
+Properties.prototype.getObject = function (__SLAG_PROPERTY, __SLAG_DEFAULT) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	if (this.__SLAG_SIMULATE_PROPERTIES.hasOwnProperty(__SLAG_PROPERTY)) {
+		return this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY];
+	} else {
+		return __SLAG_DEFAULT || null;
+	}
+};
+Properties.prototype.getString = function (__SLAG_PROPERTY, __SLAG_DEFAULT) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	if (this.__SLAG_SIMULATE_PROPERTIES.hasOwnProperty(__SLAG_PROPERTY)) {
+		return this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY];
+	} else {
+		return __SLAG_DEFAULT || null;
+	}
+};
+Properties.prototype.hasProperty = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	if (this.__SLAG_SIMULATE_PROPERTIES.hasOwnProperty(__SLAG_PROPERTY)) {
+		return true;
+	} else {
+		return false;
+	}
+};
+Properties.prototype.listProperties = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return Object.keys(this.__SLAG_SIMULATE_PROPERTIES);
+};
+Properties.prototype.removeProperty = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	delete this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY];
+};
+Properties.prototype.removeAllProperties = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Properties.prototype.setBool = function (__SLAG_PROPERTY, __SLAG_VALUE) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY] = __SLAG_VALUE;
+};
+Properties.prototype.setDouble = function (__SLAG_PROPERTY, __SLAG_VALUE) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY] = __SLAG_VALUE;
+};
+Properties.prototype.setInt = function (__SLAG_PROPERTY, __SLAG_VALUE) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY] = __SLAG_VALUE;
+};
+Properties.prototype.setList = function (__SLAG_PROPERTY, __SLAG_VALUE) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY] = __SLAG_VALUE;
+};
+Properties.prototype.setObject = function (__SLAG_PROPERTY, __SLAG_VALUE) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY] = __SLAG_VALUE;
+};
+Properties.prototype.setString = function (__SLAG_PROPERTY, __SLAG_VALUE) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.__SLAG_SIMULATE_PROPERTIES[__SLAG_PROPERTY] = __SLAG_VALUE;
+};
+Properties.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Properties.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Properties.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Properties.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Properties.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Properties(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS.js
@@ -1,0 +1,621 @@
+var crypto = require('crypto');
+function iOS(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'EVENT_ACCESSIBILITY_LAYOUT_CHANGED',
+			'EVENT_ACCESSIBILITY_SCREEN_CHANGED',
+			'BACKGROUNDFETCHINTERVAL_MIN',
+			'BACKGROUNDFETCHINTERVAL_NEVER',
+			'USER_NOTIFICATION_TYPE_NONE',
+			'USER_NOTIFICATION_TYPE_BADGE',
+			'USER_NOTIFICATION_TYPE_SOUND',
+			'USER_NOTIFICATION_TYPE_ALERT',
+			'USER_NOTIFICATION_ACTIVATION_MODE_BACKGROUND',
+			'USER_NOTIFICATION_ACTIVATION_MODE_FOREGROUND',
+			'USER_NOTIFICATION_BEHAVIOR_DEFAULT',
+			'USER_NOTIFICATION_BEHAVIOR_TEXTINPUT',
+			'UTTYPE_TEXT',
+			'UTTYPE_PLAIN_TEXT',
+			'UTTYPE_UTF8_PLAIN_TEXT',
+			'UTTYPE_UTF16_EXTERNAL_PLAIN_TEXT',
+			'UTTYPE_UTF16_PLAIN_TEXT',
+			'UTTYPE_RTF',
+			'UTTYPE_HTML',
+			'UTTYPE_XML',
+			'UTTYPE_PDF',
+			'UTTYPE_RTFD',
+			'UTTYPE_FLAT_RTFD',
+			'UTTYPE_TXN_TEXT_AND_MULTIMEDIA_DATA',
+			'UTTYPE_WEB_ARCHIVE',
+			'UTTYPE_IMAGE',
+			'UTTYPE_JPEG',
+			'UTTYPE_JPEG2000',
+			'UTTYPE_TIFF',
+			'UTTYPE_PICT',
+			'UTTYPE_GIF',
+			'UTTYPE_PNG',
+			'UTTYPE_QUICKTIME_IMAGE',
+			'UTTYPE_APPLE_ICNS',
+			'UTTYPE_BMP',
+			'UTTYPE_ICO',
+			'UTTYPE_MOVIE',
+			'UTTYPE_VIDEO',
+			'UTTYPE_AUDIO',
+			'UTTYPE_QUICKTIME_MOVIE',
+			'UTTYPE_MPEG',
+			'UTTYPE_MPEG4',
+			'UTTYPE_MP3',
+			'UTTYPE_MPEG4_AUDIO',
+			'UTTYPE_APPLE_PROTECTED_MPEG4_AUDIO',
+			'currentUserNotificationSettings',
+			'supportedUserActivityTypes',
+			'applicationOpenSettingsURL',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS';
+	if (__SLAG_PROPERTIES.EVENT_ACCESSIBILITY_LAYOUT_CHANGED) {
+		throw new Error('Ti.App.iOS.EVENT_ACCESSIBILITY_LAYOUT_CHANGED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EVENT_ACCESSIBILITY_LAYOUT_CHANGED = undefined;
+	} else {
+		this.EVENT_ACCESSIBILITY_LAYOUT_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.EVENT_ACCESSIBILITY_SCREEN_CHANGED) {
+		throw new Error('Ti.App.iOS.EVENT_ACCESSIBILITY_SCREEN_CHANGED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EVENT_ACCESSIBILITY_SCREEN_CHANGED = undefined;
+	} else {
+		this.EVENT_ACCESSIBILITY_SCREEN_CHANGED = '';
+	}
+	if (__SLAG_PROPERTIES.BACKGROUNDFETCHINTERVAL_MIN) {
+		throw new Error('Ti.App.iOS.BACKGROUNDFETCHINTERVAL_MIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BACKGROUNDFETCHINTERVAL_MIN = undefined;
+	} else {
+		this.BACKGROUNDFETCHINTERVAL_MIN = 0;
+	}
+	if (__SLAG_PROPERTIES.BACKGROUNDFETCHINTERVAL_NEVER) {
+		throw new Error('Ti.App.iOS.BACKGROUNDFETCHINTERVAL_NEVER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BACKGROUNDFETCHINTERVAL_NEVER = undefined;
+	} else {
+		this.BACKGROUNDFETCHINTERVAL_NEVER = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_TYPE_NONE) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_TYPE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_TYPE_NONE = undefined;
+	} else {
+		this.USER_NOTIFICATION_TYPE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_TYPE_BADGE) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_TYPE_BADGE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_TYPE_BADGE = undefined;
+	} else {
+		this.USER_NOTIFICATION_TYPE_BADGE = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_TYPE_SOUND) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_TYPE_SOUND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_TYPE_SOUND = undefined;
+	} else {
+		this.USER_NOTIFICATION_TYPE_SOUND = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_TYPE_ALERT) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_TYPE_ALERT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_TYPE_ALERT = undefined;
+	} else {
+		this.USER_NOTIFICATION_TYPE_ALERT = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_ACTIVATION_MODE_BACKGROUND) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_ACTIVATION_MODE_BACKGROUND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_ACTIVATION_MODE_BACKGROUND = undefined;
+	} else {
+		this.USER_NOTIFICATION_ACTIVATION_MODE_BACKGROUND = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_ACTIVATION_MODE_FOREGROUND) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_ACTIVATION_MODE_FOREGROUND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_ACTIVATION_MODE_FOREGROUND = undefined;
+	} else {
+		this.USER_NOTIFICATION_ACTIVATION_MODE_FOREGROUND = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_BEHAVIOR_DEFAULT) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_BEHAVIOR_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_BEHAVIOR_DEFAULT = undefined;
+	} else {
+		this.USER_NOTIFICATION_BEHAVIOR_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.USER_NOTIFICATION_BEHAVIOR_TEXTINPUT) {
+		throw new Error('Ti.App.iOS.USER_NOTIFICATION_BEHAVIOR_TEXTINPUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.USER_NOTIFICATION_BEHAVIOR_TEXTINPUT = undefined;
+	} else {
+		this.USER_NOTIFICATION_BEHAVIOR_TEXTINPUT = 0;
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_TEXT) {
+		throw new Error('Ti.App.iOS.UTTYPE_TEXT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_TEXT = undefined;
+	} else {
+		this.UTTYPE_TEXT = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_PLAIN_TEXT) {
+		throw new Error('Ti.App.iOS.UTTYPE_PLAIN_TEXT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_PLAIN_TEXT = undefined;
+	} else {
+		this.UTTYPE_PLAIN_TEXT = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_UTF8_PLAIN_TEXT) {
+		throw new Error('Ti.App.iOS.UTTYPE_UTF8_PLAIN_TEXT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_UTF8_PLAIN_TEXT = undefined;
+	} else {
+		this.UTTYPE_UTF8_PLAIN_TEXT = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_UTF16_EXTERNAL_PLAIN_TEXT) {
+		throw new Error('Ti.App.iOS.UTTYPE_UTF16_EXTERNAL_PLAIN_TEXT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_UTF16_EXTERNAL_PLAIN_TEXT = undefined;
+	} else {
+		this.UTTYPE_UTF16_EXTERNAL_PLAIN_TEXT = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_UTF16_PLAIN_TEXT) {
+		throw new Error('Ti.App.iOS.UTTYPE_UTF16_PLAIN_TEXT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_UTF16_PLAIN_TEXT = undefined;
+	} else {
+		this.UTTYPE_UTF16_PLAIN_TEXT = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_RTF) {
+		throw new Error('Ti.App.iOS.UTTYPE_RTF is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_RTF = undefined;
+	} else {
+		this.UTTYPE_RTF = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_HTML) {
+		throw new Error('Ti.App.iOS.UTTYPE_HTML is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_HTML = undefined;
+	} else {
+		this.UTTYPE_HTML = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_XML) {
+		throw new Error('Ti.App.iOS.UTTYPE_XML is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_XML = undefined;
+	} else {
+		this.UTTYPE_XML = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_PDF) {
+		throw new Error('Ti.App.iOS.UTTYPE_PDF is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_PDF = undefined;
+	} else {
+		this.UTTYPE_PDF = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_RTFD) {
+		throw new Error('Ti.App.iOS.UTTYPE_RTFD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_RTFD = undefined;
+	} else {
+		this.UTTYPE_RTFD = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_FLAT_RTFD) {
+		throw new Error('Ti.App.iOS.UTTYPE_FLAT_RTFD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_FLAT_RTFD = undefined;
+	} else {
+		this.UTTYPE_FLAT_RTFD = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_TXN_TEXT_AND_MULTIMEDIA_DATA) {
+		throw new Error('Ti.App.iOS.UTTYPE_TXN_TEXT_AND_MULTIMEDIA_DATA is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_TXN_TEXT_AND_MULTIMEDIA_DATA = undefined;
+	} else {
+		this.UTTYPE_TXN_TEXT_AND_MULTIMEDIA_DATA = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_WEB_ARCHIVE) {
+		throw new Error('Ti.App.iOS.UTTYPE_WEB_ARCHIVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_WEB_ARCHIVE = undefined;
+	} else {
+		this.UTTYPE_WEB_ARCHIVE = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_IMAGE) {
+		throw new Error('Ti.App.iOS.UTTYPE_IMAGE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_IMAGE = undefined;
+	} else {
+		this.UTTYPE_IMAGE = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_JPEG) {
+		throw new Error('Ti.App.iOS.UTTYPE_JPEG is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_JPEG = undefined;
+	} else {
+		this.UTTYPE_JPEG = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_JPEG2000) {
+		throw new Error('Ti.App.iOS.UTTYPE_JPEG2000 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_JPEG2000 = undefined;
+	} else {
+		this.UTTYPE_JPEG2000 = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_TIFF) {
+		throw new Error('Ti.App.iOS.UTTYPE_TIFF is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_TIFF = undefined;
+	} else {
+		this.UTTYPE_TIFF = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_PICT) {
+		throw new Error('Ti.App.iOS.UTTYPE_PICT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_PICT = undefined;
+	} else {
+		this.UTTYPE_PICT = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_GIF) {
+		throw new Error('Ti.App.iOS.UTTYPE_GIF is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_GIF = undefined;
+	} else {
+		this.UTTYPE_GIF = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_PNG) {
+		throw new Error('Ti.App.iOS.UTTYPE_PNG is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_PNG = undefined;
+	} else {
+		this.UTTYPE_PNG = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_QUICKTIME_IMAGE) {
+		throw new Error('Ti.App.iOS.UTTYPE_QUICKTIME_IMAGE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_QUICKTIME_IMAGE = undefined;
+	} else {
+		this.UTTYPE_QUICKTIME_IMAGE = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_APPLE_ICNS) {
+		throw new Error('Ti.App.iOS.UTTYPE_APPLE_ICNS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_APPLE_ICNS = undefined;
+	} else {
+		this.UTTYPE_APPLE_ICNS = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_BMP) {
+		throw new Error('Ti.App.iOS.UTTYPE_BMP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_BMP = undefined;
+	} else {
+		this.UTTYPE_BMP = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_ICO) {
+		throw new Error('Ti.App.iOS.UTTYPE_ICO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_ICO = undefined;
+	} else {
+		this.UTTYPE_ICO = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_MOVIE) {
+		throw new Error('Ti.App.iOS.UTTYPE_MOVIE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_MOVIE = undefined;
+	} else {
+		this.UTTYPE_MOVIE = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_VIDEO) {
+		throw new Error('Ti.App.iOS.UTTYPE_VIDEO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_VIDEO = undefined;
+	} else {
+		this.UTTYPE_VIDEO = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_AUDIO) {
+		throw new Error('Ti.App.iOS.UTTYPE_AUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_AUDIO = undefined;
+	} else {
+		this.UTTYPE_AUDIO = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_QUICKTIME_MOVIE) {
+		throw new Error('Ti.App.iOS.UTTYPE_QUICKTIME_MOVIE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_QUICKTIME_MOVIE = undefined;
+	} else {
+		this.UTTYPE_QUICKTIME_MOVIE = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_MPEG) {
+		throw new Error('Ti.App.iOS.UTTYPE_MPEG is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_MPEG = undefined;
+	} else {
+		this.UTTYPE_MPEG = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_MPEG4) {
+		throw new Error('Ti.App.iOS.UTTYPE_MPEG4 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_MPEG4 = undefined;
+	} else {
+		this.UTTYPE_MPEG4 = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_MP3) {
+		throw new Error('Ti.App.iOS.UTTYPE_MP3 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_MP3 = undefined;
+	} else {
+		this.UTTYPE_MP3 = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_MPEG4_AUDIO) {
+		throw new Error('Ti.App.iOS.UTTYPE_MPEG4_AUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_MPEG4_AUDIO = undefined;
+	} else {
+		this.UTTYPE_MPEG4_AUDIO = '';
+	}
+	if (__SLAG_PROPERTIES.UTTYPE_APPLE_PROTECTED_MPEG4_AUDIO) {
+		throw new Error('Ti.App.iOS.UTTYPE_APPLE_PROTECTED_MPEG4_AUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UTTYPE_APPLE_PROTECTED_MPEG4_AUDIO = undefined;
+	} else {
+		this.UTTYPE_APPLE_PROTECTED_MPEG4_AUDIO = '';
+	}
+	if (__SLAG_PROPERTIES.currentUserNotificationSettings) {
+		throw new Error('Ti.App.iOS.currentUserNotificationSettings is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentUserNotificationSettings = undefined;
+	} else {
+		this.currentUserNotificationSettings = {};
+	}
+	if (__SLAG_PROPERTIES.supportedUserActivityTypes) {
+		throw new Error('Ti.App.iOS.supportedUserActivityTypes is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.supportedUserActivityTypes = undefined;
+	} else {
+		this.supportedUserActivityTypes = '';
+	}
+	if (__SLAG_PROPERTIES.applicationOpenSettingsURL) {
+		throw new Error('Ti.App.iOS.applicationOpenSettingsURL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.applicationOpenSettingsURL = undefined;
+	} else {
+		this.applicationOpenSettingsURL = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+iOS.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+iOS.prototype.createUserDefaults = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var UserDefaults = require('./iOS/UserDefaults');
+	return UserDefaults(__SLAG_PROPERTY);
+};
+iOS.prototype.cancelAllLocalNotifications = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.cancelLocalNotification = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.registerBackgroundService = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+iOS.prototype.registerUserNotificationSettings = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.scheduleLocalNotification = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+iOS.prototype.setMinimumBackgroundFetchInterval = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.endBackgroundHandler = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.sendWatchExtensionReply = function () {
+	throw new Error('Ti.App.iOS.sendWatchExtensionReply was deprecated, since 5.0.0');
+};
+iOS.prototype.createSearchQuery = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SearchQuery = require('./iOS/SearchQuery');
+	return SearchQuery(__SLAG_PROPERTY);
+};
+iOS.prototype.createSearchableIndex = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SearchableIndex = require('./iOS/SearchableIndex');
+	return SearchableIndex(__SLAG_PROPERTY);
+};
+iOS.prototype.createSearchableItem = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SearchableItem = require('./iOS/SearchableItem');
+	return SearchableItem(__SLAG_PROPERTY);
+};
+iOS.prototype.createSearchableItemAttributeSet = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SearchableItemAttributeSet = require('./iOS/SearchableItemAttributeSet');
+	return SearchableItemAttributeSet(__SLAG_PROPERTY);
+};
+iOS.prototype.createUserActivity = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var UserActivity = require('./iOS/UserActivity');
+	return UserActivity(__SLAG_PROPERTY);
+};
+iOS.prototype.createUserNotificationAction = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var UserNotificationAction = require('./iOS/UserNotificationAction');
+	return UserNotificationAction(__SLAG_PROPERTY);
+};
+iOS.prototype.createUserNotificationCategory = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var UserNotificationCategory = require('./iOS/UserNotificationCategory');
+	return UserNotificationCategory(__SLAG_PROPERTY);
+};
+iOS.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+iOS.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+iOS.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+iOS.prototype.getCurrentUserNotificationSettings = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentUserNotificationSettings;
+};
+iOS.prototype.getSupportedUserActivityTypes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.supportedUserActivityTypes;
+};
+iOS.prototype.getApplicationOpenSettingsURL = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.applicationOpenSettingsURL;
+};
+module.exports = function (properties) {
+	return new iOS(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/BackgroundService.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/BackgroundService.js
@@ -1,0 +1,103 @@
+var crypto = require('crypto');
+function BackgroundService(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.BackgroundService.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.BackgroundService';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+BackgroundService.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BackgroundService.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BackgroundService.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BackgroundService.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+BackgroundService.prototype.stop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BackgroundService.prototype.unregister = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BackgroundService.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+BackgroundService.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+BackgroundService.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+BackgroundService.prototype.getUrl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+BackgroundService.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new BackgroundService(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/LocalNotification.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/LocalNotification.js
@@ -1,0 +1,80 @@
+var crypto = require('crypto');
+function LocalNotification(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.LocalNotification.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.LocalNotification';
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+LocalNotification.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocalNotification.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocalNotification.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocalNotification.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+LocalNotification.prototype.cancel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocalNotification.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+LocalNotification.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+LocalNotification.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new LocalNotification(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchQuery.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchQuery.js
@@ -1,0 +1,103 @@
+var crypto = require('crypto');
+function SearchQuery(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'queryString',
+			'attributes',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.SearchQuery.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.SearchQuery';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.queryString = undefined;
+	} else {
+		this.queryString = __SLAG_PROPERTIES.queryString || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = __SLAG_PROPERTIES.attributes || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SearchQuery.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchQuery.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchQuery.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchQuery.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SearchQuery.prototype.start = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchQuery.prototype.cancel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchQuery.prototype.isCancelled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+SearchQuery.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SearchQuery.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SearchQuery.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new SearchQuery(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchableIndex.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchableIndex.js
@@ -1,0 +1,101 @@
+var crypto = require('crypto');
+function SearchableIndex(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.SearchableIndex.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.SearchableIndex';
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SearchableIndex.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableIndex.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableIndex.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableIndex.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SearchableIndex.prototype.isSupported = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+SearchableIndex.prototype.addToDefaultSearchableIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableIndex.prototype.deleteAllSearchableItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableIndex.prototype.deleteAllSearchableItemByDomainIdenifiers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableIndex.prototype.deleteSearchableItemsByIdentifiers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableIndex.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SearchableIndex.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SearchableIndex.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new SearchableIndex(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchableItem.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchableItem.js
@@ -1,0 +1,135 @@
+var crypto = require('crypto');
+function SearchableItem(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'attributeSet',
+			'domainIdentifier',
+			'expirationDate',
+			'uniqueIdentifier',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.SearchableItem.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.SearchableItem';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributeSet = undefined;
+	} else {
+		this.attributeSet = __SLAG_PROPERTIES.attributeSet || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.domainIdentifier = undefined;
+	} else {
+		this.domainIdentifier = __SLAG_PROPERTIES.domainIdentifier || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.expirationDate = undefined;
+	} else {
+		this.expirationDate = __SLAG_PROPERTIES.expirationDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.uniqueIdentifier = undefined;
+	} else {
+		this.uniqueIdentifier = __SLAG_PROPERTIES.uniqueIdentifier || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SearchableItem.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableItem.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableItem.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableItem.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SearchableItem.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SearchableItem.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SearchableItem.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SearchableItem.prototype.getDomainIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.domainIdentifier;
+};
+SearchableItem.prototype.setDomainIdentifier = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.domainIdentifier = __SLAG__PROPERTY;
+};
+SearchableItem.prototype.getExpirationDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.expirationDate;
+};
+SearchableItem.prototype.setExpirationDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.expirationDate = __SLAG__PROPERTY;
+};
+SearchableItem.prototype.getUniqueIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.uniqueIdentifier;
+};
+SearchableItem.prototype.setUniqueIdentifier = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.uniqueIdentifier = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SearchableItem(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchableItemAttributeSet.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/SearchableItemAttributeSet.js
@@ -1,0 +1,1755 @@
+var crypto = require('crypto');
+function SearchableItemAttributeSet(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'itemContentType',
+			'displayName',
+			'alternateNames',
+			'path',
+			'contentURL',
+			'thumbnailURL',
+			'thumbnailData',
+			'relatedUniqueIdentifier',
+			'metadataModificationDate',
+			'contentType',
+			'contentTypeTree',
+			'keywords',
+			'title',
+			'subject',
+			'theme',
+			'contentDescription',
+			'identifier',
+			'audiences',
+			'fileSize',
+			'pageCount',
+			'pageWidth',
+			'pageHeight',
+			'securityMethod',
+			'creator',
+			'encodingApplications',
+			'kind',
+			'fontNames',
+			'audioSampleRate',
+			'audioChannelCount',
+			'tempo',
+			'keySignature',
+			'timeSignature',
+			'audioEncodingApplication',
+			'composer',
+			'lyricist',
+			'album',
+			'artist',
+			'audioTrackNumber',
+			'recordingDate',
+			'musicalGenre',
+			'generalMIDISequence',
+			'musicalInstrumentCategory',
+			'musicalInstrumentName',
+			'supportsPhoneCall',
+			'supportsNavigation',
+			'containerTitle',
+			'containerDisplayName',
+			'containerIdentifier',
+			'containerOrder',
+			'editors',
+			'participants',
+			'projects',
+			'downloadedDate',
+			'lastUsedDate',
+			'contentCreationDate',
+			'contentModificationDate',
+			'addedDate',
+			'contentSources',
+			'comment',
+			'copyright',
+			'duration',
+			'contactKeywords',
+			'codecs',
+			'organizations',
+			'mediaTypes',
+			'version',
+			'role',
+			'streamable',
+			'totalBitRate',
+			'videoBitRate',
+			'audioBitRate',
+			'deliveryType',
+			'languages',
+			'rights',
+			'publishers',
+			'contributors',
+			'coverage',
+			'rating',
+			'ratingDescription',
+			'playCount',
+			'information',
+			'director',
+			'producer',
+			'genre',
+			'performers',
+			'originalFormat',
+			'originalSource',
+			'local',
+			'contentRating',
+			'url',
+			'fullyFormattedAddress',
+			'subThoroughfare',
+			'thoroughfare',
+			'postalCode',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.SearchableItemAttributeSet.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.SearchableItemAttributeSet';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.itemContentType = undefined;
+	} else {
+		this.itemContentType = __SLAG_PROPERTIES.itemContentType || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.displayName = undefined;
+	} else {
+		this.displayName = __SLAG_PROPERTIES.displayName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alternateNames = undefined;
+	} else {
+		this.alternateNames = __SLAG_PROPERTIES.alternateNames || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.path = undefined;
+	} else {
+		this.path = __SLAG_PROPERTIES.path || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentURL = undefined;
+	} else {
+		this.contentURL = __SLAG_PROPERTIES.contentURL || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.thumbnailURL = undefined;
+	} else {
+		this.thumbnailURL = __SLAG_PROPERTIES.thumbnailURL || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.thumbnailData = undefined;
+	} else {
+		this.thumbnailData = __SLAG_PROPERTIES.thumbnailData || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.relatedUniqueIdentifier = undefined;
+	} else {
+		this.relatedUniqueIdentifier = __SLAG_PROPERTIES.relatedUniqueIdentifier || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.metadataModificationDate = undefined;
+	} else {
+		this.metadataModificationDate = __SLAG_PROPERTIES.metadataModificationDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentType = undefined;
+	} else {
+		this.contentType = __SLAG_PROPERTIES.contentType || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentTypeTree = undefined;
+	} else {
+		this.contentTypeTree = __SLAG_PROPERTIES.contentTypeTree || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keywords = undefined;
+	} else {
+		this.keywords = __SLAG_PROPERTIES.keywords || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subject = undefined;
+	} else {
+		this.subject = __SLAG_PROPERTIES.subject || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.theme = undefined;
+	} else {
+		this.theme = __SLAG_PROPERTIES.theme || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentDescription = undefined;
+	} else {
+		this.contentDescription = __SLAG_PROPERTIES.contentDescription || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.identifier = undefined;
+	} else {
+		this.identifier = __SLAG_PROPERTIES.identifier || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audiences = undefined;
+	} else {
+		this.audiences = __SLAG_PROPERTIES.audiences || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fileSize = undefined;
+	} else {
+		this.fileSize = __SLAG_PROPERTIES.fileSize || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pageCount = undefined;
+	} else {
+		this.pageCount = __SLAG_PROPERTIES.pageCount || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pageWidth = undefined;
+	} else {
+		this.pageWidth = __SLAG_PROPERTIES.pageWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pageHeight = undefined;
+	} else {
+		this.pageHeight = __SLAG_PROPERTIES.pageHeight || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.securityMethod = undefined;
+	} else {
+		this.securityMethod = __SLAG_PROPERTIES.securityMethod || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.creator = undefined;
+	} else {
+		this.creator = __SLAG_PROPERTIES.creator || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.encodingApplications = undefined;
+	} else {
+		this.encodingApplications = __SLAG_PROPERTIES.encodingApplications || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.kind = undefined;
+	} else {
+		this.kind = __SLAG_PROPERTIES.kind || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fontNames = undefined;
+	} else {
+		this.fontNames = __SLAG_PROPERTIES.fontNames || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioSampleRate = undefined;
+	} else {
+		this.audioSampleRate = __SLAG_PROPERTIES.audioSampleRate || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioChannelCount = undefined;
+	} else {
+		this.audioChannelCount = __SLAG_PROPERTIES.audioChannelCount || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tempo = undefined;
+	} else {
+		this.tempo = __SLAG_PROPERTIES.tempo || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keySignature = undefined;
+	} else {
+		this.keySignature = __SLAG_PROPERTIES.keySignature || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.timeSignature = undefined;
+	} else {
+		this.timeSignature = __SLAG_PROPERTIES.timeSignature || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioEncodingApplication = undefined;
+	} else {
+		this.audioEncodingApplication = __SLAG_PROPERTIES.audioEncodingApplication || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.composer = undefined;
+	} else {
+		this.composer = __SLAG_PROPERTIES.composer || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lyricist = undefined;
+	} else {
+		this.lyricist = __SLAG_PROPERTIES.lyricist || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.album = undefined;
+	} else {
+		this.album = __SLAG_PROPERTIES.album || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.artist = undefined;
+	} else {
+		this.artist = __SLAG_PROPERTIES.artist || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioTrackNumber = undefined;
+	} else {
+		this.audioTrackNumber = __SLAG_PROPERTIES.audioTrackNumber || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.recordingDate = undefined;
+	} else {
+		this.recordingDate = __SLAG_PROPERTIES.recordingDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.musicalGenre = undefined;
+	} else {
+		this.musicalGenre = __SLAG_PROPERTIES.musicalGenre || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.generalMIDISequence = undefined;
+	} else {
+		this.generalMIDISequence = __SLAG_PROPERTIES.generalMIDISequence || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.musicalInstrumentCategory = undefined;
+	} else {
+		this.musicalInstrumentCategory = __SLAG_PROPERTIES.musicalInstrumentCategory || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.musicalInstrumentName = undefined;
+	} else {
+		this.musicalInstrumentName = __SLAG_PROPERTIES.musicalInstrumentName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.supportsPhoneCall = undefined;
+	} else {
+		this.supportsPhoneCall = __SLAG_PROPERTIES.supportsPhoneCall || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.supportsNavigation = undefined;
+	} else {
+		this.supportsNavigation = __SLAG_PROPERTIES.supportsNavigation || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.containerTitle = undefined;
+	} else {
+		this.containerTitle = __SLAG_PROPERTIES.containerTitle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.containerDisplayName = undefined;
+	} else {
+		this.containerDisplayName = __SLAG_PROPERTIES.containerDisplayName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.containerIdentifier = undefined;
+	} else {
+		this.containerIdentifier = __SLAG_PROPERTIES.containerIdentifier || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.containerOrder = undefined;
+	} else {
+		this.containerOrder = __SLAG_PROPERTIES.containerOrder || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editors = undefined;
+	} else {
+		this.editors = __SLAG_PROPERTIES.editors || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.participants = undefined;
+	} else {
+		this.participants = __SLAG_PROPERTIES.participants || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.projects = undefined;
+	} else {
+		this.projects = __SLAG_PROPERTIES.projects || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.downloadedDate = undefined;
+	} else {
+		this.downloadedDate = __SLAG_PROPERTIES.downloadedDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastUsedDate = undefined;
+	} else {
+		this.lastUsedDate = __SLAG_PROPERTIES.lastUsedDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentCreationDate = undefined;
+	} else {
+		this.contentCreationDate = __SLAG_PROPERTIES.contentCreationDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentModificationDate = undefined;
+	} else {
+		this.contentModificationDate = __SLAG_PROPERTIES.contentModificationDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.addedDate = undefined;
+	} else {
+		this.addedDate = __SLAG_PROPERTIES.addedDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentSources = undefined;
+	} else {
+		this.contentSources = __SLAG_PROPERTIES.contentSources || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.comment = undefined;
+	} else {
+		this.comment = __SLAG_PROPERTIES.comment || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.copyright = undefined;
+	} else {
+		this.copyright = __SLAG_PROPERTIES.copyright || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contactKeywords = undefined;
+	} else {
+		this.contactKeywords = __SLAG_PROPERTIES.contactKeywords || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.codecs = undefined;
+	} else {
+		this.codecs = __SLAG_PROPERTIES.codecs || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.organizations = undefined;
+	} else {
+		this.organizations = __SLAG_PROPERTIES.organizations || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaTypes = undefined;
+	} else {
+		this.mediaTypes = __SLAG_PROPERTIES.mediaTypes || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.version = undefined;
+	} else {
+		this.version = __SLAG_PROPERTIES.version || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.role = undefined;
+	} else {
+		this.role = __SLAG_PROPERTIES.role || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.streamable = undefined;
+	} else {
+		this.streamable = __SLAG_PROPERTIES.streamable || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.totalBitRate = undefined;
+	} else {
+		this.totalBitRate = __SLAG_PROPERTIES.totalBitRate || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.videoBitRate = undefined;
+	} else {
+		this.videoBitRate = __SLAG_PROPERTIES.videoBitRate || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioBitRate = undefined;
+	} else {
+		this.audioBitRate = __SLAG_PROPERTIES.audioBitRate || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.deliveryType = undefined;
+	} else {
+		this.deliveryType = __SLAG_PROPERTIES.deliveryType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.languages = undefined;
+	} else {
+		this.languages = __SLAG_PROPERTIES.languages || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rights = undefined;
+	} else {
+		this.rights = __SLAG_PROPERTIES.rights || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.publishers = undefined;
+	} else {
+		this.publishers = __SLAG_PROPERTIES.publishers || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contributors = undefined;
+	} else {
+		this.contributors = __SLAG_PROPERTIES.contributors || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.coverage = undefined;
+	} else {
+		this.coverage = __SLAG_PROPERTIES.coverage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rating = undefined;
+	} else {
+		this.rating = __SLAG_PROPERTIES.rating || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ratingDescription = undefined;
+	} else {
+		this.ratingDescription = __SLAG_PROPERTIES.ratingDescription || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playCount = undefined;
+	} else {
+		this.playCount = __SLAG_PROPERTIES.playCount || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.information = undefined;
+	} else {
+		this.information = __SLAG_PROPERTIES.information || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.director = undefined;
+	} else {
+		this.director = __SLAG_PROPERTIES.director || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.producer = undefined;
+	} else {
+		this.producer = __SLAG_PROPERTIES.producer || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.genre = undefined;
+	} else {
+		this.genre = __SLAG_PROPERTIES.genre || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.performers = undefined;
+	} else {
+		this.performers = __SLAG_PROPERTIES.performers || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.originalFormat = undefined;
+	} else {
+		this.originalFormat = __SLAG_PROPERTIES.originalFormat || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.originalSource = undefined;
+	} else {
+		this.originalSource = __SLAG_PROPERTIES.originalSource || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.local = undefined;
+	} else {
+		this.local = __SLAG_PROPERTIES.local || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentRating = undefined;
+	} else {
+		this.contentRating = __SLAG_PROPERTIES.contentRating || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullyFormattedAddress = undefined;
+	} else {
+		this.fullyFormattedAddress = __SLAG_PROPERTIES.fullyFormattedAddress || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subThoroughfare = undefined;
+	} else {
+		this.subThoroughfare = __SLAG_PROPERTIES.subThoroughfare || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.thoroughfare = undefined;
+	} else {
+		this.thoroughfare = __SLAG_PROPERTIES.thoroughfare || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.postalCode = undefined;
+	} else {
+		this.postalCode = __SLAG_PROPERTIES.postalCode || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SearchableItemAttributeSet.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableItemAttributeSet.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableItemAttributeSet.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchableItemAttributeSet.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SearchableItemAttributeSet.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SearchableItemAttributeSet.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SearchableItemAttributeSet.prototype.getDisplayName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.displayName;
+};
+SearchableItemAttributeSet.prototype.setDisplayName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.displayName = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAlternateNames = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.alternateNames;
+};
+SearchableItemAttributeSet.prototype.setAlternateNames = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.alternateNames = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPath = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.path;
+};
+SearchableItemAttributeSet.prototype.setPath = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.path = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentURL = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentURL;
+};
+SearchableItemAttributeSet.prototype.setContentURL = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentURL = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getThumbnailURL = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.thumbnailURL;
+};
+SearchableItemAttributeSet.prototype.setThumbnailURL = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.thumbnailURL = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getThumbnailData = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.thumbnailData;
+};
+SearchableItemAttributeSet.prototype.setThumbnailData = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.thumbnailData = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getRelatedUniqueIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.relatedUniqueIdentifier;
+};
+SearchableItemAttributeSet.prototype.setRelatedUniqueIdentifier = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.relatedUniqueIdentifier = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getMetadataModificationDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.metadataModificationDate;
+};
+SearchableItemAttributeSet.prototype.setMetadataModificationDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.metadataModificationDate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentType;
+};
+SearchableItemAttributeSet.prototype.setContentType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentType = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentTypeTree = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentTypeTree;
+};
+SearchableItemAttributeSet.prototype.setContentTypeTree = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentTypeTree = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getKeywords = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keywords;
+};
+SearchableItemAttributeSet.prototype.setKeywords = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keywords = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+SearchableItemAttributeSet.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getSubject = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.subject;
+};
+SearchableItemAttributeSet.prototype.setSubject = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.subject = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getTheme = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.theme;
+};
+SearchableItemAttributeSet.prototype.setTheme = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.theme = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentDescription = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentDescription;
+};
+SearchableItemAttributeSet.prototype.setContentDescription = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentDescription = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.identifier;
+};
+SearchableItemAttributeSet.prototype.setIdentifier = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.identifier = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAudiences = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audiences;
+};
+SearchableItemAttributeSet.prototype.setAudiences = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audiences = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getFileSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fileSize;
+};
+SearchableItemAttributeSet.prototype.setFileSize = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fileSize = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPageCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pageCount;
+};
+SearchableItemAttributeSet.prototype.setPageCount = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pageCount = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPageWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pageWidth;
+};
+SearchableItemAttributeSet.prototype.setPageWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pageWidth = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPageHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pageHeight;
+};
+SearchableItemAttributeSet.prototype.setPageHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pageHeight = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getSecurityMethod = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.securityMethod;
+};
+SearchableItemAttributeSet.prototype.setSecurityMethod = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.securityMethod = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getCreator = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.creator;
+};
+SearchableItemAttributeSet.prototype.setCreator = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.creator = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getEncodingApplications = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.encodingApplications;
+};
+SearchableItemAttributeSet.prototype.setEncodingApplications = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.encodingApplications = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getKind = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.kind;
+};
+SearchableItemAttributeSet.prototype.setKind = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.kind = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getFontNames = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fontNames;
+};
+SearchableItemAttributeSet.prototype.setFontNames = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fontNames = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAudioSampleRate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioSampleRate;
+};
+SearchableItemAttributeSet.prototype.setAudioSampleRate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audioSampleRate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAudioChannelCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioChannelCount;
+};
+SearchableItemAttributeSet.prototype.setAudioChannelCount = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audioChannelCount = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getTempo = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tempo;
+};
+SearchableItemAttributeSet.prototype.setTempo = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tempo = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getKeySignature = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keySignature;
+};
+SearchableItemAttributeSet.prototype.setKeySignature = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keySignature = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getTimeSignature = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.timeSignature;
+};
+SearchableItemAttributeSet.prototype.setTimeSignature = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.timeSignature = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAudioEncodingApplication = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioEncodingApplication;
+};
+SearchableItemAttributeSet.prototype.setAudioEncodingApplication = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audioEncodingApplication = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getComposer = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.composer;
+};
+SearchableItemAttributeSet.prototype.setComposer = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.composer = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getLyricist = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lyricist;
+};
+SearchableItemAttributeSet.prototype.setLyricist = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lyricist = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAlbum = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.album;
+};
+SearchableItemAttributeSet.prototype.setAlbum = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.album = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getArtist = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.artist;
+};
+SearchableItemAttributeSet.prototype.setArtist = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.artist = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAudioTrackNumber = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioTrackNumber;
+};
+SearchableItemAttributeSet.prototype.setAudioTrackNumber = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audioTrackNumber = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getRecordingDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.recordingDate;
+};
+SearchableItemAttributeSet.prototype.setRecordingDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.recordingDate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getMusicalGenre = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.musicalGenre;
+};
+SearchableItemAttributeSet.prototype.setMusicalGenre = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.musicalGenre = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getGeneralMIDISequence = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.generalMIDISequence;
+};
+SearchableItemAttributeSet.prototype.setGeneralMIDISequence = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.generalMIDISequence = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getMusicalInstrumentCategory = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.musicalInstrumentCategory;
+};
+SearchableItemAttributeSet.prototype.setMusicalInstrumentCategory = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.musicalInstrumentCategory = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getMusicalInstrumentName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.musicalInstrumentName;
+};
+SearchableItemAttributeSet.prototype.setMusicalInstrumentName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.musicalInstrumentName = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getSupportsPhoneCall = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.supportsPhoneCall;
+};
+SearchableItemAttributeSet.prototype.setSupportsPhoneCall = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.supportsPhoneCall = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getSupportsNavigation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.supportsNavigation;
+};
+SearchableItemAttributeSet.prototype.setSupportsNavigation = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.supportsNavigation = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContainerTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.containerTitle;
+};
+SearchableItemAttributeSet.prototype.setContainerTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.containerTitle = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContainerDisplayName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.containerDisplayName;
+};
+SearchableItemAttributeSet.prototype.setContainerDisplayName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.containerDisplayName = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContainerIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.containerIdentifier;
+};
+SearchableItemAttributeSet.prototype.setContainerIdentifier = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.containerIdentifier = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContainerOrder = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.containerOrder;
+};
+SearchableItemAttributeSet.prototype.setContainerOrder = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.containerOrder = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getEditors = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editors;
+};
+SearchableItemAttributeSet.prototype.setEditors = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editors = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getParticipants = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.participants;
+};
+SearchableItemAttributeSet.prototype.setParticipants = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.participants = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getProjects = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.projects;
+};
+SearchableItemAttributeSet.prototype.setProjects = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.projects = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getDownloadedDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.downloadedDate;
+};
+SearchableItemAttributeSet.prototype.setDownloadedDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.downloadedDate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getLastUsedDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastUsedDate;
+};
+SearchableItemAttributeSet.prototype.setLastUsedDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lastUsedDate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentCreationDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentCreationDate;
+};
+SearchableItemAttributeSet.prototype.setContentCreationDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentCreationDate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentModificationDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentModificationDate;
+};
+SearchableItemAttributeSet.prototype.setContentModificationDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentModificationDate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAddedDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.addedDate;
+};
+SearchableItemAttributeSet.prototype.setAddedDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.addedDate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentSources = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentSources;
+};
+SearchableItemAttributeSet.prototype.setContentSources = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentSources = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getComment = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.comment;
+};
+SearchableItemAttributeSet.prototype.setComment = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.comment = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getCopyright = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.copyright;
+};
+SearchableItemAttributeSet.prototype.setCopyright = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.copyright = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getDuration = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.duration;
+};
+SearchableItemAttributeSet.prototype.setDuration = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.duration = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContactKeywords = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contactKeywords;
+};
+SearchableItemAttributeSet.prototype.setContactKeywords = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contactKeywords = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getCodecs = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.codecs;
+};
+SearchableItemAttributeSet.prototype.setCodecs = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.codecs = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getOrganizations = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.organizations;
+};
+SearchableItemAttributeSet.prototype.setOrganizations = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.organizations = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getMediaTypes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mediaTypes;
+};
+SearchableItemAttributeSet.prototype.setMediaTypes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mediaTypes = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getVersion = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.version;
+};
+SearchableItemAttributeSet.prototype.setVersion = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.version = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getRole = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.role;
+};
+SearchableItemAttributeSet.prototype.setRole = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.role = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getStreamable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.streamable;
+};
+SearchableItemAttributeSet.prototype.setStreamable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.streamable = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getTotalBitRate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.totalBitRate;
+};
+SearchableItemAttributeSet.prototype.setTotalBitRate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.totalBitRate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getVideoBitRate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.videoBitRate;
+};
+SearchableItemAttributeSet.prototype.setVideoBitRate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.videoBitRate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getAudioBitRate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioBitRate;
+};
+SearchableItemAttributeSet.prototype.setAudioBitRate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audioBitRate = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getDeliveryType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.deliveryType;
+};
+SearchableItemAttributeSet.prototype.setDeliveryType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.deliveryType = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getLanguages = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.languages;
+};
+SearchableItemAttributeSet.prototype.setLanguages = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.languages = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getRights = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rights;
+};
+SearchableItemAttributeSet.prototype.setRights = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rights = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPublishers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.publishers;
+};
+SearchableItemAttributeSet.prototype.setPublishers = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.publishers = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContributors = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contributors;
+};
+SearchableItemAttributeSet.prototype.setContributors = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contributors = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getCoverage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.coverage;
+};
+SearchableItemAttributeSet.prototype.setCoverage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.coverage = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getRating = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rating;
+};
+SearchableItemAttributeSet.prototype.setRating = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rating = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getRatingDescription = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ratingDescription;
+};
+SearchableItemAttributeSet.prototype.setRatingDescription = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ratingDescription = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPlayCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playCount;
+};
+SearchableItemAttributeSet.prototype.setPlayCount = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.playCount = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getInformation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.information;
+};
+SearchableItemAttributeSet.prototype.setInformation = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.information = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getDirector = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.director;
+};
+SearchableItemAttributeSet.prototype.setDirector = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.director = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getProducer = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.producer;
+};
+SearchableItemAttributeSet.prototype.setProducer = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.producer = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getGenre = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.genre;
+};
+SearchableItemAttributeSet.prototype.setGenre = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.genre = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPerformers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.performers;
+};
+SearchableItemAttributeSet.prototype.setPerformers = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.performers = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getOriginalFormat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.originalFormat;
+};
+SearchableItemAttributeSet.prototype.setOriginalFormat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.originalFormat = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getOriginalSource = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.originalSource;
+};
+SearchableItemAttributeSet.prototype.setOriginalSource = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.originalSource = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getLocal = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.local;
+};
+SearchableItemAttributeSet.prototype.setLocal = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.local = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getContentRating = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentRating;
+};
+SearchableItemAttributeSet.prototype.setContentRating = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentRating = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getUrl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+SearchableItemAttributeSet.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getFullyFormattedAddress = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fullyFormattedAddress;
+};
+SearchableItemAttributeSet.prototype.setFullyFormattedAddress = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fullyFormattedAddress = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getSubThoroughfare = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.subThoroughfare;
+};
+SearchableItemAttributeSet.prototype.setSubThoroughfare = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.subThoroughfare = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getThoroughfare = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.thoroughfare;
+};
+SearchableItemAttributeSet.prototype.setThoroughfare = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.thoroughfare = __SLAG__PROPERTY;
+};
+SearchableItemAttributeSet.prototype.getPostalCode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.postalCode;
+};
+SearchableItemAttributeSet.prototype.setPostalCode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.postalCode = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SearchableItemAttributeSet(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserActivity.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserActivity.js
@@ -1,0 +1,309 @@
+var crypto = require('crypto');
+function UserActivity(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'activityType',
+			'eligibleForPublicIndexing',
+			'eligibleForSearch',
+			'eligibleForHandoff',
+			'expirationDate',
+			'keywords',
+			'needsSave',
+			'requiredUserInfoKeys',
+			'supported',
+			'title',
+			'userInfo',
+			'webpageURL',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.UserActivity.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.UserActivity';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityType = undefined;
+	} else {
+		this.activityType = __SLAG_PROPERTIES.activityType || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.eligibleForPublicIndexing = undefined;
+	} else {
+		this.eligibleForPublicIndexing = __SLAG_PROPERTIES.eligibleForPublicIndexing || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.eligibleForSearch = undefined;
+	} else {
+		this.eligibleForSearch = __SLAG_PROPERTIES.eligibleForSearch || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.eligibleForHandoff = undefined;
+	} else {
+		this.eligibleForHandoff = __SLAG_PROPERTIES.eligibleForHandoff || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.expirationDate = undefined;
+	} else {
+		this.expirationDate = __SLAG_PROPERTIES.expirationDate || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keywords = undefined;
+	} else {
+		this.keywords = __SLAG_PROPERTIES.keywords || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.needsSave = undefined;
+	} else {
+		this.needsSave = __SLAG_PROPERTIES.needsSave || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.requiredUserInfoKeys = undefined;
+	} else {
+		this.requiredUserInfoKeys = __SLAG_PROPERTIES.requiredUserInfoKeys || '';
+	}
+	if (__SLAG_PROPERTIES.supported) {
+		throw new Error('Ti.App.iOS.UserActivity.supported was deprecated, since 5.1.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.userInfo = undefined;
+	} else {
+		this.userInfo = __SLAG_PROPERTIES.userInfo || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.webpageURL = undefined;
+	} else {
+		this.webpageURL = __SLAG_PROPERTIES.webpageURL || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+UserActivity.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserActivity.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserActivity.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserActivity.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+UserActivity.prototype.addContentAttributeSet = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserActivity.prototype.becomeCurrent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserActivity.prototype.invalidate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserActivity.prototype.resignCurrent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserActivity.prototype.isSupported = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+UserActivity.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+UserActivity.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+UserActivity.prototype.getActivityType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activityType;
+};
+UserActivity.prototype.setActivityType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activityType = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getEligibleForPublicIndexing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.eligibleForPublicIndexing;
+};
+UserActivity.prototype.setEligibleForPublicIndexing = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.eligibleForPublicIndexing = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getEligibleForSearch = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.eligibleForSearch;
+};
+UserActivity.prototype.setEligibleForSearch = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.eligibleForSearch = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getEligibleForHandoff = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.eligibleForHandoff;
+};
+UserActivity.prototype.setEligibleForHandoff = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.eligibleForHandoff = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getExpirationDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.expirationDate;
+};
+UserActivity.prototype.setExpirationDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.expirationDate = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getKeywords = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keywords;
+};
+UserActivity.prototype.setKeywords = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keywords = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getNeedsSave = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.needsSave;
+};
+UserActivity.prototype.setNeedsSave = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.needsSave = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getRequiredUserInfoKeys = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.requiredUserInfoKeys;
+};
+UserActivity.prototype.setRequiredUserInfoKeys = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.requiredUserInfoKeys = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getSupported = function () {
+	throw new Error('Ti.App.iOS.UserActivity.getSupported was deprecated, since 5.1.0');
+};
+UserActivity.prototype.setSupported = function () {
+	throw new Error('Ti.App.iOS.UserActivity.setSupported was deprecated, since 5.1.0');
+};
+UserActivity.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+UserActivity.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getUserInfo = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.userInfo;
+};
+UserActivity.prototype.setUserInfo = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.userInfo = __SLAG__PROPERTY;
+};
+UserActivity.prototype.getWebpageURL = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.webpageURL;
+};
+UserActivity.prototype.setWebpageURL = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.webpageURL = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new UserActivity(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserDefaults.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserDefaults.js
@@ -1,0 +1,181 @@
+var crypto = require('crypto');
+function UserDefaults(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'suiteName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.UserDefaults.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.UserDefaults';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.suiteName = undefined;
+	} else {
+		this.suiteName = __SLAG_PROPERTIES.suiteName || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+UserDefaults.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+UserDefaults.prototype.getBool = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+UserDefaults.prototype.getDouble = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+UserDefaults.prototype.getInt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+UserDefaults.prototype.getList = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+UserDefaults.prototype.getObject = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+UserDefaults.prototype.getString = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+UserDefaults.prototype.hasProperty = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+UserDefaults.prototype.listProperties = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+UserDefaults.prototype.removeProperty = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.removeAllProperties = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.setBool = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.setDouble = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.setInt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.setList = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.setObject = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.setString = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UserDefaults.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+UserDefaults.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+UserDefaults.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+UserDefaults.prototype.getSuiteName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.suiteName;
+};
+UserDefaults.prototype.setSuiteName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.suiteName = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new UserDefaults(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserNotificationAction.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserNotificationAction.js
@@ -1,0 +1,97 @@
+var crypto = require('crypto');
+function UserNotificationAction(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'activationMode',
+			'behavior',
+			'authenticationRequired',
+			'destructive',
+			'identifier',
+			'title',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.UserNotificationAction.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.UserNotificationAction';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activationMode = undefined;
+	} else {
+		this.activationMode = __SLAG_PROPERTIES.activationMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.behavior = undefined;
+	} else {
+		this.behavior = __SLAG_PROPERTIES.behavior || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.authenticationRequired = undefined;
+	} else {
+		this.authenticationRequired = __SLAG_PROPERTIES.authenticationRequired || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.destructive = undefined;
+	} else {
+		this.destructive = __SLAG_PROPERTIES.destructive || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.identifier = undefined;
+	} else {
+		this.identifier = __SLAG_PROPERTIES.identifier || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+UserNotificationAction.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+UserNotificationAction.prototype.getActivationMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activationMode;
+};
+UserNotificationAction.prototype.setActivationMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activationMode = __SLAG__PROPERTY;
+};
+UserNotificationAction.prototype.getBehavior = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.behavior;
+};
+UserNotificationAction.prototype.setBehavior = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.behavior = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new UserNotificationAction(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserNotificationCategory.js
+++ b/lib/titanium/6.0.4.GA/Titanium/App/iOS/UserNotificationCategory.js
@@ -1,0 +1,55 @@
+var crypto = require('crypto');
+function UserNotificationCategory(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'actionsForDefaultContext',
+			'actionsForMinimalContext',
+			'identifier',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.App.iOS.UserNotificationCategory.apiName is read only property');
+	}
+	this.apiName = 'Ti.App.iOS.UserNotificationCategory';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.actionsForDefaultContext = undefined;
+	} else {
+		this.actionsForDefaultContext = __SLAG_PROPERTIES.actionsForDefaultContext || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.actionsForMinimalContext = undefined;
+	} else {
+		this.actionsForMinimalContext = __SLAG_PROPERTIES.actionsForMinimalContext || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.identifier = undefined;
+	} else {
+		this.identifier = __SLAG_PROPERTIES.identifier || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+UserNotificationCategory.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new UserNotificationCategory(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Blob.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Blob.js
@@ -1,0 +1,372 @@
+var crypto = require('crypto');
+function Blob(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'file',
+			'length',
+			'text',
+			'mimeType',
+			'height',
+			'width',
+			'nativePath',
+			'size',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Blob.apiName is read only property');
+	}
+	this.apiName = 'Ti.Blob';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.file) {
+		throw new Error('Ti.Blob.file is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.file = undefined;
+	} else {
+		this.file = {};
+	}
+	if (__SLAG_PROPERTIES.length) {
+		throw new Error('Ti.Blob.length is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = 0;
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.Blob.text is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.text = undefined;
+	} else {
+		this.text = '';
+	}
+	if (__SLAG_PROPERTIES.mimeType) {
+		throw new Error('Ti.Blob.mimeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mimeType = undefined;
+	} else {
+		this.mimeType = '';
+	}
+	if (__SLAG_PROPERTIES.height) {
+		throw new Error('Ti.Blob.height is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = 0;
+	}
+	if (__SLAG_PROPERTIES.width) {
+		throw new Error('Ti.Blob.width is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = 0;
+	}
+	if (__SLAG_PROPERTIES.nativePath) {
+		throw new Error('Ti.Blob.nativePath is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nativePath = undefined;
+	} else {
+		this.nativePath = '';
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.Blob.size is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Blob.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Blob.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Blob.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Blob.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Blob.prototype.toString = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Blob.prototype.append = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Blob.prototype.imageAsCropped = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Blob.prototype.imageAsResized = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Blob.prototype.imageAsThumbnail = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Blob.prototype.imageWithAlpha = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Blob.prototype.imageWithRoundedCorner = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Blob.prototype.imageWithTransparentBorder = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Blob.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Blob.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Blob.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Blob.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Blob.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Blob.prototype.getFile = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.file;
+};
+Blob.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+Blob.prototype.getText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.text;
+};
+Blob.prototype.getMimeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mimeType;
+};
+Blob.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Blob.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Blob.prototype.getNativePath = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nativePath;
+};
+Blob.prototype.getSize = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+module.exports = function (properties) {
+	return new Blob(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/BlobStream.js
+++ b/lib/titanium/6.0.4.GA/Titanium/BlobStream.js
@@ -1,0 +1,167 @@
+var crypto = require('crypto');
+function BlobStream(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.BlobStream.apiName is read only property');
+	}
+	this.apiName = 'Ti.BlobStream';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+BlobStream.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlobStream.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlobStream.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlobStream.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+BlobStream.prototype.read = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+BlobStream.prototype.write = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+BlobStream.prototype.isWritable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+BlobStream.prototype.isReadable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+BlobStream.prototype.close = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlobStream.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+BlobStream.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+BlobStream.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+BlobStream.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+BlobStream.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new BlobStream(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Buffer.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Buffer.js
@@ -1,0 +1,325 @@
+var crypto = require('crypto');
+function Buffer(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'length',
+			'value',
+			'type',
+			'byteOrder',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Buffer.apiName is read only property');
+	}
+	this.apiName = 'Ti.Buffer';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = __SLAG_PROPERTIES.length || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.byteOrder = undefined;
+	} else {
+		this.byteOrder = __SLAG_PROPERTIES.byteOrder || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Buffer.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Buffer.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Buffer.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Buffer.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Buffer.prototype.append = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Buffer.prototype.insert = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Buffer.prototype.copy = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Buffer.prototype.clone = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Buffer.prototype.fill = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Buffer.prototype.clear = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Buffer.prototype.release = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Buffer.prototype.toString = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Buffer.prototype.toBlob = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Buffer.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Buffer.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Buffer.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Buffer.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Buffer.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Buffer.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+Buffer.prototype.setLength = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.length = __SLAG__PROPERTY;
+};
+Buffer.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+Buffer.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Buffer.prototype.getType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+Buffer.prototype.setType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.type = __SLAG__PROPERTY;
+};
+Buffer.prototype.getByteOrder = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.byteOrder;
+};
+Buffer.prototype.setByteOrder = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.byteOrder = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Buffer(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/BufferStream.js
+++ b/lib/titanium/6.0.4.GA/Titanium/BufferStream.js
@@ -1,0 +1,167 @@
+var crypto = require('crypto');
+function BufferStream(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.BufferStream.apiName is read only property');
+	}
+	this.apiName = 'Ti.BufferStream';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+BufferStream.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BufferStream.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BufferStream.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BufferStream.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+BufferStream.prototype.read = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+BufferStream.prototype.write = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+BufferStream.prototype.isWritable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+BufferStream.prototype.isReadable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+BufferStream.prototype.close = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BufferStream.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+BufferStream.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+BufferStream.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+BufferStream.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+BufferStream.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new BufferStream(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Calendar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Calendar.js
@@ -1,0 +1,682 @@
+var crypto = require('crypto');
+function Calendar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'METHOD_ALERT',
+			'METHOD_DEFAULT',
+			'METHOD_EMAIL',
+			'METHOD_SMS',
+			'STATE_DISMISSED',
+			'STATE_FIRED',
+			'STATE_SCHEDULED',
+			'STATUS_NONE',
+			'STATUS_CANCELLED',
+			'STATUS_CANCELED',
+			'STATUS_CONFIRMED',
+			'STATUS_TENTATIVE',
+			'AVAILABILITY_NOTSUPPORTED',
+			'AVAILABILITY_BUSY',
+			'AVAILABILITY_FREE',
+			'AVAILABILITY_TENTATIVE',
+			'AVAILABILITY_UNAVAILABLE',
+			'AUTHORIZATION_AUTHORIZED',
+			'AUTHORIZATION_DENIED',
+			'AUTHORIZATION_RESTRICTED',
+			'AUTHORIZATION_UNKNOWN',
+			'SPAN_THISEVENT',
+			'SPAN_FUTUREEVENTS',
+			'RECURRENCEFREQUENCY_DAILY',
+			'RECURRENCEFREQUENCY_WEEKLY',
+			'RECURRENCEFREQUENCY_MONTHLY',
+			'RECURRENCEFREQUENCY_YEARLY',
+			'VISIBILITY_CONFIDENTIAL',
+			'VISIBILITY_DEFAULT',
+			'VISIBILITY_PRIVATE',
+			'VISIBILITY_PUBLIC',
+			'ATTENDEE_STATUS_UNKNOWN',
+			'ATTENDEE_STATUS_PENDING',
+			'ATTENDEE_STATUS_ACCEPTED',
+			'ATTENDEE_STATUS_DECLINED',
+			'ATTENDEE_STATUS_TENTATIVE',
+			'ATTENDEE_STATUS_DELEGATED',
+			'ATTENDEE_STATUS_IN_PROCESS',
+			'ATTENDEE_ROLE_UNKNOWN',
+			'ATTENDEE_ROLE_OPTIONAL',
+			'ATTENDEE_ROLE_REQUIRED',
+			'ATTENDEE_ROLE_CHAIR',
+			'ATTENDEE_ROLE_NON_PARTICIPANT',
+			'ATTENDEE_TYPE_UNKNOWN',
+			'ATTENDEE_TYPE_PERSON',
+			'ATTENDEE_TYPE_ROOM',
+			'ATTENDEE_TYPE_RESOURCE',
+			'ATTENDEE_TYPE_GROUP',
+			'eventsAuthorization',
+			'calendarAuthorization',
+			'allAlerts',
+			'allCalendars',
+			'allEditableCalendars',
+			'selectableCalendars',
+			'defaultCalendar',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Calendar.apiName is read only property');
+	}
+	this.apiName = 'Ti.Calendar';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.METHOD_ALERT) {
+		throw new Error('Ti.Calendar.METHOD_ALERT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_ALERT = undefined;
+	} else {
+		this.METHOD_ALERT = 0;
+	}
+	if (__SLAG_PROPERTIES.METHOD_DEFAULT) {
+		throw new Error('Ti.Calendar.METHOD_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_DEFAULT = undefined;
+	} else {
+		this.METHOD_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.METHOD_EMAIL) {
+		throw new Error('Ti.Calendar.METHOD_EMAIL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_EMAIL = undefined;
+	} else {
+		this.METHOD_EMAIL = 0;
+	}
+	if (__SLAG_PROPERTIES.METHOD_SMS) {
+		throw new Error('Ti.Calendar.METHOD_SMS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.METHOD_SMS = undefined;
+	} else {
+		this.METHOD_SMS = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_DISMISSED) {
+		throw new Error('Ti.Calendar.STATE_DISMISSED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_DISMISSED = undefined;
+	} else {
+		this.STATE_DISMISSED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_FIRED) {
+		throw new Error('Ti.Calendar.STATE_FIRED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_FIRED = undefined;
+	} else {
+		this.STATE_FIRED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_SCHEDULED) {
+		throw new Error('Ti.Calendar.STATE_SCHEDULED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_SCHEDULED = undefined;
+	} else {
+		this.STATE_SCHEDULED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATUS_NONE) {
+		throw new Error('Ti.Calendar.STATUS_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATUS_NONE = undefined;
+	} else {
+		this.STATUS_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.STATUS_CANCELLED) {
+		throw new Error('Ti.Calendar.STATUS_CANCELLED was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.STATUS_CANCELED) {
+		throw new Error('Ti.Calendar.STATUS_CANCELED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATUS_CANCELED = undefined;
+	} else {
+		this.STATUS_CANCELED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATUS_CONFIRMED) {
+		throw new Error('Ti.Calendar.STATUS_CONFIRMED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATUS_CONFIRMED = undefined;
+	} else {
+		this.STATUS_CONFIRMED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATUS_TENTATIVE) {
+		throw new Error('Ti.Calendar.STATUS_TENTATIVE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATUS_TENTATIVE = undefined;
+	} else {
+		this.STATUS_TENTATIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.AVAILABILITY_NOTSUPPORTED) {
+		throw new Error('Ti.Calendar.AVAILABILITY_NOTSUPPORTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AVAILABILITY_NOTSUPPORTED = undefined;
+	} else {
+		this.AVAILABILITY_NOTSUPPORTED = 0;
+	}
+	if (__SLAG_PROPERTIES.AVAILABILITY_BUSY) {
+		throw new Error('Ti.Calendar.AVAILABILITY_BUSY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AVAILABILITY_BUSY = undefined;
+	} else {
+		this.AVAILABILITY_BUSY = 0;
+	}
+	if (__SLAG_PROPERTIES.AVAILABILITY_FREE) {
+		throw new Error('Ti.Calendar.AVAILABILITY_FREE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AVAILABILITY_FREE = undefined;
+	} else {
+		this.AVAILABILITY_FREE = 0;
+	}
+	if (__SLAG_PROPERTIES.AVAILABILITY_TENTATIVE) {
+		throw new Error('Ti.Calendar.AVAILABILITY_TENTATIVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AVAILABILITY_TENTATIVE = undefined;
+	} else {
+		this.AVAILABILITY_TENTATIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.AVAILABILITY_UNAVAILABLE) {
+		throw new Error('Ti.Calendar.AVAILABILITY_UNAVAILABLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AVAILABILITY_UNAVAILABLE = undefined;
+	} else {
+		this.AVAILABILITY_UNAVAILABLE = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_AUTHORIZED) {
+		throw new Error('Ti.Calendar.AUTHORIZATION_AUTHORIZED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_AUTHORIZED = undefined;
+	} else {
+		this.AUTHORIZATION_AUTHORIZED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_DENIED) {
+		throw new Error('Ti.Calendar.AUTHORIZATION_DENIED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_DENIED = undefined;
+	} else {
+		this.AUTHORIZATION_DENIED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_RESTRICTED) {
+		throw new Error('Ti.Calendar.AUTHORIZATION_RESTRICTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_RESTRICTED = undefined;
+	} else {
+		this.AUTHORIZATION_RESTRICTED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_UNKNOWN) {
+		throw new Error('Ti.Calendar.AUTHORIZATION_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_UNKNOWN = undefined;
+	} else {
+		this.AUTHORIZATION_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.SPAN_THISEVENT) {
+		throw new Error('Ti.Calendar.SPAN_THISEVENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SPAN_THISEVENT = undefined;
+	} else {
+		this.SPAN_THISEVENT = 0;
+	}
+	if (__SLAG_PROPERTIES.SPAN_FUTUREEVENTS) {
+		throw new Error('Ti.Calendar.SPAN_FUTUREEVENTS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SPAN_FUTUREEVENTS = undefined;
+	} else {
+		this.SPAN_FUTUREEVENTS = 0;
+	}
+	if (__SLAG_PROPERTIES.RECURRENCEFREQUENCY_DAILY) {
+		throw new Error('Ti.Calendar.RECURRENCEFREQUENCY_DAILY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RECURRENCEFREQUENCY_DAILY = undefined;
+	} else {
+		this.RECURRENCEFREQUENCY_DAILY = 0;
+	}
+	if (__SLAG_PROPERTIES.RECURRENCEFREQUENCY_WEEKLY) {
+		throw new Error('Ti.Calendar.RECURRENCEFREQUENCY_WEEKLY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RECURRENCEFREQUENCY_WEEKLY = undefined;
+	} else {
+		this.RECURRENCEFREQUENCY_WEEKLY = 0;
+	}
+	if (__SLAG_PROPERTIES.RECURRENCEFREQUENCY_MONTHLY) {
+		throw new Error('Ti.Calendar.RECURRENCEFREQUENCY_MONTHLY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RECURRENCEFREQUENCY_MONTHLY = undefined;
+	} else {
+		this.RECURRENCEFREQUENCY_MONTHLY = 0;
+	}
+	if (__SLAG_PROPERTIES.RECURRENCEFREQUENCY_YEARLY) {
+		throw new Error('Ti.Calendar.RECURRENCEFREQUENCY_YEARLY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RECURRENCEFREQUENCY_YEARLY = undefined;
+	} else {
+		this.RECURRENCEFREQUENCY_YEARLY = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_CONFIDENTIAL) {
+		throw new Error('Ti.Calendar.VISIBILITY_CONFIDENTIAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_CONFIDENTIAL = undefined;
+	} else {
+		this.VISIBILITY_CONFIDENTIAL = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_DEFAULT) {
+		throw new Error('Ti.Calendar.VISIBILITY_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_DEFAULT = undefined;
+	} else {
+		this.VISIBILITY_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_PRIVATE) {
+		throw new Error('Ti.Calendar.VISIBILITY_PRIVATE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_PRIVATE = undefined;
+	} else {
+		this.VISIBILITY_PRIVATE = 0;
+	}
+	if (__SLAG_PROPERTIES.VISIBILITY_PUBLIC) {
+		throw new Error('Ti.Calendar.VISIBILITY_PUBLIC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VISIBILITY_PUBLIC = undefined;
+	} else {
+		this.VISIBILITY_PUBLIC = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_STATUS_UNKNOWN) {
+		throw new Error('Ti.Calendar.ATTENDEE_STATUS_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_STATUS_UNKNOWN = undefined;
+	} else {
+		this.ATTENDEE_STATUS_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_STATUS_PENDING) {
+		throw new Error('Ti.Calendar.ATTENDEE_STATUS_PENDING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_STATUS_PENDING = undefined;
+	} else {
+		this.ATTENDEE_STATUS_PENDING = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_STATUS_ACCEPTED) {
+		throw new Error('Ti.Calendar.ATTENDEE_STATUS_ACCEPTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_STATUS_ACCEPTED = undefined;
+	} else {
+		this.ATTENDEE_STATUS_ACCEPTED = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_STATUS_DECLINED) {
+		throw new Error('Ti.Calendar.ATTENDEE_STATUS_DECLINED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_STATUS_DECLINED = undefined;
+	} else {
+		this.ATTENDEE_STATUS_DECLINED = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_STATUS_TENTATIVE) {
+		throw new Error('Ti.Calendar.ATTENDEE_STATUS_TENTATIVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_STATUS_TENTATIVE = undefined;
+	} else {
+		this.ATTENDEE_STATUS_TENTATIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_STATUS_DELEGATED) {
+		throw new Error('Ti.Calendar.ATTENDEE_STATUS_DELEGATED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_STATUS_DELEGATED = undefined;
+	} else {
+		this.ATTENDEE_STATUS_DELEGATED = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_STATUS_IN_PROCESS) {
+		throw new Error('Ti.Calendar.ATTENDEE_STATUS_IN_PROCESS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_STATUS_IN_PROCESS = undefined;
+	} else {
+		this.ATTENDEE_STATUS_IN_PROCESS = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_ROLE_UNKNOWN) {
+		throw new Error('Ti.Calendar.ATTENDEE_ROLE_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_ROLE_UNKNOWN = undefined;
+	} else {
+		this.ATTENDEE_ROLE_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_ROLE_OPTIONAL) {
+		throw new Error('Ti.Calendar.ATTENDEE_ROLE_OPTIONAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_ROLE_OPTIONAL = undefined;
+	} else {
+		this.ATTENDEE_ROLE_OPTIONAL = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_ROLE_REQUIRED) {
+		throw new Error('Ti.Calendar.ATTENDEE_ROLE_REQUIRED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_ROLE_REQUIRED = undefined;
+	} else {
+		this.ATTENDEE_ROLE_REQUIRED = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_ROLE_CHAIR) {
+		throw new Error('Ti.Calendar.ATTENDEE_ROLE_CHAIR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_ROLE_CHAIR = undefined;
+	} else {
+		this.ATTENDEE_ROLE_CHAIR = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_ROLE_NON_PARTICIPANT) {
+		throw new Error('Ti.Calendar.ATTENDEE_ROLE_NON_PARTICIPANT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_ROLE_NON_PARTICIPANT = undefined;
+	} else {
+		this.ATTENDEE_ROLE_NON_PARTICIPANT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_TYPE_UNKNOWN) {
+		throw new Error('Ti.Calendar.ATTENDEE_TYPE_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_TYPE_UNKNOWN = undefined;
+	} else {
+		this.ATTENDEE_TYPE_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_TYPE_PERSON) {
+		throw new Error('Ti.Calendar.ATTENDEE_TYPE_PERSON is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_TYPE_PERSON = undefined;
+	} else {
+		this.ATTENDEE_TYPE_PERSON = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_TYPE_ROOM) {
+		throw new Error('Ti.Calendar.ATTENDEE_TYPE_ROOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_TYPE_ROOM = undefined;
+	} else {
+		this.ATTENDEE_TYPE_ROOM = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_TYPE_RESOURCE) {
+		throw new Error('Ti.Calendar.ATTENDEE_TYPE_RESOURCE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_TYPE_RESOURCE = undefined;
+	} else {
+		this.ATTENDEE_TYPE_RESOURCE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTENDEE_TYPE_GROUP) {
+		throw new Error('Ti.Calendar.ATTENDEE_TYPE_GROUP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTENDEE_TYPE_GROUP = undefined;
+	} else {
+		this.ATTENDEE_TYPE_GROUP = 0;
+	}
+	if (__SLAG_PROPERTIES.eventsAuthorization) {
+		throw new Error('Ti.Calendar.eventsAuthorization was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.calendarAuthorization) {
+		throw new Error('Ti.Calendar.calendarAuthorization is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.calendarAuthorization = undefined;
+	} else {
+		this.calendarAuthorization = 0;
+	}
+	if (__SLAG_PROPERTIES.allAlerts) {
+		throw new Error('Ti.Calendar.allAlerts is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allAlerts = undefined;
+	} else {
+		this.allAlerts = [];
+	}
+	if (__SLAG_PROPERTIES.allCalendars) {
+		throw new Error('Ti.Calendar.allCalendars is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allCalendars = undefined;
+	} else {
+		this.allCalendars = [];
+	}
+	if (__SLAG_PROPERTIES.allEditableCalendars) {
+		throw new Error('Ti.Calendar.allEditableCalendars is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allEditableCalendars = undefined;
+	} else {
+		this.allEditableCalendars = [];
+	}
+	if (__SLAG_PROPERTIES.selectableCalendars) {
+		throw new Error('Ti.Calendar.selectableCalendars is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectableCalendars = undefined;
+	} else {
+		this.selectableCalendars = [];
+	}
+	if (__SLAG_PROPERTIES.defaultCalendar) {
+		throw new Error('Ti.Calendar.defaultCalendar is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.defaultCalendar = undefined;
+	} else {
+		this.defaultCalendar = {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Calendar.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Calendar.prototype.getCalendarById = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Calendar.prototype.hasCalendarPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Calendar.prototype.requestCalendarPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.requestEventsAuthorization = function () {
+	throw new Error('Ti.Calendar.requestEventsAuthorization was deprecated, since 5.1.0');
+};
+Calendar.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Calendar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Calendar.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Calendar.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Calendar.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Calendar.prototype.getEventsAuthorization = function () {
+	throw new Error('Ti.Calendar.getEventsAuthorization was deprecated, since 5.2.0');
+};
+Calendar.prototype.getCalendarAuthorization = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.calendarAuthorization;
+};
+Calendar.prototype.getAllAlerts = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allAlerts;
+};
+Calendar.prototype.getAllCalendars = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allCalendars;
+};
+Calendar.prototype.getAllEditableCalendars = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allEditableCalendars;
+};
+Calendar.prototype.getSelectableCalendars = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectableCalendars;
+};
+Calendar.prototype.getDefaultCalendar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.defaultCalendar;
+};
+module.exports = function (properties) {
+	return new Calendar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Calendar/Alert.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Calendar/Alert.js
@@ -1,0 +1,261 @@
+var crypto = require('crypto');
+function Alert(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'absoluteDate',
+			'relativeOffset',
+			'alarmTime',
+			'begin',
+			'end',
+			'eventId',
+			'id',
+			'minutes',
+			'state',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Calendar.Alert.apiName is read only property');
+	}
+	this.apiName = 'Ti.Calendar.Alert';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.absoluteDate = undefined;
+	} else {
+		this.absoluteDate = __SLAG_PROPERTIES.absoluteDate || new Date();
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.relativeOffset = undefined;
+	} else {
+		this.relativeOffset = __SLAG_PROPERTIES.relativeOffset || 0;
+	}
+	if (__SLAG_PROPERTIES.alarmTime) {
+		throw new Error('Ti.Calendar.Alert.alarmTime is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alarmTime = undefined;
+	} else {
+		this.alarmTime = new Date();
+	}
+	if (__SLAG_PROPERTIES.begin) {
+		throw new Error('Ti.Calendar.Alert.begin is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.begin = undefined;
+	} else {
+		this.begin = new Date();
+	}
+	if (__SLAG_PROPERTIES.end) {
+		throw new Error('Ti.Calendar.Alert.end is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.end = undefined;
+	} else {
+		this.end = new Date();
+	}
+	if (__SLAG_PROPERTIES.eventId) {
+		throw new Error('Ti.Calendar.Alert.eventId is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.eventId = undefined;
+	} else {
+		this.eventId = 0;
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Calendar.Alert.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.minutes) {
+		throw new Error('Ti.Calendar.Alert.minutes is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minutes = undefined;
+	} else {
+		this.minutes = 0;
+	}
+	if (__SLAG_PROPERTIES.state) {
+		throw new Error('Ti.Calendar.Alert.state is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.state = undefined;
+	} else {
+		this.state = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Alert.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Alert.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Alert.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Alert.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Alert.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Alert.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Alert.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Alert.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Alert.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Alert.prototype.getAbsoluteDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.absoluteDate;
+};
+Alert.prototype.setAbsoluteDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.absoluteDate = __SLAG__PROPERTY;
+};
+Alert.prototype.getRelativeOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.relativeOffset;
+};
+Alert.prototype.setRelativeOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.relativeOffset = __SLAG__PROPERTY;
+};
+Alert.prototype.getAlarmTime = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.alarmTime;
+};
+Alert.prototype.getBegin = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.begin;
+};
+Alert.prototype.getEnd = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.end;
+};
+Alert.prototype.getEventId = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.eventId;
+};
+Alert.prototype.getId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Alert.prototype.getMinutes = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minutes;
+};
+Alert.prototype.getState = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.state;
+};
+module.exports = function (properties) {
+	return new Alert(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Calendar/Attendee.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Calendar/Attendee.js
@@ -1,0 +1,183 @@
+var crypto = require('crypto');
+function Attendee(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'isOrganizer',
+			'name',
+			'email',
+			'role',
+			'type',
+			'status',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Calendar.Attendee.apiName is read only property');
+	}
+	this.apiName = 'Ti.Calendar.Attendee';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isOrganizer = undefined;
+	} else {
+		this.isOrganizer = __SLAG_PROPERTIES.isOrganizer || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.email = undefined;
+	} else {
+		this.email = __SLAG_PROPERTIES.email || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.role = undefined;
+	} else {
+		this.role = __SLAG_PROPERTIES.role || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.status = undefined;
+	} else {
+		this.status = __SLAG_PROPERTIES.status || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Attendee.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attendee.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attendee.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attendee.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Attendee.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Attendee.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Attendee.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Attendee.prototype.getIsOrganizer = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isOrganizer;
+};
+Attendee.prototype.setIsOrganizer = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.isOrganizer = __SLAG__PROPERTY;
+};
+Attendee.prototype.getName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+Attendee.prototype.setName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.name = __SLAG__PROPERTY;
+};
+Attendee.prototype.getEmail = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.email;
+};
+Attendee.prototype.setEmail = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.email = __SLAG__PROPERTY;
+};
+Attendee.prototype.getRole = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.role;
+};
+Attendee.prototype.setRole = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.role = __SLAG__PROPERTY;
+};
+Attendee.prototype.getType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+Attendee.prototype.setType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.type = __SLAG__PROPERTY;
+};
+Attendee.prototype.getStatus = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.status;
+};
+Attendee.prototype.setStatus = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.status = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Attendee(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Calendar/Calendar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Calendar/Calendar.js
@@ -1,0 +1,247 @@
+var crypto = require('crypto');
+function Calendar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'hidden',
+			'id',
+			'name',
+			'selected',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Calendar.Calendar.apiName is read only property');
+	}
+	this.apiName = 'Ti.Calendar.Calendar';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.hidden) {
+		throw new Error('Ti.Calendar.Calendar.hidden is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidden = undefined;
+	} else {
+		this.hidden = true;
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Calendar.Calendar.id is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.Calendar.Calendar.name is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if (__SLAG_PROPERTIES.selected) {
+		throw new Error('Ti.Calendar.Calendar.selected is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selected = undefined;
+	} else {
+		this.selected = true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Calendar.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Calendar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Calendar.prototype.createEvent = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Event = require('./Event');
+	return Event(__SLAG_PROPERTY);
+};
+Calendar.prototype.getEventById = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Calendar.prototype.getEventsBetweenDates = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getEventsInDate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getEventsInMonth = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getEventsInYear = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Calendar.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Calendar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Calendar.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Calendar.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Calendar.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Calendar.prototype.getHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidden;
+};
+Calendar.prototype.getId = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Calendar.prototype.getName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+Calendar.prototype.getSelected = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selected;
+};
+module.exports = function (properties) {
+	return new Calendar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Calendar/Event.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Calendar/Event.js
@@ -1,0 +1,553 @@
+var crypto = require('crypto');
+function Event(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'alerts',
+			'allDay',
+			'begin',
+			'notes',
+			'description',
+			'end',
+			'extendedProperties',
+			'hasAlarm',
+			'id',
+			'location',
+			'reminders',
+			'status',
+			'availability',
+			'isDetached',
+			'title',
+			'recurrenceRule',
+			'recurrenceRules',
+			'visibility',
+			'attendees',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Calendar.Event.apiName is read only property');
+	}
+	this.apiName = 'Ti.Calendar.Event';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alerts = undefined;
+	} else {
+		this.alerts = __SLAG_PROPERTIES.alerts || [];
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allDay = undefined;
+	} else {
+		this.allDay = __SLAG_PROPERTIES.allDay || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.begin = undefined;
+	} else {
+		this.begin = __SLAG_PROPERTIES.begin || new Date();
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.notes = undefined;
+	} else {
+		this.notes = __SLAG_PROPERTIES.notes || '';
+	}
+	if (__SLAG_PROPERTIES.description) {
+		throw new Error('Ti.Calendar.Event.description is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.description = undefined;
+	} else {
+		this.description = '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.end = undefined;
+	} else {
+		this.end = __SLAG_PROPERTIES.end || new Date();
+	}
+	if (__SLAG_PROPERTIES.extendedProperties) {
+		throw new Error('Ti.Calendar.Event.extendedProperties is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.extendedProperties = undefined;
+	} else {
+		this.extendedProperties = {};
+	}
+	if (__SLAG_PROPERTIES.hasAlarm) {
+		throw new Error('Ti.Calendar.Event.hasAlarm is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasAlarm = undefined;
+	} else {
+		this.hasAlarm = true;
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Calendar.Event.id is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.location = undefined;
+	} else {
+		this.location = __SLAG_PROPERTIES.location || '';
+	}
+	if (__SLAG_PROPERTIES.reminders) {
+		throw new Error('Ti.Calendar.Event.reminders is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.reminders = undefined;
+	} else {
+		this.reminders = [];
+	}
+	if (__SLAG_PROPERTIES.status) {
+		throw new Error('Ti.Calendar.Event.status is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.status = undefined;
+	} else {
+		this.status = 0;
+	}
+	if (__SLAG_PROPERTIES.availability) {
+		throw new Error('Ti.Calendar.Event.availability is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.availability = undefined;
+	} else {
+		this.availability = 0;
+	}
+	if (__SLAG_PROPERTIES.isDetached) {
+		throw new Error('Ti.Calendar.Event.isDetached is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isDetached = undefined;
+	} else {
+		this.isDetached = true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (__SLAG_PROPERTIES.recurrenceRule) {
+		throw new Error('Ti.Calendar.Event.recurrenceRule was deprecated, since 3.1.3');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.recurrenceRules = undefined;
+	} else {
+		this.recurrenceRules = __SLAG_PROPERTIES.recurrenceRules || [];
+	}
+	if (__SLAG_PROPERTIES.visibility) {
+		throw new Error('Ti.Calendar.Event.visibility is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visibility = undefined;
+	} else {
+		this.visibility = 0;
+	}
+	if (__SLAG_PROPERTIES.attendees) {
+		throw new Error('Ti.Calendar.Event.attendees is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attendees = undefined;
+	} else {
+		this.attendees = [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Event.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Event.prototype.createAlert = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Alert = require('./Alert');
+	return Alert(__SLAG_PROPERTY);
+};
+Event.prototype.createReminder = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Reminder = require('./Reminder');
+	return Reminder(__SLAG_PROPERTY);
+};
+Event.prototype.getExtendedProperty = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Event.prototype.setExtendedProperty = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.createRecurrenceRule = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var RecurrenceRule = require('./Event/RecurrenceRule');
+	return RecurrenceRule(__SLAG_PROPERTY);
+};
+Event.prototype.save = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Event.prototype.remove = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Event.prototype.refresh = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Event.prototype.addRecurrenceRule = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.removeRecurrenceRule = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Event.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Event.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Event.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Event.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Event.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Event.prototype.getAlerts = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.alerts;
+};
+Event.prototype.setAlerts = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.alerts = __SLAG__PROPERTY;
+};
+Event.prototype.getAllDay = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allDay;
+};
+Event.prototype.setAllDay = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allDay = __SLAG__PROPERTY;
+};
+Event.prototype.getBegin = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.begin;
+};
+Event.prototype.setBegin = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.begin = __SLAG__PROPERTY;
+};
+Event.prototype.getNotes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.notes;
+};
+Event.prototype.setNotes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.notes = __SLAG__PROPERTY;
+};
+Event.prototype.getDescription = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.description;
+};
+Event.prototype.getEnd = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.end;
+};
+Event.prototype.setEnd = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.end = __SLAG__PROPERTY;
+};
+Event.prototype.getExtendedProperties = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.extendedProperties;
+};
+Event.prototype.getHasAlarm = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasAlarm;
+};
+Event.prototype.getId = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Event.prototype.getLocation = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.location;
+};
+Event.prototype.setLocation = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.location = __SLAG__PROPERTY;
+};
+Event.prototype.getReminders = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.reminders;
+};
+Event.prototype.getStatus = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.status;
+};
+Event.prototype.getAvailability = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.availability;
+};
+Event.prototype.getIsDetached = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isDetached;
+};
+Event.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+Event.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+Event.prototype.getRecurrenceRule = function () {
+	throw new Error('Ti.Calendar.Event.getRecurrenceRule was deprecated, since 3.1.3');
+};
+Event.prototype.setRecurrenceRule = function () {
+	throw new Error('Ti.Calendar.Event.setRecurrenceRule was deprecated, since 3.1.3');
+};
+Event.prototype.getRecurrenceRules = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.recurrenceRules;
+};
+Event.prototype.setRecurrenceRules = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.recurrenceRules = __SLAG__PROPERTY;
+};
+Event.prototype.getVisibility = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visibility;
+};
+Event.prototype.getAttendees = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attendees;
+};
+module.exports = function (properties) {
+	return new Event(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Calendar/RecurrenceRule.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Calendar/RecurrenceRule.js
@@ -1,0 +1,225 @@
+var crypto = require('crypto');
+function RecurrenceRule(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'calendarID',
+			'frequency',
+			'interval',
+			'daysOfTheWeek',
+			'daysOfTheMonth',
+			'monthsOfTheYear',
+			'weeksOfTheYear',
+			'daysOfTheYear',
+			'setPositions',
+			'end',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Calendar.RecurrenceRule.apiName is read only property');
+	}
+	this.apiName = 'Ti.Calendar.RecurrenceRule';
+	if (__SLAG_PROPERTIES.calendarID) {
+		throw new Error('Ti.Calendar.RecurrenceRule.calendarID is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.calendarID = undefined;
+	} else {
+		this.calendarID = '';
+	}
+	if (__SLAG_PROPERTIES.frequency) {
+		throw new Error('Ti.Calendar.RecurrenceRule.frequency is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.frequency = undefined;
+	} else {
+		this.frequency = 0;
+	}
+	if (__SLAG_PROPERTIES.interval) {
+		throw new Error('Ti.Calendar.RecurrenceRule.interval is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.interval = undefined;
+	} else {
+		this.interval = 0;
+	}
+	if (__SLAG_PROPERTIES.daysOfTheWeek) {
+		throw new Error('Ti.Calendar.RecurrenceRule.daysOfTheWeek is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.daysOfTheWeek = undefined;
+	} else {
+		this.daysOfTheWeek = {};
+	}
+	if (__SLAG_PROPERTIES.daysOfTheMonth) {
+		throw new Error('Ti.Calendar.RecurrenceRule.daysOfTheMonth is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.daysOfTheMonth = undefined;
+	} else {
+		this.daysOfTheMonth = 0;
+	}
+	if (__SLAG_PROPERTIES.monthsOfTheYear) {
+		throw new Error('Ti.Calendar.RecurrenceRule.monthsOfTheYear is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.monthsOfTheYear = undefined;
+	} else {
+		this.monthsOfTheYear = 0;
+	}
+	if (__SLAG_PROPERTIES.weeksOfTheYear) {
+		throw new Error('Ti.Calendar.RecurrenceRule.weeksOfTheYear is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.weeksOfTheYear = undefined;
+	} else {
+		this.weeksOfTheYear = 0;
+	}
+	if (__SLAG_PROPERTIES.daysOfTheYear) {
+		throw new Error('Ti.Calendar.RecurrenceRule.daysOfTheYear is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.daysOfTheYear = undefined;
+	} else {
+		this.daysOfTheYear = 0;
+	}
+	if (__SLAG_PROPERTIES.setPositions) {
+		throw new Error('Ti.Calendar.RecurrenceRule.setPositions is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.setPositions = undefined;
+	} else {
+		this.setPositions = 0;
+	}
+	if (__SLAG_PROPERTIES.end) {
+		throw new Error('Ti.Calendar.RecurrenceRule.end is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.end = undefined;
+	} else {
+		this.end = {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+RecurrenceRule.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RecurrenceRule.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RecurrenceRule.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RecurrenceRule.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+RecurrenceRule.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+RecurrenceRule.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+RecurrenceRule.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+RecurrenceRule.prototype.getCalendarID = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.calendarID;
+};
+RecurrenceRule.prototype.getFrequency = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.frequency;
+};
+RecurrenceRule.prototype.getInterval = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.interval;
+};
+RecurrenceRule.prototype.getDaysOfTheWeek = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.daysOfTheWeek;
+};
+RecurrenceRule.prototype.getDaysOfTheMonth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.daysOfTheMonth;
+};
+RecurrenceRule.prototype.getMonthsOfTheYear = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.monthsOfTheYear;
+};
+RecurrenceRule.prototype.getWeeksOfTheYear = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.weeksOfTheYear;
+};
+RecurrenceRule.prototype.getDaysOfTheYear = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.daysOfTheYear;
+};
+RecurrenceRule.prototype.getSetPositions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.setPositions;
+};
+RecurrenceRule.prototype.getEnd = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.end;
+};
+module.exports = function (properties) {
+	return new RecurrenceRule(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Calendar/Reminder.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Calendar/Reminder.js
@@ -1,0 +1,138 @@
+var crypto = require('crypto');
+function Reminder(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id',
+			'method',
+			'minutes',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Calendar.Reminder.apiName is read only property');
+	}
+	this.apiName = 'Ti.Calendar.Reminder';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Calendar.Reminder.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.method) {
+		throw new Error('Ti.Calendar.Reminder.method is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.method = undefined;
+	} else {
+		this.method = 0;
+	}
+	if (__SLAG_PROPERTIES.minutes) {
+		throw new Error('Ti.Calendar.Reminder.minutes is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minutes = undefined;
+	} else {
+		this.minutes = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Reminder.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reminder.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reminder.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Reminder.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Reminder.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Reminder.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Reminder.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Reminder.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Reminder.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Reminder.prototype.getId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Reminder.prototype.getMethod = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.method;
+};
+Reminder.prototype.getMinutes = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minutes;
+};
+module.exports = function (properties) {
+	return new Reminder(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Codec.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Codec.js
@@ -1,0 +1,350 @@
+var crypto = require('crypto');
+function Codec(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'CHARSET_ASCII',
+			'CHARSET_ISO_LATIN_1',
+			'CHARSET_UTF8',
+			'CHARSET_UTF16',
+			'CHARSET_UTF16BE',
+			'CHARSET_UTF16LE',
+			'TYPE_BYTE',
+			'TYPE_SHORT',
+			'TYPE_INT',
+			'TYPE_FLOAT',
+			'TYPE_LONG',
+			'TYPE_DOUBLE',
+			'BIG_ENDIAN',
+			'LITTLE_ENDIAN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Codec.apiName is read only property');
+	}
+	this.apiName = 'Ti.Codec';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.CHARSET_ASCII) {
+		throw new Error('Ti.Codec.CHARSET_ASCII is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CHARSET_ASCII = undefined;
+	} else {
+		this.CHARSET_ASCII = '';
+	}
+	if (__SLAG_PROPERTIES.CHARSET_ISO_LATIN_1) {
+		throw new Error('Ti.Codec.CHARSET_ISO_LATIN_1 is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CHARSET_ISO_LATIN_1 = undefined;
+	} else {
+		this.CHARSET_ISO_LATIN_1 = '';
+	}
+	if (__SLAG_PROPERTIES.CHARSET_UTF8) {
+		throw new Error('Ti.Codec.CHARSET_UTF8 is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CHARSET_UTF8 = undefined;
+	} else {
+		this.CHARSET_UTF8 = '';
+	}
+	if (__SLAG_PROPERTIES.CHARSET_UTF16) {
+		throw new Error('Ti.Codec.CHARSET_UTF16 is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CHARSET_UTF16 = undefined;
+	} else {
+		this.CHARSET_UTF16 = '';
+	}
+	if (__SLAG_PROPERTIES.CHARSET_UTF16BE) {
+		throw new Error('Ti.Codec.CHARSET_UTF16BE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CHARSET_UTF16BE = undefined;
+	} else {
+		this.CHARSET_UTF16BE = '';
+	}
+	if (__SLAG_PROPERTIES.CHARSET_UTF16LE) {
+		throw new Error('Ti.Codec.CHARSET_UTF16LE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CHARSET_UTF16LE = undefined;
+	} else {
+		this.CHARSET_UTF16LE = '';
+	}
+	if (__SLAG_PROPERTIES.TYPE_BYTE) {
+		throw new Error('Ti.Codec.TYPE_BYTE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TYPE_BYTE = undefined;
+	} else {
+		this.TYPE_BYTE = '';
+	}
+	if (__SLAG_PROPERTIES.TYPE_SHORT) {
+		throw new Error('Ti.Codec.TYPE_SHORT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TYPE_SHORT = undefined;
+	} else {
+		this.TYPE_SHORT = '';
+	}
+	if (__SLAG_PROPERTIES.TYPE_INT) {
+		throw new Error('Ti.Codec.TYPE_INT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TYPE_INT = undefined;
+	} else {
+		this.TYPE_INT = '';
+	}
+	if (__SLAG_PROPERTIES.TYPE_FLOAT) {
+		throw new Error('Ti.Codec.TYPE_FLOAT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TYPE_FLOAT = undefined;
+	} else {
+		this.TYPE_FLOAT = '';
+	}
+	if (__SLAG_PROPERTIES.TYPE_LONG) {
+		throw new Error('Ti.Codec.TYPE_LONG is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TYPE_LONG = undefined;
+	} else {
+		this.TYPE_LONG = '';
+	}
+	if (__SLAG_PROPERTIES.TYPE_DOUBLE) {
+		throw new Error('Ti.Codec.TYPE_DOUBLE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TYPE_DOUBLE = undefined;
+	} else {
+		this.TYPE_DOUBLE = '';
+	}
+	if (__SLAG_PROPERTIES.BIG_ENDIAN) {
+		throw new Error('Ti.Codec.BIG_ENDIAN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BIG_ENDIAN = undefined;
+	} else {
+		this.BIG_ENDIAN = 0;
+	}
+	if (__SLAG_PROPERTIES.LITTLE_ENDIAN) {
+		throw new Error('Ti.Codec.LITTLE_ENDIAN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LITTLE_ENDIAN = undefined;
+	} else {
+		this.LITTLE_ENDIAN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Codec.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Codec.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Codec.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Codec.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Codec.prototype.getNativeByteOrder = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Codec.prototype.encodeNumber = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Codec.prototype.decodeNumber = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Codec.prototype.encodeString = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Codec.prototype.decodeString = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Codec.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Codec.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Codec.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Codec.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Codec.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Codec(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Contacts.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Contacts.js
@@ -1,0 +1,356 @@
+var crypto = require('crypto');
+function Contacts(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'CONTACTS_KIND_ORGANIZATION',
+			'CONTACTS_KIND_PERSON',
+			'CONTACTS_SORT_FIRST_NAME',
+			'CONTACTS_SORT_LAST_NAME',
+			'AUTHORIZATION_AUTHORIZED',
+			'AUTHORIZATION_DENIED',
+			'AUTHORIZATION_RESTRICTED',
+			'AUTHORIZATION_UNKNOWN',
+			'contactsAuthorization',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Contacts.apiName is read only property');
+	}
+	this.apiName = 'Ti.Contacts';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.CONTACTS_KIND_ORGANIZATION) {
+		throw new Error('Ti.Contacts.CONTACTS_KIND_ORGANIZATION is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONTACTS_KIND_ORGANIZATION = undefined;
+	} else {
+		this.CONTACTS_KIND_ORGANIZATION = 0;
+	}
+	if (__SLAG_PROPERTIES.CONTACTS_KIND_PERSON) {
+		throw new Error('Ti.Contacts.CONTACTS_KIND_PERSON is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONTACTS_KIND_PERSON = undefined;
+	} else {
+		this.CONTACTS_KIND_PERSON = 0;
+	}
+	if (__SLAG_PROPERTIES.CONTACTS_SORT_FIRST_NAME) {
+		throw new Error('Ti.Contacts.CONTACTS_SORT_FIRST_NAME is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONTACTS_SORT_FIRST_NAME = undefined;
+	} else {
+		this.CONTACTS_SORT_FIRST_NAME = 0;
+	}
+	if (__SLAG_PROPERTIES.CONTACTS_SORT_LAST_NAME) {
+		throw new Error('Ti.Contacts.CONTACTS_SORT_LAST_NAME is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONTACTS_SORT_LAST_NAME = undefined;
+	} else {
+		this.CONTACTS_SORT_LAST_NAME = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_AUTHORIZED) {
+		throw new Error('Ti.Contacts.AUTHORIZATION_AUTHORIZED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_AUTHORIZED = undefined;
+	} else {
+		this.AUTHORIZATION_AUTHORIZED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_DENIED) {
+		throw new Error('Ti.Contacts.AUTHORIZATION_DENIED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_DENIED = undefined;
+	} else {
+		this.AUTHORIZATION_DENIED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_RESTRICTED) {
+		throw new Error('Ti.Contacts.AUTHORIZATION_RESTRICTED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_RESTRICTED = undefined;
+	} else {
+		this.AUTHORIZATION_RESTRICTED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_UNKNOWN) {
+		throw new Error('Ti.Contacts.AUTHORIZATION_UNKNOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_UNKNOWN = undefined;
+	} else {
+		this.AUTHORIZATION_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.contactsAuthorization) {
+		throw new Error('Ti.Contacts.contactsAuthorization is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contactsAuthorization = undefined;
+	} else {
+		this.contactsAuthorization = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Contacts.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Contacts.prototype.createGroup = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Group = require('./Contacts/Group');
+	return Group(__SLAG_PROPERTY);
+};
+Contacts.prototype.createPerson = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Person = require('./Contacts/Person');
+	return Person(__SLAG_PROPERTY);
+};
+Contacts.prototype.getAllGroups = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Contacts.prototype.getAllPeople = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Contacts.prototype.getGroupByID = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Contacts.prototype.getGroupByIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Contacts.prototype.getPeopleWithName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Contacts.prototype.getPersonByID = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Contacts.prototype.getPersonByIdentifier = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Contacts.prototype.removeGroup = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.removePerson = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.revert = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.save = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.showContacts = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.hasContactsPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Contacts.prototype.requestContactsPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Contacts.prototype.requestAuthorization = function () {
+	throw new Error('Ti.Contacts.requestAuthorization was deprecated, since 5.1.0');
+};
+Contacts.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Contacts.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Contacts.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Contacts.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Contacts.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Contacts.prototype.getContactsAuthorization = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contactsAuthorization;
+};
+module.exports = function (properties) {
+	return new Contacts(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Contacts/Group.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Contacts/Group.js
@@ -1,0 +1,148 @@
+var crypto = require('crypto');
+function Group(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'name',
+			'recordId',
+			'identifier',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Contacts.Group.apiName is read only property');
+	}
+	this.apiName = 'Ti.Contacts.Group';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.recordId = undefined;
+	} else {
+		this.recordId = __SLAG_PROPERTIES.recordId || 0;
+	}
+	if (__SLAG_PROPERTIES.identifier) {
+		throw new Error('Ti.Contacts.Group.identifier is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.identifier = undefined;
+	} else {
+		this.identifier = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Group.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Group.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Group.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Group.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Group.prototype.add = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Group.prototype.members = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Group.prototype.remove = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Group.prototype.sortedMembers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Group.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Group.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Group.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Group.prototype.getName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+Group.prototype.setName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.name = __SLAG__PROPERTY;
+};
+Group.prototype.getRecordId = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.recordId;
+};
+Group.prototype.setRecordId = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.recordId = __SLAG__PROPERTY;
+};
+Group.prototype.getIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.identifier;
+};
+module.exports = function (properties) {
+	return new Group(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Contacts/Person.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Contacts/Person.js
@@ -1,0 +1,858 @@
+var crypto = require('crypto');
+function Person(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'address',
+			'birthday',
+			'alternateBirthday',
+			'created',
+			'date',
+			'department',
+			'email',
+			'firstName',
+			'firstPhonetic',
+			'fullName',
+			'id',
+			'identifier',
+			'image',
+			'instantMessage',
+			'socialProfile',
+			'jobTitle',
+			'kind',
+			'lastName',
+			'lastPhonetic',
+			'middleName',
+			'middlePhonetic',
+			'modified',
+			'nickname',
+			'note',
+			'organization',
+			'phone',
+			'prefix',
+			'recordId',
+			'relatedNames',
+			'suffix',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Contacts.Person.apiName is read only property');
+	}
+	this.apiName = 'Ti.Contacts.Person';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.address = undefined;
+	} else {
+		this.address = __SLAG_PROPERTIES.address || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.birthday = undefined;
+	} else {
+		this.birthday = __SLAG_PROPERTIES.birthday || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.alternateBirthday = undefined;
+	} else {
+		this.alternateBirthday = __SLAG_PROPERTIES.alternateBirthday || {};
+	}
+	if (__SLAG_PROPERTIES.created) {
+		throw new Error('Ti.Contacts.Person.created is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.created = undefined;
+	} else {
+		this.created = '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.date = undefined;
+	} else {
+		this.date = __SLAG_PROPERTIES.date || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.department = undefined;
+	} else {
+		this.department = __SLAG_PROPERTIES.department || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.email = undefined;
+	} else {
+		this.email = __SLAG_PROPERTIES.email || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstName = undefined;
+	} else {
+		this.firstName = __SLAG_PROPERTIES.firstName || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstPhonetic = undefined;
+	} else {
+		this.firstPhonetic = __SLAG_PROPERTIES.firstPhonetic || '';
+	}
+	if (__SLAG_PROPERTIES.fullName) {
+		throw new Error('Ti.Contacts.Person.fullName is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullName = undefined;
+	} else {
+		this.fullName = '';
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Contacts.Person.id is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = 0;
+	}
+	if (__SLAG_PROPERTIES.identifier) {
+		throw new Error('Ti.Contacts.Person.identifier is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.identifier = undefined;
+	} else {
+		this.identifier = '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.instantMessage = undefined;
+	} else {
+		this.instantMessage = __SLAG_PROPERTIES.instantMessage || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.socialProfile = undefined;
+	} else {
+		this.socialProfile = __SLAG_PROPERTIES.socialProfile || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.jobTitle = undefined;
+	} else {
+		this.jobTitle = __SLAG_PROPERTIES.jobTitle || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.kind = undefined;
+	} else {
+		this.kind = __SLAG_PROPERTIES.kind || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastName = undefined;
+	} else {
+		this.lastName = __SLAG_PROPERTIES.lastName || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastPhonetic = undefined;
+	} else {
+		this.lastPhonetic = __SLAG_PROPERTIES.lastPhonetic || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.middleName = undefined;
+	} else {
+		this.middleName = __SLAG_PROPERTIES.middleName || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.middlePhonetic = undefined;
+	} else {
+		this.middlePhonetic = __SLAG_PROPERTIES.middlePhonetic || '';
+	}
+	if (__SLAG_PROPERTIES.modified) {
+		throw new Error('Ti.Contacts.Person.modified is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modified = undefined;
+	} else {
+		this.modified = '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nickname = undefined;
+	} else {
+		this.nickname = __SLAG_PROPERTIES.nickname || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.note = undefined;
+	} else {
+		this.note = __SLAG_PROPERTIES.note || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.organization = undefined;
+	} else {
+		this.organization = __SLAG_PROPERTIES.organization || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.phone = undefined;
+	} else {
+		this.phone = __SLAG_PROPERTIES.phone || {};
+	}
+	if (__SLAG_PROPERTIES.prefix) {
+		throw new Error('Ti.Contacts.Person.prefix is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.recordId = undefined;
+	} else {
+		this.recordId = __SLAG_PROPERTIES.recordId || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.relatedNames = undefined;
+	} else {
+		this.relatedNames = __SLAG_PROPERTIES.relatedNames || {};
+	}
+	if (__SLAG_PROPERTIES.suffix) {
+		throw new Error('Ti.Contacts.Person.suffix is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.suffix = undefined;
+	} else {
+		this.suffix = '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Person.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Person.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Person.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Person.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Person.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Person.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Person.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Person.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Person.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Person.prototype.getAddress = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.address;
+};
+Person.prototype.setAddress = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.address = __SLAG__PROPERTY;
+};
+Person.prototype.getBirthday = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.birthday;
+};
+Person.prototype.setBirthday = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.birthday = __SLAG__PROPERTY;
+};
+Person.prototype.getAlternateBirthday = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.alternateBirthday;
+};
+Person.prototype.setAlternateBirthday = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.alternateBirthday = __SLAG__PROPERTY;
+};
+Person.prototype.getCreated = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.created;
+};
+Person.prototype.getDate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.date;
+};
+Person.prototype.setDate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.date = __SLAG__PROPERTY;
+};
+Person.prototype.getDepartment = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.department;
+};
+Person.prototype.setDepartment = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.department = __SLAG__PROPERTY;
+};
+Person.prototype.getEmail = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.email;
+};
+Person.prototype.setEmail = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.email = __SLAG__PROPERTY;
+};
+Person.prototype.getFirstName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstName;
+};
+Person.prototype.setFirstName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.firstName = __SLAG__PROPERTY;
+};
+Person.prototype.getFirstPhonetic = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstPhonetic;
+};
+Person.prototype.setFirstPhonetic = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.firstPhonetic = __SLAG__PROPERTY;
+};
+Person.prototype.getFullName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fullName;
+};
+Person.prototype.getId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Person.prototype.getIdentifier = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.identifier;
+};
+Person.prototype.getImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.image;
+};
+Person.prototype.setImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.image = __SLAG__PROPERTY;
+};
+Person.prototype.getInstantMessage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.instantMessage;
+};
+Person.prototype.setInstantMessage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.instantMessage = __SLAG__PROPERTY;
+};
+Person.prototype.getSocialProfile = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.socialProfile;
+};
+Person.prototype.setSocialProfile = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.socialProfile = __SLAG__PROPERTY;
+};
+Person.prototype.getJobTitle = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.jobTitle;
+};
+Person.prototype.setJobTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.jobTitle = __SLAG__PROPERTY;
+};
+Person.prototype.getKind = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.kind;
+};
+Person.prototype.setKind = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.kind = __SLAG__PROPERTY;
+};
+Person.prototype.getLastName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastName;
+};
+Person.prototype.setLastName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lastName = __SLAG__PROPERTY;
+};
+Person.prototype.getLastPhonetic = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastPhonetic;
+};
+Person.prototype.setLastPhonetic = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lastPhonetic = __SLAG__PROPERTY;
+};
+Person.prototype.getMiddleName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.middleName;
+};
+Person.prototype.setMiddleName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.middleName = __SLAG__PROPERTY;
+};
+Person.prototype.getMiddlePhonetic = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.middlePhonetic;
+};
+Person.prototype.setMiddlePhonetic = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.middlePhonetic = __SLAG__PROPERTY;
+};
+Person.prototype.getModified = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.modified;
+};
+Person.prototype.getNickname = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nickname;
+};
+Person.prototype.setNickname = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nickname = __SLAG__PROPERTY;
+};
+Person.prototype.getNote = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.note;
+};
+Person.prototype.setNote = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.note = __SLAG__PROPERTY;
+};
+Person.prototype.getOrganization = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.organization;
+};
+Person.prototype.setOrganization = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.organization = __SLAG__PROPERTY;
+};
+Person.prototype.getPhone = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.phone;
+};
+Person.prototype.setPhone = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.phone = __SLAG__PROPERTY;
+};
+Person.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Person.prototype.getRecordId = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.recordId;
+};
+Person.prototype.setRecordId = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.recordId = __SLAG__PROPERTY;
+};
+Person.prototype.getRelatedNames = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.relatedNames;
+};
+Person.prototype.setRelatedNames = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.relatedNames = __SLAG__PROPERTY;
+};
+Person.prototype.getSuffix = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.suffix;
+};
+Person.prototype.getUrl = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+Person.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Person(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Database.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Database.js
@@ -1,0 +1,181 @@
+var crypto = require('crypto');
+function Database(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'FIELD_TYPE_DOUBLE',
+			'FIELD_TYPE_FLOAT',
+			'FIELD_TYPE_INT',
+			'FIELD_TYPE_STRING',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Database.apiName is read only property');
+	}
+	this.apiName = 'Ti.Database';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.FIELD_TYPE_DOUBLE) {
+		throw new Error('Ti.Database.FIELD_TYPE_DOUBLE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FIELD_TYPE_DOUBLE = undefined;
+	} else {
+		this.FIELD_TYPE_DOUBLE = 0;
+	}
+	if (__SLAG_PROPERTIES.FIELD_TYPE_FLOAT) {
+		throw new Error('Ti.Database.FIELD_TYPE_FLOAT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FIELD_TYPE_FLOAT = undefined;
+	} else {
+		this.FIELD_TYPE_FLOAT = 0;
+	}
+	if (__SLAG_PROPERTIES.FIELD_TYPE_INT) {
+		throw new Error('Ti.Database.FIELD_TYPE_INT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FIELD_TYPE_INT = undefined;
+	} else {
+		this.FIELD_TYPE_INT = 0;
+	}
+	if (__SLAG_PROPERTIES.FIELD_TYPE_STRING) {
+		throw new Error('Ti.Database.FIELD_TYPE_STRING is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FIELD_TYPE_STRING = undefined;
+	} else {
+		this.FIELD_TYPE_STRING = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Database.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Database.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Database.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Database.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Database.prototype.install = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Database.prototype.open = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var DB = require('./Database/DB');
+	return DB();
+};
+Database.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Database.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Database.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Database.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Database.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Database(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Database/DB.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Database/DB.js
@@ -1,0 +1,242 @@
+var crypto = require('crypto');
+function DB(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'file',
+			'lastInsertRowId',
+			'name',
+			'rowsAffected',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Database.DB.apiName is read only property');
+	}
+	this.apiName = 'Ti.Database.DB';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.file) {
+		throw new Error('Ti.Database.DB.file is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.file = undefined;
+	} else {
+		this.file = {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastInsertRowId = undefined;
+	} else {
+		this.lastInsertRowId = __SLAG_PROPERTIES.lastInsertRowId || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowsAffected = undefined;
+	} else {
+		this.rowsAffected = __SLAG_PROPERTIES.rowsAffected || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DB.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DB.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DB.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DB.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DB.prototype.close = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DB.prototype.execute = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ResultSet = require('./ResultSet');
+	return ResultSet();
+};
+DB.prototype.remove = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DB.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DB.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DB.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DB.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+DB.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+DB.prototype.getFile = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.file;
+};
+DB.prototype.getLastInsertRowId = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastInsertRowId;
+};
+DB.prototype.setLastInsertRowId = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lastInsertRowId = __SLAG__PROPERTY;
+};
+DB.prototype.getName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+DB.prototype.setName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.name = __SLAG__PROPERTY;
+};
+DB.prototype.getRowsAffected = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowsAffected;
+};
+DB.prototype.setRowsAffected = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rowsAffected = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DB(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Database/ResultSet.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Database/ResultSet.js
@@ -1,0 +1,242 @@
+var crypto = require('crypto');
+function ResultSet(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'fieldCount',
+			'rowCount',
+			'validRow',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Database.ResultSet.apiName is read only property');
+	}
+	this.apiName = 'Ti.Database.ResultSet';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.fieldCount) {
+		throw new Error('Ti.Database.ResultSet.fieldCount is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fieldCount = undefined;
+	} else {
+		this.fieldCount = 0;
+	}
+	if (__SLAG_PROPERTIES.rowCount) {
+		throw new Error('Ti.Database.ResultSet.rowCount is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowCount = undefined;
+	} else {
+		this.rowCount = 0;
+	}
+	if (__SLAG_PROPERTIES.validRow) {
+		throw new Error('Ti.Database.ResultSet.validRow is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.validRow = undefined;
+	} else {
+		this.validRow = true;
+	}
+	this.__SLAG_SIMULATE_IS_VALID_ROW = true;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ResultSet.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ResultSet.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ResultSet.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ResultSet.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ResultSet.prototype.close = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ResultSet.prototype.field = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+ResultSet.prototype.fieldByName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+ResultSet.prototype.fieldCount = function () {
+	throw new Error('Ti.Database.ResultSet.fieldCount was deprecated, since 3.3.0');
+};
+ResultSet.prototype.fieldName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+ResultSet.prototype.getFieldName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+ResultSet.prototype.isValidRow = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var __SLAG_SIMULATE_IS_VALID_ROW = this.__SLAG_SIMULATE_IS_VALID_ROW;
+	this.__SLAG_SIMULATE_IS_VALID_ROW = !this.__SLAG_SIMULATE_IS_VALID_ROW;
+	return __SLAG_SIMULATE_IS_VALID_ROW;
+};
+ResultSet.prototype.next = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+ResultSet.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ResultSet.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ResultSet.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ResultSet.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ResultSet.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ResultSet.prototype.getFieldCount = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fieldCount;
+};
+ResultSet.prototype.getRowCount = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowCount;
+};
+ResultSet.prototype.getValidRow = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.validRow;
+};
+module.exports = function (properties) {
+	return new ResultSet(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Event.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Event.js
@@ -1,0 +1,73 @@
+var crypto = require('crypto');
+function Event(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'source',
+			'type',
+			'bubbles',
+			'cancelBubble',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.source) {
+		throw new Error('Ti.Event.source is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = {};
+	}
+	if (__SLAG_PROPERTIES.type) {
+		throw new Error('Ti.Event.type is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = '';
+	}
+	if (__SLAG_PROPERTIES.bubbles) {
+		throw new Error('Ti.Event.bubbles is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbles = undefined;
+	} else {
+		this.bubbles = true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancelBubble = undefined;
+	} else {
+		this.cancelBubble = __SLAG_PROPERTIES.cancelBubble || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new Event(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Facebook.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Facebook.js
@@ -1,0 +1,402 @@
+var crypto = require('crypto');
+function Facebook(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'BUTTON_STYLE_NORMAL',
+			'BUTTON_STYLE_WIDE',
+			'accessToken',
+			'appid',
+			'expirationDate',
+			'forceDialogAuth',
+			'loggedIn',
+			'permissions',
+			'uid',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Facebook.apiName is read only property');
+	}
+	this.apiName = 'Ti.Facebook';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.BUTTON_STYLE_NORMAL) {
+		throw new Error('Ti.Facebook.BUTTON_STYLE_NORMAL is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BUTTON_STYLE_NORMAL = undefined;
+	} else {
+		this.BUTTON_STYLE_NORMAL = 0;
+	}
+	if (__SLAG_PROPERTIES.BUTTON_STYLE_WIDE) {
+		throw new Error('Ti.Facebook.BUTTON_STYLE_WIDE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BUTTON_STYLE_WIDE = undefined;
+	} else {
+		this.BUTTON_STYLE_WIDE = 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessToken = undefined;
+	} else {
+		this.accessToken = __SLAG_PROPERTIES.accessToken || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.appid = undefined;
+	} else {
+		this.appid = __SLAG_PROPERTIES.appid || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.expirationDate = undefined;
+	} else {
+		this.expirationDate = __SLAG_PROPERTIES.expirationDate || new Date();
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.forceDialogAuth = undefined;
+	} else {
+		this.forceDialogAuth = __SLAG_PROPERTIES.forceDialogAuth || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.loggedIn = undefined;
+	} else {
+		this.loggedIn = __SLAG_PROPERTIES.loggedIn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.permissions = undefined;
+	} else {
+		this.permissions = __SLAG_PROPERTIES.permissions || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.uid = undefined;
+	} else {
+		this.uid = __SLAG_PROPERTIES.uid || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Facebook.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Facebook.prototype.authorize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.dialog = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.logout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.request = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.requestWithGraphPath = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Facebook.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Facebook.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Facebook.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Facebook.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Facebook.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Facebook.prototype.getAccessToken = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessToken;
+};
+Facebook.prototype.setAccessToken = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessToken = __SLAG__PROPERTY;
+};
+Facebook.prototype.getAppid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.appid;
+};
+Facebook.prototype.setAppid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.appid = __SLAG__PROPERTY;
+};
+Facebook.prototype.getExpirationDate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.expirationDate;
+};
+Facebook.prototype.setExpirationDate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.expirationDate = __SLAG__PROPERTY;
+};
+Facebook.prototype.getForceDialogAuth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.forceDialogAuth;
+};
+Facebook.prototype.setForceDialogAuth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.forceDialogAuth = __SLAG__PROPERTY;
+};
+Facebook.prototype.getLoggedIn = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.loggedIn;
+};
+Facebook.prototype.setLoggedIn = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.loggedIn = __SLAG__PROPERTY;
+};
+Facebook.prototype.getPermissions = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.permissions;
+};
+Facebook.prototype.setPermissions = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.permissions = __SLAG__PROPERTY;
+};
+Facebook.prototype.getUid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.uid;
+};
+Facebook.prototype.setUid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.uid = __SLAG__PROPERTY;
+};
+Facebook.prototype.createLoginButton = function () {
+	throw new Error('Ti.Facebook.createLoginButton was deprecated, since 3.1.0');
+};
+module.exports = function (properties) {
+	return new Facebook(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Facebook/LoginButton.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Facebook/LoginButton.js
@@ -1,0 +1,1646 @@
+var crypto = require('crypto');
+function LoginButton(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'style',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Facebook.LoginButton.apiName is read only property');
+	}
+	this.apiName = 'Ti.Facebook.LoginButton';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.Facebook.LoginButton.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.Facebook.LoginButton.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.Facebook.LoginButton.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.Facebook.LoginButton.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+LoginButton.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+LoginButton.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+LoginButton.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.finishLayout = function () {
+	throw new Error('Ti.Facebook.LoginButton.finishLayout was deprecated, since 3.0.0');
+};
+LoginButton.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+LoginButton.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LoginButton.prototype.startLayout = function () {
+	throw new Error('Ti.Facebook.LoginButton.startLayout was deprecated, since 3.0.0');
+};
+LoginButton.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+LoginButton.prototype.updateLayout = function () {
+	throw new Error('Ti.Facebook.LoginButton.updateLayout was deprecated, since 3.0.0');
+};
+LoginButton.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+LoginButton.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+LoginButton.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+LoginButton.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+LoginButton.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+LoginButton.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+LoginButton.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+LoginButton.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+LoginButton.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+LoginButton.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+LoginButton.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+LoginButton.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+LoginButton.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+LoginButton.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+LoginButton.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+LoginButton.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+LoginButton.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+LoginButton.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+LoginButton.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+LoginButton.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+LoginButton.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+LoginButton.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+LoginButton.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+LoginButton.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+LoginButton.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+LoginButton.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+LoginButton.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+LoginButton.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+LoginButton.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+LoginButton.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+LoginButton.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+LoginButton.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+LoginButton.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+LoginButton.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+LoginButton.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+LoginButton.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+LoginButton.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+LoginButton.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+LoginButton.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+LoginButton.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+LoginButton.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+LoginButton.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+LoginButton.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+LoginButton.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+LoginButton.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+LoginButton.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+LoginButton.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+LoginButton.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+LoginButton.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+LoginButton.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+LoginButton.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+LoginButton.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+LoginButton.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+LoginButton.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+LoginButton.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+LoginButton.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+LoginButton.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+LoginButton.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+LoginButton.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+LoginButton.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+LoginButton.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+LoginButton.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+LoginButton.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+LoginButton.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+LoginButton.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+LoginButton.prototype.getStyle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+LoginButton.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new LoginButton(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Filesystem.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Filesystem.js
@@ -1,0 +1,464 @@
+var crypto = require('crypto');
+function Filesystem(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'MODE_APPEND',
+			'MODE_READ',
+			'MODE_WRITE',
+			'IOS_FILE_PROTECTION_NONE',
+			'IOS_FILE_PROTECTION_COMPLETE',
+			'IOS_FILE_PROTECTION_COMPLETE_UNLESS_OPEN',
+			'IOS_FILE_PROTECTION_COMPLETE_UNTIL_FIRST_USER_AUTHENTICATION',
+			'applicationCacheDirectory',
+			'applicationDataDirectory',
+			'applicationDirectory',
+			'applicationSupportDirectory',
+			'externalStorageDirectory',
+			'lineEnding',
+			'resourcesDirectory',
+			'resRawDirectory',
+			'separator',
+			'tempDirectory',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Filesystem.apiName is read only property');
+	}
+	this.apiName = 'Ti.Filesystem';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.MODE_APPEND) {
+		throw new Error('Ti.Filesystem.MODE_APPEND is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODE_APPEND = undefined;
+	} else {
+		this.MODE_APPEND = 0;
+	}
+	if (__SLAG_PROPERTIES.MODE_READ) {
+		throw new Error('Ti.Filesystem.MODE_READ is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODE_READ = undefined;
+	} else {
+		this.MODE_READ = 0;
+	}
+	if (__SLAG_PROPERTIES.MODE_WRITE) {
+		throw new Error('Ti.Filesystem.MODE_WRITE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODE_WRITE = undefined;
+	} else {
+		this.MODE_WRITE = 0;
+	}
+	if (__SLAG_PROPERTIES.IOS_FILE_PROTECTION_NONE) {
+		throw new Error('Ti.Filesystem.IOS_FILE_PROTECTION_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.IOS_FILE_PROTECTION_NONE = undefined;
+	} else {
+		this.IOS_FILE_PROTECTION_NONE = '';
+	}
+	if (__SLAG_PROPERTIES.IOS_FILE_PROTECTION_COMPLETE) {
+		throw new Error('Ti.Filesystem.IOS_FILE_PROTECTION_COMPLETE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.IOS_FILE_PROTECTION_COMPLETE = undefined;
+	} else {
+		this.IOS_FILE_PROTECTION_COMPLETE = '';
+	}
+	if (__SLAG_PROPERTIES.IOS_FILE_PROTECTION_COMPLETE_UNLESS_OPEN) {
+		throw new Error('Ti.Filesystem.IOS_FILE_PROTECTION_COMPLETE_UNLESS_OPEN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.IOS_FILE_PROTECTION_COMPLETE_UNLESS_OPEN = undefined;
+	} else {
+		this.IOS_FILE_PROTECTION_COMPLETE_UNLESS_OPEN = '';
+	}
+	if (__SLAG_PROPERTIES.IOS_FILE_PROTECTION_COMPLETE_UNTIL_FIRST_USER_AUTHENTICATION) {
+		throw new Error('Ti.Filesystem.IOS_FILE_PROTECTION_COMPLETE_UNTIL_FIRST_USER_AUTHENTICATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.IOS_FILE_PROTECTION_COMPLETE_UNTIL_FIRST_USER_AUTHENTICATION = undefined;
+	} else {
+		this.IOS_FILE_PROTECTION_COMPLETE_UNTIL_FIRST_USER_AUTHENTICATION = '';
+	}
+	if (__SLAG_PROPERTIES.applicationCacheDirectory) {
+		throw new Error('Ti.Filesystem.applicationCacheDirectory is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.applicationCacheDirectory = undefined;
+	} else {
+		this.applicationCacheDirectory = '';
+	}
+	if (__SLAG_PROPERTIES.applicationDataDirectory) {
+		throw new Error('Ti.Filesystem.applicationDataDirectory is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.applicationDataDirectory = undefined;
+	} else {
+		this.applicationDataDirectory = '';
+	}
+	if (__SLAG_PROPERTIES.applicationDirectory) {
+		throw new Error('Ti.Filesystem.applicationDirectory is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.applicationDirectory = undefined;
+	} else {
+		this.applicationDirectory = '';
+	}
+	if (__SLAG_PROPERTIES.applicationSupportDirectory) {
+		throw new Error('Ti.Filesystem.applicationSupportDirectory is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.applicationSupportDirectory = undefined;
+	} else {
+		this.applicationSupportDirectory = '';
+	}
+	if (__SLAG_PROPERTIES.externalStorageDirectory) {
+		throw new Error('Ti.Filesystem.externalStorageDirectory is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.externalStorageDirectory = undefined;
+	} else {
+		this.externalStorageDirectory = '';
+	}
+	if (__SLAG_PROPERTIES.lineEnding) {
+		throw new Error('Ti.Filesystem.lineEnding is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lineEnding = undefined;
+	} else {
+		this.lineEnding = '';
+	}
+	if (__SLAG_PROPERTIES.resourcesDirectory) {
+		throw new Error('Ti.Filesystem.resourcesDirectory is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.resourcesDirectory = undefined;
+	} else {
+		this.resourcesDirectory = '';
+	}
+	if (__SLAG_PROPERTIES.resRawDirectory) {
+		throw new Error('Ti.Filesystem.resRawDirectory is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.resRawDirectory = undefined;
+	} else {
+		this.resRawDirectory = '';
+	}
+	if (__SLAG_PROPERTIES.separator) {
+		throw new Error('Ti.Filesystem.separator is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.separator = undefined;
+	} else {
+		this.separator = '';
+	}
+	if (__SLAG_PROPERTIES.tempDirectory) {
+		throw new Error('Ti.Filesystem.tempDirectory is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tempDirectory = undefined;
+	} else {
+		this.tempDirectory = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Filesystem.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Filesystem.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Filesystem.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Filesystem.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Filesystem.prototype.createTempDirectory = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TempDirectory = require('./Filesystem/TempDirectory');
+	return TempDirectory(__SLAG_PROPERTY);
+};
+Filesystem.prototype.createTempFile = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TempFile = require('./Filesystem/TempFile');
+	return TempFile(__SLAG_PROPERTY);
+};
+Filesystem.prototype.getFile = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Filesystem.prototype.getAsset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Filesystem.prototype.isExternalStoragePresent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Filesystem.prototype.hasStoragePermissions = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Filesystem.prototype.requestStoragePermissions = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Filesystem.prototype.openStream = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Filesystem.prototype.directoryForSuite = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Filesystem.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Filesystem.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Filesystem.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Filesystem.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Filesystem.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Filesystem.prototype.getApplicationCacheDirectory = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.applicationCacheDirectory;
+};
+Filesystem.prototype.getApplicationDataDirectory = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.applicationDataDirectory;
+};
+Filesystem.prototype.getApplicationDirectory = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.applicationDirectory;
+};
+Filesystem.prototype.getApplicationSupportDirectory = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.applicationSupportDirectory;
+};
+Filesystem.prototype.getExternalStorageDirectory = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.externalStorageDirectory;
+};
+Filesystem.prototype.getLineEnding = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lineEnding;
+};
+Filesystem.prototype.getResourcesDirectory = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.resourcesDirectory;
+};
+Filesystem.prototype.getResRawDirectory = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.resRawDirectory;
+};
+Filesystem.prototype.getSeparator = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.separator;
+};
+Filesystem.prototype.getTempDirectory = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tempDirectory;
+};
+module.exports = function (properties) {
+	return new Filesystem(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Filesystem/File.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Filesystem/File.js
@@ -1,0 +1,575 @@
+var crypto = require('crypto');
+function File(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'executable',
+			'hidden',
+			'name',
+			'nativePath',
+			'parent',
+			'readonly',
+			'size',
+			'remoteBackup',
+			'symbolicLink',
+			'writable',
+			'writeable',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Filesystem.File.apiName is read only property');
+	}
+	this.apiName = 'Ti.Filesystem.File';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.executable) {
+		throw new Error('Ti.Filesystem.File.executable is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.executable = undefined;
+	} else {
+		this.executable = true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidden = undefined;
+	} else {
+		this.hidden = __SLAG_PROPERTIES.hidden || true;
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.Filesystem.File.name is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if (__SLAG_PROPERTIES.nativePath) {
+		throw new Error('Ti.Filesystem.File.nativePath is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nativePath = undefined;
+	} else {
+		this.nativePath = '';
+	}
+	if (__SLAG_PROPERTIES.parent) {
+		throw new Error('Ti.Filesystem.File.parent is read only property');
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parent = undefined;
+	} else {
+		this.parent = {};
+	}
+	if (__SLAG_PROPERTIES.readonly) {
+		throw new Error('Ti.Filesystem.File.readonly is read only property');
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.readonly = undefined;
+	} else {
+		this.readonly = true;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.Filesystem.File.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.remoteBackup = undefined;
+	} else {
+		this.remoteBackup = __SLAG_PROPERTIES.remoteBackup || true;
+	}
+	if (__SLAG_PROPERTIES.symbolicLink) {
+		throw new Error('Ti.Filesystem.File.symbolicLink is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.symbolicLink = undefined;
+	} else {
+		this.symbolicLink = true;
+	}
+	if (__SLAG_PROPERTIES.writable) {
+		throw new Error('Ti.Filesystem.File.writable is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.writable = undefined;
+	} else {
+		this.writable = true;
+	}
+	if (__SLAG_PROPERTIES.writeable) {
+		throw new Error('Ti.Filesystem.File.writeable was deprecated, since 1.8.1');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+File.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+File.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+File.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+File.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+File.prototype.append = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.copy = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.createDirectory = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Directory = require('./File/Directory');
+	return Directory(__SLAG_PROPERTY);
+};
+File.prototype.createFile = function (__SLAG_PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var File = require('./File/File');
+	return File(__SLAG_PROPERTY);
+};
+File.prototype.createTimestamp = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Timestamp = require('./File/Timestamp');
+	return Timestamp(__SLAG_PROPERTY);
+};
+File.prototype.deleteDirectory = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.deleteFile = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.exists = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.extension = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+File.prototype.getDirectoryListing = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+File.prototype.getParent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parent;
+};
+File.prototype.getProtectionKey = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+File.prototype.isDirectory = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.isFile = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.modificationTimestamp = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+File.prototype.move = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.open = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+File.prototype.read = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+File.prototype.rename = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.resolve = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+File.prototype.setProtectionKey = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.spaceAvailable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+File.prototype.write = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+File.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+File.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+File.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+File.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+File.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+File.prototype.getExecutable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.executable;
+};
+File.prototype.getHidden = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidden;
+};
+File.prototype.setHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidden = __SLAG__PROPERTY;
+};
+File.prototype.getName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+File.prototype.getNativePath = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nativePath;
+};
+File.prototype.getParent = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parent;
+};
+File.prototype.getReadonly = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.readonly;
+};
+File.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+File.prototype.getRemoteBackup = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.remoteBackup;
+};
+File.prototype.setRemoteBackup = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.remoteBackup = __SLAG__PROPERTY;
+};
+File.prototype.getSymbolicLink = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.symbolicLink;
+};
+File.prototype.getWritable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.writable;
+};
+File.prototype.getWriteable = function () {
+	throw new Error('Ti.Filesystem.File.getWriteable was deprecated, since 1.8.1');
+};
+module.exports = function (properties) {
+	return new File(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Filesystem/FileStream.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Filesystem/FileStream.js
@@ -1,0 +1,167 @@
+var crypto = require('crypto');
+function FileStream(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Filesystem.FileStream.apiName is read only property');
+	}
+	this.apiName = 'Ti.Filesystem.FileStream';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+FileStream.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FileStream.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FileStream.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FileStream.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+FileStream.prototype.read = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+FileStream.prototype.write = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+FileStream.prototype.isWritable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+FileStream.prototype.isReadable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+FileStream.prototype.close = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FileStream.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+FileStream.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+FileStream.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+FileStream.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+FileStream.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new FileStream(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Geolocation.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Geolocation.js
@@ -1,0 +1,734 @@
+var crypto = require('crypto');
+function Geolocation(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ACCURACY_BEST',
+			'ACCURACY_HUNDRED_METERS',
+			'ACCURACY_KILOMETER',
+			'ACCURACY_NEAREST_TEN_METERS',
+			'ACCURACY_THREE_KILOMETERS',
+			'ACCURACY_HIGH',
+			'ACCURACY_BEST_FOR_NAVIGATION',
+			'ACCURACY_LOW',
+			'AUTHORIZATION_AUTHORIZED',
+			'AUTHORIZATION_DENIED',
+			'AUTHORIZATION_RESTRICTED',
+			'AUTHORIZATION_UNKNOWN',
+			'AUTHORIZATION_ALWAYS',
+			'AUTHORIZATION_WHEN_IN_USE',
+			'ERROR_DENIED',
+			'ERROR_HEADING_FAILURE',
+			'ERROR_LOCATION_UNKNOWN',
+			'ERROR_NETWORK',
+			'ERROR_REGION_MONITORING_DELAYED',
+			'ERROR_REGION_MONITORING_DENIED',
+			'ERROR_REGION_MONITORING_FAILURE',
+			'ERROR_TIMEOUT',
+			'PROVIDER_GPS',
+			'PROVIDER_NETWORK',
+			'PROVIDER_PASSIVE',
+			'ACTIVITYTYPE_OTHER',
+			'ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION',
+			'ACTIVITYTYPE_FITNESS',
+			'ACTIVITYTYPE_OTHER_NAVIGATION',
+			'accuracy',
+			'distanceFilter',
+			'frequency',
+			'hasCompass',
+			'headingFilter',
+			'locationServicesAuthorization',
+			'locationServicesEnabled',
+			'preferredProvider',
+			'purpose',
+			'showCalibration',
+			'trackSignificantLocationChange',
+			'allowsBackgroundLocationUpdates',
+			'activityType',
+			'pauseLocationUpdateAutomatically',
+			'lastGeolocation',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Geolocation.apiName is read only property');
+	}
+	this.apiName = 'Ti.Geolocation';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_BEST) {
+		throw new Error('Ti.Geolocation.ACCURACY_BEST is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_BEST = undefined;
+	} else {
+		this.ACCURACY_BEST = 0;
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_HUNDRED_METERS) {
+		throw new Error('Ti.Geolocation.ACCURACY_HUNDRED_METERS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_HUNDRED_METERS = undefined;
+	} else {
+		this.ACCURACY_HUNDRED_METERS = 0;
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_KILOMETER) {
+		throw new Error('Ti.Geolocation.ACCURACY_KILOMETER is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_KILOMETER = undefined;
+	} else {
+		this.ACCURACY_KILOMETER = 0;
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_NEAREST_TEN_METERS) {
+		throw new Error('Ti.Geolocation.ACCURACY_NEAREST_TEN_METERS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_NEAREST_TEN_METERS = undefined;
+	} else {
+		this.ACCURACY_NEAREST_TEN_METERS = 0;
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_THREE_KILOMETERS) {
+		throw new Error('Ti.Geolocation.ACCURACY_THREE_KILOMETERS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_THREE_KILOMETERS = undefined;
+	} else {
+		this.ACCURACY_THREE_KILOMETERS = 0;
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_HIGH) {
+		throw new Error('Ti.Geolocation.ACCURACY_HIGH is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_HIGH = undefined;
+	} else {
+		this.ACCURACY_HIGH = 0;
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_BEST_FOR_NAVIGATION) {
+		throw new Error('Ti.Geolocation.ACCURACY_BEST_FOR_NAVIGATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_BEST_FOR_NAVIGATION = undefined;
+	} else {
+		this.ACCURACY_BEST_FOR_NAVIGATION = 0;
+	}
+	if (__SLAG_PROPERTIES.ACCURACY_LOW) {
+		throw new Error('Ti.Geolocation.ACCURACY_LOW is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACCURACY_LOW = undefined;
+	} else {
+		this.ACCURACY_LOW = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_AUTHORIZED) {
+		throw new Error('Ti.Geolocation.AUTHORIZATION_AUTHORIZED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_AUTHORIZED = undefined;
+	} else {
+		this.AUTHORIZATION_AUTHORIZED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_DENIED) {
+		throw new Error('Ti.Geolocation.AUTHORIZATION_DENIED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_DENIED = undefined;
+	} else {
+		this.AUTHORIZATION_DENIED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_RESTRICTED) {
+		throw new Error('Ti.Geolocation.AUTHORIZATION_RESTRICTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_RESTRICTED = undefined;
+	} else {
+		this.AUTHORIZATION_RESTRICTED = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_UNKNOWN) {
+		throw new Error('Ti.Geolocation.AUTHORIZATION_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_UNKNOWN = undefined;
+	} else {
+		this.AUTHORIZATION_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_ALWAYS) {
+		throw new Error('Ti.Geolocation.AUTHORIZATION_ALWAYS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_ALWAYS = undefined;
+	} else {
+		this.AUTHORIZATION_ALWAYS = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTHORIZATION_WHEN_IN_USE) {
+		throw new Error('Ti.Geolocation.AUTHORIZATION_WHEN_IN_USE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTHORIZATION_WHEN_IN_USE = undefined;
+	} else {
+		this.AUTHORIZATION_WHEN_IN_USE = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_DENIED) {
+		throw new Error('Ti.Geolocation.ERROR_DENIED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_DENIED = undefined;
+	} else {
+		this.ERROR_DENIED = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_HEADING_FAILURE) {
+		throw new Error('Ti.Geolocation.ERROR_HEADING_FAILURE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_HEADING_FAILURE = undefined;
+	} else {
+		this.ERROR_HEADING_FAILURE = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_LOCATION_UNKNOWN) {
+		throw new Error('Ti.Geolocation.ERROR_LOCATION_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_LOCATION_UNKNOWN = undefined;
+	} else {
+		this.ERROR_LOCATION_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_NETWORK) {
+		throw new Error('Ti.Geolocation.ERROR_NETWORK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_NETWORK = undefined;
+	} else {
+		this.ERROR_NETWORK = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_REGION_MONITORING_DELAYED) {
+		throw new Error('Ti.Geolocation.ERROR_REGION_MONITORING_DELAYED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_REGION_MONITORING_DELAYED = undefined;
+	} else {
+		this.ERROR_REGION_MONITORING_DELAYED = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_REGION_MONITORING_DENIED) {
+		throw new Error('Ti.Geolocation.ERROR_REGION_MONITORING_DENIED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_REGION_MONITORING_DENIED = undefined;
+	} else {
+		this.ERROR_REGION_MONITORING_DENIED = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_REGION_MONITORING_FAILURE) {
+		throw new Error('Ti.Geolocation.ERROR_REGION_MONITORING_FAILURE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_REGION_MONITORING_FAILURE = undefined;
+	} else {
+		this.ERROR_REGION_MONITORING_FAILURE = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR_TIMEOUT) {
+		throw new Error('Ti.Geolocation.ERROR_TIMEOUT is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR_TIMEOUT = undefined;
+	} else {
+		this.ERROR_TIMEOUT = 0;
+	}
+	if (__SLAG_PROPERTIES.PROVIDER_GPS) {
+		throw new Error('Ti.Geolocation.PROVIDER_GPS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROVIDER_GPS = undefined;
+	} else {
+		this.PROVIDER_GPS = '';
+	}
+	if (__SLAG_PROPERTIES.PROVIDER_NETWORK) {
+		throw new Error('Ti.Geolocation.PROVIDER_NETWORK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROVIDER_NETWORK = undefined;
+	} else {
+		this.PROVIDER_NETWORK = '';
+	}
+	if (__SLAG_PROPERTIES.PROVIDER_PASSIVE) {
+		throw new Error('Ti.Geolocation.PROVIDER_PASSIVE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROVIDER_PASSIVE = undefined;
+	} else {
+		this.PROVIDER_PASSIVE = '';
+	}
+	if (__SLAG_PROPERTIES.ACTIVITYTYPE_OTHER) {
+		throw new Error('Ti.Geolocation.ACTIVITYTYPE_OTHER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVITYTYPE_OTHER = undefined;
+	} else {
+		this.ACTIVITYTYPE_OTHER = '';
+	}
+	if (__SLAG_PROPERTIES.ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION) {
+		throw new Error('Ti.Geolocation.ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION = undefined;
+	} else {
+		this.ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION = '';
+	}
+	if (__SLAG_PROPERTIES.ACTIVITYTYPE_FITNESS) {
+		throw new Error('Ti.Geolocation.ACTIVITYTYPE_FITNESS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVITYTYPE_FITNESS = undefined;
+	} else {
+		this.ACTIVITYTYPE_FITNESS = '';
+	}
+	if (__SLAG_PROPERTIES.ACTIVITYTYPE_OTHER_NAVIGATION) {
+		throw new Error('Ti.Geolocation.ACTIVITYTYPE_OTHER_NAVIGATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVITYTYPE_OTHER_NAVIGATION = undefined;
+	} else {
+		this.ACTIVITYTYPE_OTHER_NAVIGATION = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accuracy = undefined;
+	} else {
+		this.accuracy = __SLAG_PROPERTIES.accuracy || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.distanceFilter = undefined;
+	} else {
+		this.distanceFilter = __SLAG_PROPERTIES.distanceFilter || 0;
+	}
+	if (__SLAG_PROPERTIES.frequency) {
+		throw new Error('Ti.Geolocation.frequency was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.hasCompass) {
+		throw new Error('Ti.Geolocation.hasCompass is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasCompass = undefined;
+	} else {
+		this.hasCompass = true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headingFilter = undefined;
+	} else {
+		this.headingFilter = __SLAG_PROPERTIES.headingFilter || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.locationServicesAuthorization = undefined;
+	} else {
+		this.locationServicesAuthorization = __SLAG_PROPERTIES.locationServicesAuthorization || 0;
+	}
+	if (__SLAG_PROPERTIES.locationServicesEnabled) {
+		throw new Error('Ti.Geolocation.locationServicesEnabled is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.locationServicesEnabled = undefined;
+	} else {
+		this.locationServicesEnabled = true;
+	}
+	if (__SLAG_PROPERTIES.preferredProvider) {
+		throw new Error('Ti.Geolocation.preferredProvider was deprecated, since 2.0.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.purpose = undefined;
+	} else {
+		this.purpose = __SLAG_PROPERTIES.purpose || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showCalibration = undefined;
+	} else {
+		this.showCalibration = __SLAG_PROPERTIES.showCalibration || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.trackSignificantLocationChange = undefined;
+	} else {
+		this.trackSignificantLocationChange = __SLAG_PROPERTIES.trackSignificantLocationChange || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsBackgroundLocationUpdates = undefined;
+	} else {
+		this.allowsBackgroundLocationUpdates = __SLAG_PROPERTIES.allowsBackgroundLocationUpdates || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityType = undefined;
+	} else {
+		this.activityType = __SLAG_PROPERTIES.activityType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pauseLocationUpdateAutomatically = undefined;
+	} else {
+		this.pauseLocationUpdateAutomatically = __SLAG_PROPERTIES.pauseLocationUpdateAutomatically || true;
+	}
+	if (__SLAG_PROPERTIES.lastGeolocation) {
+		throw new Error('Ti.Geolocation.lastGeolocation is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastGeolocation = undefined;
+	} else {
+		this.lastGeolocation = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Geolocation.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Geolocation.prototype.forwardGeocoder = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.getCurrentHeading = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.getCurrentPosition = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.hasLocationPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Geolocation.prototype.requestLocationPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.reverseGeocoder = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Geolocation.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Geolocation.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Geolocation.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Geolocation.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getAccuracy = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accuracy;
+};
+Geolocation.prototype.setAccuracy = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accuracy = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getDistanceFilter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.distanceFilter;
+};
+Geolocation.prototype.setDistanceFilter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.distanceFilter = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getFrequency = function () {
+	throw new Error('Ti.Geolocation.getFrequency was deprecated, since 2.0.0');
+};
+Geolocation.prototype.setFrequency = function () {
+	throw new Error('Ti.Geolocation.setFrequency was deprecated, since 2.0.0');
+};
+Geolocation.prototype.getHasCompass = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasCompass;
+};
+Geolocation.prototype.getHeadingFilter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headingFilter;
+};
+Geolocation.prototype.setHeadingFilter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headingFilter = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getLocationServicesAuthorization = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.locationServicesAuthorization;
+};
+Geolocation.prototype.setLocationServicesAuthorization = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.locationServicesAuthorization = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getLocationServicesEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.locationServicesEnabled;
+};
+Geolocation.prototype.getPreferredProvider = function () {
+	throw new Error('Ti.Geolocation.getPreferredProvider was deprecated, since 2.0.0');
+};
+Geolocation.prototype.setPreferredProvider = function () {
+	throw new Error('Ti.Geolocation.setPreferredProvider was deprecated, since 2.0.0');
+};
+Geolocation.prototype.getPurpose = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.purpose;
+};
+Geolocation.prototype.setPurpose = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.purpose = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getShowCalibration = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showCalibration;
+};
+Geolocation.prototype.setShowCalibration = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showCalibration = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getTrackSignificantLocationChange = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.trackSignificantLocationChange;
+};
+Geolocation.prototype.setTrackSignificantLocationChange = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.trackSignificantLocationChange = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getAllowsBackgroundLocationUpdates = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsBackgroundLocationUpdates;
+};
+Geolocation.prototype.setAllowsBackgroundLocationUpdates = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsBackgroundLocationUpdates = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getActivityType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activityType;
+};
+Geolocation.prototype.setActivityType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activityType = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getPauseLocationUpdateAutomatically = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pauseLocationUpdateAutomatically;
+};
+Geolocation.prototype.setPauseLocationUpdateAutomatically = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pauseLocationUpdateAutomatically = __SLAG__PROPERTY;
+};
+Geolocation.prototype.getLastGeolocation = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastGeolocation;
+};
+module.exports = function (properties) {
+	return new Geolocation(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Geolocation/Android.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Geolocation/Android.js
@@ -1,0 +1,145 @@
+var crypto = require('crypto');
+function Android(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'manualMode',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Geolocation.Android.apiName is read only property');
+	}
+	this.apiName = 'Ti.Geolocation.Android';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.manualMode = undefined;
+	} else {
+		this.manualMode = __SLAG_PROPERTIES.manualMode || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Android.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Android.prototype.addLocationProvider = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeLocationProvider = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.addLocationRule = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeLocationRule = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Android.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Android.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Android.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Android.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Android.prototype.getManualMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.manualMode;
+};
+Android.prototype.setManualMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.manualMode = __SLAG__PROPERTY;
+};
+Android.prototype.createLocationProvider = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var LocationProvider = require('./Android/LocationProvider');
+	return LocationProvider(__SLAG_PROPERTY);
+};
+Android.prototype.createLocationRule = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var LocationRule = require('./Android/LocationRule');
+	return LocationRule(__SLAG_PROPERTY);
+};
+module.exports = function (properties) {
+	return new Android(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Geolocation/Android/LocationProvider.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Geolocation/Android/LocationProvider.js
@@ -1,0 +1,147 @@
+var crypto = require('crypto');
+function LocationProvider(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'name',
+			'minUpdateTime',
+			'minUpdateDistance',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Geolocation.Android.LocationProvider.apiName is read only property');
+	}
+	this.apiName = 'Ti.Geolocation.Android.LocationProvider';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minUpdateTime = undefined;
+	} else {
+		this.minUpdateTime = __SLAG_PROPERTIES.minUpdateTime || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minUpdateDistance = undefined;
+	} else {
+		this.minUpdateDistance = __SLAG_PROPERTIES.minUpdateDistance || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+LocationProvider.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocationProvider.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocationProvider.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocationProvider.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+LocationProvider.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+LocationProvider.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+LocationProvider.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+LocationProvider.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+LocationProvider.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+LocationProvider.prototype.getName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+LocationProvider.prototype.setName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.name = __SLAG__PROPERTY;
+};
+LocationProvider.prototype.getMinUpdateTime = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minUpdateTime;
+};
+LocationProvider.prototype.setMinUpdateTime = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minUpdateTime = __SLAG__PROPERTY;
+};
+LocationProvider.prototype.getMinUpdateDistance = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minUpdateDistance;
+};
+LocationProvider.prototype.setMinUpdateDistance = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minUpdateDistance = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new LocationProvider(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Geolocation/Android/LocationRule.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Geolocation/Android/LocationRule.js
@@ -1,0 +1,165 @@
+var crypto = require('crypto');
+function LocationRule(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'name',
+			'accuracy',
+			'minAge',
+			'maxAge',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Geolocation.Android.LocationRule.apiName is read only property');
+	}
+	this.apiName = 'Ti.Geolocation.Android.LocationRule';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accuracy = undefined;
+	} else {
+		this.accuracy = __SLAG_PROPERTIES.accuracy || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minAge = undefined;
+	} else {
+		this.minAge = __SLAG_PROPERTIES.minAge || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxAge = undefined;
+	} else {
+		this.maxAge = __SLAG_PROPERTIES.maxAge || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+LocationRule.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocationRule.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocationRule.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LocationRule.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+LocationRule.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+LocationRule.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+LocationRule.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+LocationRule.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+LocationRule.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+LocationRule.prototype.getName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+LocationRule.prototype.setName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.name = __SLAG__PROPERTY;
+};
+LocationRule.prototype.getAccuracy = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accuracy;
+};
+LocationRule.prototype.setAccuracy = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accuracy = __SLAG__PROPERTY;
+};
+LocationRule.prototype.getMinAge = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minAge;
+};
+LocationRule.prototype.setMinAge = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minAge = __SLAG__PROPERTY;
+};
+LocationRule.prototype.getMaxAge = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxAge;
+};
+LocationRule.prototype.setMaxAge = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxAge = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new LocationRule(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Geolocation/MobileWeb.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Geolocation/MobileWeb.js
@@ -1,0 +1,147 @@
+var crypto = require('crypto');
+function MobileWeb(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'locationTimeout',
+			'maximumLocationAge',
+			'maximumHeadingAge',
+			'forwardGeocoderTimeout',
+			'reverseGeocoderTimeout',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Geolocation.MobileWeb.apiName is read only property');
+	}
+	this.apiName = 'Ti.Geolocation.MobileWeb';
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.locationTimeout = undefined;
+	} else {
+		this.locationTimeout = __SLAG_PROPERTIES.locationTimeout || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maximumLocationAge = undefined;
+	} else {
+		this.maximumLocationAge = __SLAG_PROPERTIES.maximumLocationAge || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maximumHeadingAge = undefined;
+	} else {
+		this.maximumHeadingAge = __SLAG_PROPERTIES.maximumHeadingAge || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.forwardGeocoderTimeout = undefined;
+	} else {
+		this.forwardGeocoderTimeout = __SLAG_PROPERTIES.forwardGeocoderTimeout || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.reverseGeocoderTimeout = undefined;
+	} else {
+		this.reverseGeocoderTimeout = __SLAG_PROPERTIES.reverseGeocoderTimeout || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+MobileWeb.prototype.addEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MobileWeb.prototype.removeEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MobileWeb.prototype.fireEvent = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MobileWeb.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+MobileWeb.prototype.getApiName = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+MobileWeb.prototype.getLocationTimeout = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.locationTimeout;
+};
+MobileWeb.prototype.setLocationTimeout = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.locationTimeout = __SLAG__PROPERTY;
+};
+MobileWeb.prototype.getMaximumLocationAge = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maximumLocationAge;
+};
+MobileWeb.prototype.setMaximumLocationAge = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maximumLocationAge = __SLAG__PROPERTY;
+};
+MobileWeb.prototype.getMaximumHeadingAge = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maximumHeadingAge;
+};
+MobileWeb.prototype.setMaximumHeadingAge = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maximumHeadingAge = __SLAG__PROPERTY;
+};
+MobileWeb.prototype.getForwardGeocoderTimeout = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.forwardGeocoderTimeout;
+};
+MobileWeb.prototype.setForwardGeocoderTimeout = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.forwardGeocoderTimeout = __SLAG__PROPERTY;
+};
+MobileWeb.prototype.getReverseGeocoderTimeout = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.reverseGeocoderTimeout;
+};
+MobileWeb.prototype.setReverseGeocoderTimeout = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.reverseGeocoderTimeout = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new MobileWeb(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Gesture.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Gesture.js
@@ -1,0 +1,197 @@
+var crypto = require('crypto');
+function Gesture(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'portrait',
+			'landscape',
+			'orientation',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Gesture.apiName is read only property');
+	}
+	this.apiName = 'Ti.Gesture';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.portrait) {
+		throw new Error('Ti.Gesture.portrait is read only property');
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.portrait = undefined;
+	} else {
+		this.portrait = true;
+	}
+	if (__SLAG_PROPERTIES.landscape) {
+		throw new Error('Ti.Gesture.landscape is read only property');
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.landscape = undefined;
+	} else {
+		this.landscape = true;
+	}
+	if (__SLAG_PROPERTIES.orientation) {
+		throw new Error('Ti.Gesture.orientation is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientation = undefined;
+	} else {
+		this.orientation = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Gesture.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Gesture.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Gesture.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Gesture.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Gesture.prototype.getLandscape = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.landscape;
+};
+Gesture.prototype.getPortrait = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.portrait;
+};
+Gesture.prototype.isLandscape = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Gesture.prototype.isPortrait = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Gesture.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Gesture.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Gesture.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Gesture.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Gesture.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Gesture.prototype.getOrientation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientation;
+};
+module.exports = function (properties) {
+	return new Gesture(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/IOStream.js
+++ b/lib/titanium/6.0.4.GA/Titanium/IOStream.js
@@ -1,0 +1,167 @@
+var crypto = require('crypto');
+function IOStream(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.IOStream.apiName is read only property');
+	}
+	this.apiName = 'Ti.IOStream';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+IOStream.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+IOStream.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+IOStream.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+IOStream.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+IOStream.prototype.read = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+IOStream.prototype.write = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+IOStream.prototype.isWritable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+IOStream.prototype.isReadable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+IOStream.prototype.close = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+IOStream.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+IOStream.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+IOStream.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+IOStream.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+IOStream.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new IOStream(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Locale.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Locale.js
@@ -1,0 +1,230 @@
+var crypto = require('crypto');
+function Locale(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'currentCountry',
+			'currentLanguage',
+			'currentLocale',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Locale.apiName is read only property');
+	}
+	this.apiName = 'Ti.Locale';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.currentCountry) {
+		throw new Error('Ti.Locale.currentCountry is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentCountry = undefined;
+	} else {
+		this.currentCountry = '';
+	}
+	if (__SLAG_PROPERTIES.currentLanguage) {
+		throw new Error('Ti.Locale.currentLanguage is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentLanguage = undefined;
+	} else {
+		this.currentLanguage = '';
+	}
+	if (__SLAG_PROPERTIES.currentLocale) {
+		throw new Error('Ti.Locale.currentLocale is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentLocale = undefined;
+	} else {
+		this.currentLocale = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Locale.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Locale.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Locale.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Locale.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Locale.prototype.formatTelephoneNumber = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Locale.prototype.getCurrencyCode = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Locale.prototype.getCurrencySymbol = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Locale.prototype.getLocaleCurrencySymbol = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Locale.prototype.getString = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Locale.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Locale.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Locale.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Locale.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Locale.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Locale.prototype.getCurrentCountry = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentCountry;
+};
+Locale.prototype.getCurrentLanguage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentLanguage;
+};
+Locale.prototype.getCurrentLocale = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentLocale;
+};
+module.exports = function (properties) {
+	return new Locale(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Map.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Map.js
@@ -1,0 +1,256 @@
+var crypto = require('crypto');
+function Map(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ANNOTATION_DRAG_STATE_NONE',
+			'ANNOTATION_DRAG_STATE_START',
+			'ANNOTATION_DRAG_STATE_DRAG',
+			'ANNOTATION_DRAG_STATE_CANCEL',
+			'ANNOTATION_DRAG_STATE_END',
+			'ANNOTATION_GREEN',
+			'ANNOTATION_PURPLE',
+			'ANNOTATION_RED',
+			'HYBRID_TYPE',
+			'SATELLITE_TYPE',
+			'STANDARD_TYPE',
+			'TERRAIN_TYPE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Map.apiName is read only property');
+	}
+	this.apiName = 'Ti.Map';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_DRAG_STATE_NONE) {
+		throw new Error('Ti.Map.ANNOTATION_DRAG_STATE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_DRAG_STATE_NONE = undefined;
+	} else {
+		this.ANNOTATION_DRAG_STATE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_DRAG_STATE_START) {
+		throw new Error('Ti.Map.ANNOTATION_DRAG_STATE_START is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_DRAG_STATE_START = undefined;
+	} else {
+		this.ANNOTATION_DRAG_STATE_START = 0;
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_DRAG_STATE_DRAG) {
+		throw new Error('Ti.Map.ANNOTATION_DRAG_STATE_DRAG is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_DRAG_STATE_DRAG = undefined;
+	} else {
+		this.ANNOTATION_DRAG_STATE_DRAG = 0;
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_DRAG_STATE_CANCEL) {
+		throw new Error('Ti.Map.ANNOTATION_DRAG_STATE_CANCEL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_DRAG_STATE_CANCEL = undefined;
+	} else {
+		this.ANNOTATION_DRAG_STATE_CANCEL = 0;
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_DRAG_STATE_END) {
+		throw new Error('Ti.Map.ANNOTATION_DRAG_STATE_END is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_DRAG_STATE_END = undefined;
+	} else {
+		this.ANNOTATION_DRAG_STATE_END = 0;
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_GREEN) {
+		throw new Error('Ti.Map.ANNOTATION_GREEN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_GREEN = undefined;
+	} else {
+		this.ANNOTATION_GREEN = 0;
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_PURPLE) {
+		throw new Error('Ti.Map.ANNOTATION_PURPLE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_PURPLE = undefined;
+	} else {
+		this.ANNOTATION_PURPLE = 0;
+	}
+	if (__SLAG_PROPERTIES.ANNOTATION_RED) {
+		throw new Error('Ti.Map.ANNOTATION_RED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANNOTATION_RED = undefined;
+	} else {
+		this.ANNOTATION_RED = 0;
+	}
+	if (__SLAG_PROPERTIES.HYBRID_TYPE) {
+		throw new Error('Ti.Map.HYBRID_TYPE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.HYBRID_TYPE = undefined;
+	} else {
+		this.HYBRID_TYPE = 0;
+	}
+	if (__SLAG_PROPERTIES.SATELLITE_TYPE) {
+		throw new Error('Ti.Map.SATELLITE_TYPE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SATELLITE_TYPE = undefined;
+	} else {
+		this.SATELLITE_TYPE = 0;
+	}
+	if (__SLAG_PROPERTIES.STANDARD_TYPE) {
+		throw new Error('Ti.Map.STANDARD_TYPE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STANDARD_TYPE = undefined;
+	} else {
+		this.STANDARD_TYPE = 0;
+	}
+	if (__SLAG_PROPERTIES.TERRAIN_TYPE) {
+		throw new Error('Ti.Map.TERRAIN_TYPE is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TERRAIN_TYPE = undefined;
+	} else {
+		this.TERRAIN_TYPE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Map.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Map.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Map.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Map.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Map.prototype.createAnnotation = function () {
+	throw new Error('Ti.Map.createAnnotation was deprecated, since 3.2.0');
+};
+Map.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Map.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Map.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Map.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Map.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Map.prototype.createView = function () {
+	throw new Error('Ti.Map.createView was deprecated, since 3.2.0');
+};
+module.exports = function (properties) {
+	return new Map(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Map/Annotation.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Map/Annotation.js
@@ -1,0 +1,587 @@
+var crypto = require('crypto');
+function Annotation(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'animate',
+			'canShowCallout',
+			'centerOffset',
+			'customView',
+			'draggable',
+			'image',
+			'latitude',
+			'longitude',
+			'leftButton',
+			'leftView',
+			'pinImage',
+			'pincolor',
+			'rightButton',
+			'rightView',
+			'subtitle',
+			'subtitleid',
+			'title',
+			'titleid',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Map.Annotation.apiName is read only property');
+	}
+	this.apiName = 'Ti.Map.Annotation';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animate = undefined;
+	} else {
+		this.animate = __SLAG_PROPERTIES.animate || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canShowCallout = undefined;
+	} else {
+		this.canShowCallout = __SLAG_PROPERTIES.canShowCallout || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.centerOffset = undefined;
+	} else {
+		this.centerOffset = __SLAG_PROPERTIES.centerOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.customView = undefined;
+	} else {
+		this.customView = __SLAG_PROPERTIES.customView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.draggable = undefined;
+	} else {
+		this.draggable = __SLAG_PROPERTIES.draggable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitude = undefined;
+	} else {
+		this.latitude = __SLAG_PROPERTIES.latitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitude = undefined;
+	} else {
+		this.longitude = __SLAG_PROPERTIES.longitude || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftButton = undefined;
+	} else {
+		this.leftButton = __SLAG_PROPERTIES.leftButton || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftView = undefined;
+	} else {
+		this.leftView = __SLAG_PROPERTIES.leftView || {};
+	}
+	if (__SLAG_PROPERTIES.pinImage) {
+		throw new Error('Ti.Map.Annotation.pinImage was deprecated, since 1.4');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pincolor = undefined;
+	} else {
+		this.pincolor = __SLAG_PROPERTIES.pincolor || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightButton = undefined;
+	} else {
+		this.rightButton = __SLAG_PROPERTIES.rightButton || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightView = undefined;
+	} else {
+		this.rightView = __SLAG_PROPERTIES.rightView || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subtitle = undefined;
+	} else {
+		this.subtitle = __SLAG_PROPERTIES.subtitle || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subtitleid = undefined;
+	} else {
+		this.subtitleid = __SLAG_PROPERTIES.subtitleid || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Annotation.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Annotation.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Annotation.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Annotation.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Annotation.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Annotation.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Annotation.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Annotation.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Annotation.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Annotation.prototype.getAnimate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animate;
+};
+Annotation.prototype.setAnimate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.animate = __SLAG__PROPERTY;
+};
+Annotation.prototype.getCanShowCallout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.canShowCallout;
+};
+Annotation.prototype.setCanShowCallout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.canShowCallout = __SLAG__PROPERTY;
+};
+Annotation.prototype.getCenterOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.centerOffset;
+};
+Annotation.prototype.setCenterOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.centerOffset = __SLAG__PROPERTY;
+};
+Annotation.prototype.getCustomView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.customView;
+};
+Annotation.prototype.setCustomView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.customView = __SLAG__PROPERTY;
+};
+Annotation.prototype.getDraggable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.draggable;
+};
+Annotation.prototype.setDraggable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.draggable = __SLAG__PROPERTY;
+};
+Annotation.prototype.getImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.image;
+};
+Annotation.prototype.setImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.image = __SLAG__PROPERTY;
+};
+Annotation.prototype.getLatitude = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.latitude;
+};
+Annotation.prototype.setLatitude = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.latitude = __SLAG__PROPERTY;
+};
+Annotation.prototype.getLongitude = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.longitude;
+};
+Annotation.prototype.setLongitude = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.longitude = __SLAG__PROPERTY;
+};
+Annotation.prototype.getLeftButton = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftButton;
+};
+Annotation.prototype.setLeftButton = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftButton = __SLAG__PROPERTY;
+};
+Annotation.prototype.getLeftView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftView;
+};
+Annotation.prototype.setLeftView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftView = __SLAG__PROPERTY;
+};
+Annotation.prototype.getPinImage = function () {
+	throw new Error('Ti.Map.Annotation.getPinImage was deprecated, since 1.4');
+};
+Annotation.prototype.setPinImage = function () {
+	throw new Error('Ti.Map.Annotation.setPinImage was deprecated, since 1.4');
+};
+Annotation.prototype.getPincolor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pincolor;
+};
+Annotation.prototype.setPincolor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pincolor = __SLAG__PROPERTY;
+};
+Annotation.prototype.getRightButton = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightButton;
+};
+Annotation.prototype.setRightButton = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightButton = __SLAG__PROPERTY;
+};
+Annotation.prototype.getRightView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightView;
+};
+Annotation.prototype.setRightView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightView = __SLAG__PROPERTY;
+};
+Annotation.prototype.getSubtitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.subtitle;
+};
+Annotation.prototype.setSubtitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.subtitle = __SLAG__PROPERTY;
+};
+Annotation.prototype.getSubtitleid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.subtitleid;
+};
+Annotation.prototype.setSubtitleid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.subtitleid = __SLAG__PROPERTY;
+};
+Annotation.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+Annotation.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+Annotation.prototype.getTitleid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+Annotation.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Annotation(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Map/View.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Map/View.js
@@ -1,0 +1,1974 @@
+var crypto = require('crypto');
+function View(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'animate',
+			'animated',
+			'annotations',
+			'hideAnnotationWhenTouchMap',
+			'mapType',
+			'region',
+			'regionFit',
+			'userLocation',
+			'latitudeDelta',
+			'longitudeDelta',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Map.View.apiName is read only property');
+	}
+	this.apiName = 'Ti.Map.View';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.Map.View.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.Map.View.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.Map.View.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.Map.View.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animate = undefined;
+	} else {
+		this.animate = __SLAG_PROPERTIES.animate || true;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.annotations = undefined;
+	} else {
+		this.annotations = __SLAG_PROPERTIES.annotations || [];
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hideAnnotationWhenTouchMap = undefined;
+	} else {
+		this.hideAnnotationWhenTouchMap = __SLAG_PROPERTIES.hideAnnotationWhenTouchMap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mapType = undefined;
+	} else {
+		this.mapType = __SLAG_PROPERTIES.mapType || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.region = undefined;
+	} else {
+		this.region = __SLAG_PROPERTIES.region || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.regionFit = undefined;
+	} else {
+		this.regionFit = __SLAG_PROPERTIES.regionFit || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.userLocation = undefined;
+	} else {
+		this.userLocation = __SLAG_PROPERTIES.userLocation || true;
+	}
+	if (__SLAG_PROPERTIES.latitudeDelta) {
+		throw new Error('Ti.Map.View.latitudeDelta is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.latitudeDelta = undefined;
+	} else {
+		this.latitudeDelta = 0;
+	}
+	if (__SLAG_PROPERTIES.longitudeDelta) {
+		throw new Error('Ti.Map.View.longitudeDelta is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.longitudeDelta = undefined;
+	} else {
+		this.longitudeDelta = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+View.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+View.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+View.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.finishLayout = function () {
+	throw new Error('Ti.Map.View.finishLayout was deprecated, since 3.0.0');
+};
+View.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+View.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.startLayout = function () {
+	throw new Error('Ti.Map.View.startLayout was deprecated, since 3.0.0');
+};
+View.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+View.prototype.updateLayout = function () {
+	throw new Error('Ti.Map.View.updateLayout was deprecated, since 3.0.0');
+};
+View.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+View.prototype.addAnnotation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.addAnnotations = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.addRoute = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.deselectAnnotation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.removeAllAnnotations = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.removeAnnotation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.removeAnnotations = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.removeRoute = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.selectAnnotation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.setLocation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.setMapType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mapType = __SLAG__PROPERTY;
+};
+View.prototype.zoom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+View.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+View.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+View.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+View.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+View.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+View.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+View.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+View.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+View.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+View.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+View.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+View.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+View.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+View.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+View.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+View.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+View.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+View.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+View.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+View.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+View.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+View.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+View.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+View.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+View.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+View.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+View.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+View.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+View.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+View.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+View.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+View.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+View.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+View.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+View.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+View.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+View.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+View.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+View.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+View.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+View.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+View.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+View.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+View.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+View.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+View.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+View.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+View.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+View.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+View.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+View.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+View.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+View.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+View.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+View.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+View.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+View.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+View.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+View.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+View.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+View.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+View.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+View.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+View.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+View.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+View.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+View.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+View.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+View.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+View.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+View.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+View.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+View.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+View.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+View.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+View.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+View.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+View.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+View.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+View.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+View.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+View.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+View.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+View.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+View.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+View.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+View.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+View.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+View.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+View.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+View.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+View.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+View.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+View.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+View.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+View.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+View.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+View.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+View.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+View.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+View.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+View.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+View.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+View.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+View.prototype.getAnimate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animate;
+};
+View.prototype.setAnimate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.animate = __SLAG__PROPERTY;
+};
+View.prototype.getAnimated = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animated;
+};
+View.prototype.setAnimated = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.animated = __SLAG__PROPERTY;
+};
+View.prototype.getAnnotations = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.annotations;
+};
+View.prototype.setAnnotations = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.annotations = __SLAG__PROPERTY;
+};
+View.prototype.getHideAnnotationWhenTouchMap = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hideAnnotationWhenTouchMap;
+};
+View.prototype.setHideAnnotationWhenTouchMap = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hideAnnotationWhenTouchMap = __SLAG__PROPERTY;
+};
+View.prototype.getMapType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mapType;
+};
+View.prototype.setMapType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mapType = __SLAG__PROPERTY;
+};
+View.prototype.getRegion = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.region;
+};
+View.prototype.setRegion = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.region = __SLAG__PROPERTY;
+};
+View.prototype.getRegionFit = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.regionFit;
+};
+View.prototype.setRegionFit = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.regionFit = __SLAG__PROPERTY;
+};
+View.prototype.getUserLocation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.userLocation;
+};
+View.prototype.setUserLocation = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.userLocation = __SLAG__PROPERTY;
+};
+View.prototype.getLatitudeDelta = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.latitudeDelta;
+};
+View.prototype.getLongitudeDelta = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.longitudeDelta;
+};
+module.exports = function (properties) {
+	return new View(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media.js
@@ -1,0 +1,1943 @@
+var crypto = require('crypto');
+function Media(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'AUDIO_FILEFORMAT_3GP2',
+			'AUDIO_FILEFORMAT_3GPP',
+			'AUDIO_FILEFORMAT_AIFF',
+			'AUDIO_FILEFORMAT_AMR',
+			'AUDIO_FILEFORMAT_CAF',
+			'AUDIO_FILEFORMAT_MP3',
+			'AUDIO_FILEFORMAT_MP4',
+			'AUDIO_FILEFORMAT_MP4A',
+			'AUDIO_FILEFORMAT_WAVE',
+			'AUDIO_FORMAT_AAC',
+			'AUDIO_FORMAT_ALAW',
+			'AUDIO_FORMAT_APPLE_LOSSLESS',
+			'AUDIO_FORMAT_ILBC',
+			'AUDIO_FORMAT_IMA4',
+			'AUDIO_FORMAT_LINEAR_PCM',
+			'AUDIO_FORMAT_ULAW',
+			'AUDIO_HEADPHONES',
+			'AUDIO_HEADPHONES_AND_MIC',
+			'AUDIO_HEADSET_INOUT',
+			'AUDIO_LINEOUT',
+			'AUDIO_MICROPHONE',
+			'AUDIO_MUTED',
+			'AUDIO_RECEIVER_AND_MIC',
+			'AUDIO_SESSION_CATEGORY_AMBIENT',
+			'AUDIO_SESSION_CATEGORY_PLAYBACK',
+			'AUDIO_SESSION_CATEGORY_PLAY_AND_RECORD',
+			'AUDIO_SESSION_CATEGORY_RECORD',
+			'AUDIO_SESSION_CATEGORY_SOLO_AMBIENT',
+			'AUDIO_SESSION_MODE_AMBIENT',
+			'AUDIO_SESSION_MODE_PLAYBACK',
+			'AUDIO_SESSION_MODE_PLAY_AND_RECORD',
+			'AUDIO_SESSION_MODE_RECORD',
+			'AUDIO_SESSION_MODE_SOLO_AMBIENT',
+			'AUDIO_SESSION_OVERRIDE_ROUTE_NONE',
+			'AUDIO_SESSION_OVERRIDE_ROUTE_SPEAKER',
+			'AUDIO_SESSION_PORT_LINEIN',
+			'AUDIO_SESSION_PORT_BUILTINMIC',
+			'AUDIO_SESSION_PORT_HEADSETMIC',
+			'AUDIO_SESSION_PORT_LINEOUT',
+			'AUDIO_SESSION_PORT_HEADPHONES',
+			'AUDIO_SESSION_PORT_BLUETOOTHA2DP',
+			'AUDIO_SESSION_PORT_BUILTINRECEIVER',
+			'AUDIO_SESSION_PORT_BUILTINSPEAKER',
+			'AUDIO_SESSION_PORT_HDMI',
+			'AUDIO_SESSION_PORT_AIRPLAY',
+			'AUDIO_SESSION_PORT_BLUETOOTHHFP',
+			'AUDIO_SESSION_PORT_USBAUDIO',
+			'AUDIO_SESSION_PORT_BLUETOOTHLE',
+			'AUDIO_SESSION_PORT_CARAUDIO',
+			'AUDIO_SPEAKER',
+			'AUDIO_UNAVAILABLE',
+			'AUDIO_UNKNOWN',
+			'CAMERA_FLASH_AUTO',
+			'CAMERA_FLASH_OFF',
+			'CAMERA_FLASH_ON',
+			'CAMERA_FRONT',
+			'CAMERA_REAR',
+			'CAMERA_AUTHORIZATION_AUTHORIZED',
+			'CAMERA_AUTHORIZATION_DENIED',
+			'CAMERA_AUTHORIZATION_RESTRICTED',
+			'CAMERA_AUTHORIZATION_NOT_DETERMINED',
+			'CAMERA_AUTHORIZATION_UNKNOWN',
+			'DEVICE_BUSY',
+			'MEDIA_TYPE_PHOTO',
+			'MEDIA_TYPE_LIVEPHOTO',
+			'MEDIA_TYPE_VIDEO',
+			'MUSIC_MEDIA_TYPE_ALL',
+			'MUSIC_MEDIA_TYPE_ANY_AUDIO',
+			'MUSIC_MEDIA_TYPE_AUDIOBOOK',
+			'MUSIC_MEDIA_TYPE_MUSIC',
+			'MUSIC_MEDIA_TYPE_PODCAST',
+			'MUSIC_MEDIA_GROUP_TITLE',
+			'MUSIC_MEDIA_GROUP_ALBUM',
+			'MUSIC_MEDIA_GROUP_ARTIST',
+			'MUSIC_MEDIA_GROUP_ALBUM_ARTIST',
+			'MUSIC_MEDIA_GROUP_COMPOSER',
+			'MUSIC_MEDIA_GROUP_GENRE',
+			'MUSIC_MEDIA_GROUP_PLAYLIST',
+			'MUSIC_MEDIA_GROUP_PODCAST_TITLE',
+			'MUSIC_PLAYER_REPEAT_ALL',
+			'MUSIC_PLAYER_REPEAT_DEFAULT',
+			'MUSIC_PLAYER_REPEAT_NONE',
+			'MUSIC_PLAYER_REPEAT_ONE',
+			'MUSIC_PLAYER_SHUFFLE_ALBUMS',
+			'MUSIC_PLAYER_SHUFFLE_DEFAULT',
+			'MUSIC_PLAYER_SHUFFLE_NONE',
+			'MUSIC_PLAYER_SHUFFLE_SONGS',
+			'MUSIC_PLAYER_STATE_INTERRUPTED',
+			'MUSIC_PLAYER_STATE_PAUSED',
+			'MUSIC_PLAYER_STATE_PLAYING',
+			'MUSIC_PLAYER_STATE_SEEK_BACKWARD',
+			'MUSIC_PLAYER_STATE_SEEK_FORWARD',
+			'MUSIC_PLAYER_STATE_STOPPED',
+			'NO_CAMERA',
+			'NO_VIDEO',
+			'QUALITY_HIGH',
+			'QUALITY_LOW',
+			'QUALITY_MEDIUM',
+			'QUALITY_640x480',
+			'QUALITY_IFRAME_1280x720',
+			'QUALITY_IFRAME_960x540',
+			'UNKNOWN_ERROR',
+			'VIDEO_CONTROL_DEFAULT',
+			'VIDEO_CONTROL_EMBEDDED',
+			'VIDEO_CONTROL_FULLSCREEN',
+			'VIDEO_CONTROL_HIDDEN',
+			'VIDEO_CONTROL_NONE',
+			'VIDEO_CONTROL_VOLUME_ONLY',
+			'VIDEO_FINISH_REASON_PLAYBACK_ENDED',
+			'VIDEO_FINISH_REASON_PLAYBACK_ERROR',
+			'VIDEO_FINISH_REASON_USER_EXITED',
+			'VIDEO_LOAD_STATE_PLAYABLE',
+			'VIDEO_LOAD_STATE_PLAYTHROUGH_OK',
+			'VIDEO_LOAD_STATE_STALLED',
+			'VIDEO_LOAD_STATE_UNKNOWN',
+			'VIDEO_MEDIA_TYPE_AUDIO',
+			'VIDEO_MEDIA_TYPE_NONE',
+			'VIDEO_MEDIA_TYPE_VIDEO',
+			'VIDEO_PLAYBACK_STATE_INTERRUPTED',
+			'VIDEO_PLAYBACK_STATE_PAUSED',
+			'VIDEO_PLAYBACK_STATE_PLAYING',
+			'VIDEO_PLAYBACK_STATE_SEEKING_BACKWARD',
+			'VIDEO_PLAYBACK_STATE_SEEKING_FORWARD',
+			'VIDEO_PLAYBACK_STATE_STOPPED',
+			'VIDEO_REPEAT_MODE_NONE',
+			'VIDEO_REPEAT_MODE_ONE',
+			'VIDEO_SCALING_ASPECT_FILL',
+			'VIDEO_SCALING_ASPECT_FIT',
+			'VIDEO_SCALING_MODE_FILL',
+			'VIDEO_SCALING_NONE',
+			'VIDEO_SOURCE_TYPE_FILE',
+			'VIDEO_SOURCE_TYPE_STREAMING',
+			'VIDEO_SOURCE_TYPE_UNKNOWN',
+			'VIDEO_TIME_OPTION_EXACT',
+			'VIDEO_TIME_OPTION_NEAREST_KEYFRAME',
+			'VIDEO_TIME_OPTION_CLOSEST_SYNC',
+			'VIDEO_TIME_OPTION_NEXT_SYNC',
+			'VIDEO_TIME_OPTION_PREVIOUS_SYNC',
+			'appMusicPlayer',
+			'audioLineType',
+			'audioPlaying',
+			'audioSessionCategory',
+			'audioSessionMode',
+			'availableCameras',
+			'availableCameraMediaTypes',
+			'availablePhotoGalleryMediaTypes',
+			'availablePhotoMediaTypes',
+			'averageMicrophonePower',
+			'cameraFlashMode',
+			'canRecord',
+			'currentRoute',
+			'isCameraSupported',
+			'cameraAuthorizationStatus',
+			'cameraAuthorization',
+			'peakMicrophonePower',
+			'systemMusicPlayer',
+			'volume',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_3GP2) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_3GP2 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_3GP2 = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_3GP2 = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_3GPP) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_3GPP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_3GPP = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_3GPP = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_AIFF) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_AIFF is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_AIFF = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_AIFF = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_AMR) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_AMR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_AMR = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_AMR = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_CAF) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_CAF is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_CAF = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_CAF = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_MP3) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_MP3 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_MP3 = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_MP3 = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_MP4) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_MP4 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_MP4 = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_MP4 = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_MP4A) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_MP4A is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_MP4A = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_MP4A = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FILEFORMAT_WAVE) {
+		throw new Error('Ti.Media.AUDIO_FILEFORMAT_WAVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FILEFORMAT_WAVE = undefined;
+	} else {
+		this.AUDIO_FILEFORMAT_WAVE = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FORMAT_AAC) {
+		throw new Error('Ti.Media.AUDIO_FORMAT_AAC is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FORMAT_AAC = undefined;
+	} else {
+		this.AUDIO_FORMAT_AAC = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FORMAT_ALAW) {
+		throw new Error('Ti.Media.AUDIO_FORMAT_ALAW is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FORMAT_ALAW = undefined;
+	} else {
+		this.AUDIO_FORMAT_ALAW = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FORMAT_APPLE_LOSSLESS) {
+		throw new Error('Ti.Media.AUDIO_FORMAT_APPLE_LOSSLESS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FORMAT_APPLE_LOSSLESS = undefined;
+	} else {
+		this.AUDIO_FORMAT_APPLE_LOSSLESS = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FORMAT_ILBC) {
+		throw new Error('Ti.Media.AUDIO_FORMAT_ILBC is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FORMAT_ILBC = undefined;
+	} else {
+		this.AUDIO_FORMAT_ILBC = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FORMAT_IMA4) {
+		throw new Error('Ti.Media.AUDIO_FORMAT_IMA4 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FORMAT_IMA4 = undefined;
+	} else {
+		this.AUDIO_FORMAT_IMA4 = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FORMAT_LINEAR_PCM) {
+		throw new Error('Ti.Media.AUDIO_FORMAT_LINEAR_PCM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FORMAT_LINEAR_PCM = undefined;
+	} else {
+		this.AUDIO_FORMAT_LINEAR_PCM = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_FORMAT_ULAW) {
+		throw new Error('Ti.Media.AUDIO_FORMAT_ULAW is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_FORMAT_ULAW = undefined;
+	} else {
+		this.AUDIO_FORMAT_ULAW = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_HEADPHONES) {
+		throw new Error('Ti.Media.AUDIO_HEADPHONES was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_HEADPHONES_AND_MIC) {
+		throw new Error('Ti.Media.AUDIO_HEADPHONES_AND_MIC was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_HEADSET_INOUT) {
+		throw new Error('Ti.Media.AUDIO_HEADSET_INOUT was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_LINEOUT) {
+		throw new Error('Ti.Media.AUDIO_LINEOUT was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_MICROPHONE) {
+		throw new Error('Ti.Media.AUDIO_MICROPHONE was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_MUTED) {
+		throw new Error('Ti.Media.AUDIO_MUTED was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_RECEIVER_AND_MIC) {
+		throw new Error('Ti.Media.AUDIO_RECEIVER_AND_MIC was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_CATEGORY_AMBIENT) {
+		throw new Error('Ti.Media.AUDIO_SESSION_CATEGORY_AMBIENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_CATEGORY_AMBIENT = undefined;
+	} else {
+		this.AUDIO_SESSION_CATEGORY_AMBIENT = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_CATEGORY_PLAYBACK) {
+		throw new Error('Ti.Media.AUDIO_SESSION_CATEGORY_PLAYBACK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_CATEGORY_PLAYBACK = undefined;
+	} else {
+		this.AUDIO_SESSION_CATEGORY_PLAYBACK = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_CATEGORY_PLAY_AND_RECORD) {
+		throw new Error('Ti.Media.AUDIO_SESSION_CATEGORY_PLAY_AND_RECORD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_CATEGORY_PLAY_AND_RECORD = undefined;
+	} else {
+		this.AUDIO_SESSION_CATEGORY_PLAY_AND_RECORD = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_CATEGORY_RECORD) {
+		throw new Error('Ti.Media.AUDIO_SESSION_CATEGORY_RECORD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_CATEGORY_RECORD = undefined;
+	} else {
+		this.AUDIO_SESSION_CATEGORY_RECORD = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_CATEGORY_SOLO_AMBIENT) {
+		throw new Error('Ti.Media.AUDIO_SESSION_CATEGORY_SOLO_AMBIENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_CATEGORY_SOLO_AMBIENT = undefined;
+	} else {
+		this.AUDIO_SESSION_CATEGORY_SOLO_AMBIENT = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_MODE_AMBIENT) {
+		throw new Error('Ti.Media.AUDIO_SESSION_MODE_AMBIENT was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_MODE_PLAYBACK) {
+		throw new Error('Ti.Media.AUDIO_SESSION_MODE_PLAYBACK was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_MODE_PLAY_AND_RECORD) {
+		throw new Error('Ti.Media.AUDIO_SESSION_MODE_PLAY_AND_RECORD was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_MODE_RECORD) {
+		throw new Error('Ti.Media.AUDIO_SESSION_MODE_RECORD was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_MODE_SOLO_AMBIENT) {
+		throw new Error('Ti.Media.AUDIO_SESSION_MODE_SOLO_AMBIENT was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_OVERRIDE_ROUTE_NONE) {
+		throw new Error('Ti.Media.AUDIO_SESSION_OVERRIDE_ROUTE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_OVERRIDE_ROUTE_NONE = undefined;
+	} else {
+		this.AUDIO_SESSION_OVERRIDE_ROUTE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_OVERRIDE_ROUTE_SPEAKER) {
+		throw new Error('Ti.Media.AUDIO_SESSION_OVERRIDE_ROUTE_SPEAKER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_OVERRIDE_ROUTE_SPEAKER = undefined;
+	} else {
+		this.AUDIO_SESSION_OVERRIDE_ROUTE_SPEAKER = 0;
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_LINEIN) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_LINEIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_LINEIN = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_LINEIN = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_BUILTINMIC) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_BUILTINMIC is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_BUILTINMIC = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_BUILTINMIC = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_HEADSETMIC) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_HEADSETMIC is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_HEADSETMIC = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_HEADSETMIC = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_LINEOUT) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_LINEOUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_LINEOUT = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_LINEOUT = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_HEADPHONES) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_HEADPHONES is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_HEADPHONES = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_HEADPHONES = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_BLUETOOTHA2DP) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_BLUETOOTHA2DP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_BLUETOOTHA2DP = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_BLUETOOTHA2DP = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_BUILTINRECEIVER) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_BUILTINRECEIVER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_BUILTINRECEIVER = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_BUILTINRECEIVER = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_BUILTINSPEAKER) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_BUILTINSPEAKER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_BUILTINSPEAKER = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_BUILTINSPEAKER = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_HDMI) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_HDMI is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_HDMI = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_HDMI = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_AIRPLAY) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_AIRPLAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_AIRPLAY = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_AIRPLAY = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_BLUETOOTHHFP) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_BLUETOOTHHFP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_BLUETOOTHHFP = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_BLUETOOTHHFP = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_USBAUDIO) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_USBAUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_USBAUDIO = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_USBAUDIO = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_BLUETOOTHLE) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_BLUETOOTHLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_BLUETOOTHLE = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_BLUETOOTHLE = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SESSION_PORT_CARAUDIO) {
+		throw new Error('Ti.Media.AUDIO_SESSION_PORT_CARAUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUDIO_SESSION_PORT_CARAUDIO = undefined;
+	} else {
+		this.AUDIO_SESSION_PORT_CARAUDIO = '';
+	}
+	if (__SLAG_PROPERTIES.AUDIO_SPEAKER) {
+		throw new Error('Ti.Media.AUDIO_SPEAKER was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_UNAVAILABLE) {
+		throw new Error('Ti.Media.AUDIO_UNAVAILABLE was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.AUDIO_UNKNOWN) {
+		throw new Error('Ti.Media.AUDIO_UNKNOWN was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.CAMERA_FLASH_AUTO) {
+		throw new Error('Ti.Media.CAMERA_FLASH_AUTO is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_FLASH_AUTO = undefined;
+	} else {
+		this.CAMERA_FLASH_AUTO = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_FLASH_OFF) {
+		throw new Error('Ti.Media.CAMERA_FLASH_OFF is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_FLASH_OFF = undefined;
+	} else {
+		this.CAMERA_FLASH_OFF = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_FLASH_ON) {
+		throw new Error('Ti.Media.CAMERA_FLASH_ON is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_FLASH_ON = undefined;
+	} else {
+		this.CAMERA_FLASH_ON = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_FRONT) {
+		throw new Error('Ti.Media.CAMERA_FRONT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_FRONT = undefined;
+	} else {
+		this.CAMERA_FRONT = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_REAR) {
+		throw new Error('Ti.Media.CAMERA_REAR is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_REAR = undefined;
+	} else {
+		this.CAMERA_REAR = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_AUTHORIZATION_AUTHORIZED) {
+		throw new Error('Ti.Media.CAMERA_AUTHORIZATION_AUTHORIZED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_AUTHORIZATION_AUTHORIZED = undefined;
+	} else {
+		this.CAMERA_AUTHORIZATION_AUTHORIZED = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_AUTHORIZATION_DENIED) {
+		throw new Error('Ti.Media.CAMERA_AUTHORIZATION_DENIED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_AUTHORIZATION_DENIED = undefined;
+	} else {
+		this.CAMERA_AUTHORIZATION_DENIED = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_AUTHORIZATION_RESTRICTED) {
+		throw new Error('Ti.Media.CAMERA_AUTHORIZATION_RESTRICTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_AUTHORIZATION_RESTRICTED = undefined;
+	} else {
+		this.CAMERA_AUTHORIZATION_RESTRICTED = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA_AUTHORIZATION_NOT_DETERMINED) {
+		throw new Error('Ti.Media.CAMERA_AUTHORIZATION_NOT_DETERMINED was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.CAMERA_AUTHORIZATION_UNKNOWN) {
+		throw new Error('Ti.Media.CAMERA_AUTHORIZATION_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA_AUTHORIZATION_UNKNOWN = undefined;
+	} else {
+		this.CAMERA_AUTHORIZATION_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.DEVICE_BUSY) {
+		throw new Error('Ti.Media.DEVICE_BUSY is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEVICE_BUSY = undefined;
+	} else {
+		this.DEVICE_BUSY = 0;
+	}
+	if (__SLAG_PROPERTIES.MEDIA_TYPE_PHOTO) {
+		throw new Error('Ti.Media.MEDIA_TYPE_PHOTO is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MEDIA_TYPE_PHOTO = undefined;
+	} else {
+		this.MEDIA_TYPE_PHOTO = '';
+	}
+	if (__SLAG_PROPERTIES.MEDIA_TYPE_LIVEPHOTO) {
+		throw new Error('Ti.Media.MEDIA_TYPE_LIVEPHOTO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MEDIA_TYPE_LIVEPHOTO = undefined;
+	} else {
+		this.MEDIA_TYPE_LIVEPHOTO = '';
+	}
+	if (__SLAG_PROPERTIES.MEDIA_TYPE_VIDEO) {
+		throw new Error('Ti.Media.MEDIA_TYPE_VIDEO is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MEDIA_TYPE_VIDEO = undefined;
+	} else {
+		this.MEDIA_TYPE_VIDEO = '';
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_TYPE_ALL) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_TYPE_ALL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_TYPE_ALL = undefined;
+	} else {
+		this.MUSIC_MEDIA_TYPE_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_TYPE_ANY_AUDIO) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_TYPE_ANY_AUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_TYPE_ANY_AUDIO = undefined;
+	} else {
+		this.MUSIC_MEDIA_TYPE_ANY_AUDIO = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_TYPE_AUDIOBOOK) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_TYPE_AUDIOBOOK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_TYPE_AUDIOBOOK = undefined;
+	} else {
+		this.MUSIC_MEDIA_TYPE_AUDIOBOOK = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_TYPE_MUSIC) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_TYPE_MUSIC is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_TYPE_MUSIC = undefined;
+	} else {
+		this.MUSIC_MEDIA_TYPE_MUSIC = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_TYPE_PODCAST) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_TYPE_PODCAST is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_TYPE_PODCAST = undefined;
+	} else {
+		this.MUSIC_MEDIA_TYPE_PODCAST = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_TITLE) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_TITLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_TITLE = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_TITLE = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_ALBUM) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_ALBUM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_ALBUM = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_ALBUM = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_ARTIST) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_ARTIST is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_ARTIST = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_ARTIST = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_ALBUM_ARTIST) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_ALBUM_ARTIST is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_ALBUM_ARTIST = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_ALBUM_ARTIST = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_COMPOSER) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_COMPOSER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_COMPOSER = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_COMPOSER = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_GENRE) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_GENRE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_GENRE = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_GENRE = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_PLAYLIST) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_PLAYLIST is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_PLAYLIST = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_PLAYLIST = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_MEDIA_GROUP_PODCAST_TITLE) {
+		throw new Error('Ti.Media.MUSIC_MEDIA_GROUP_PODCAST_TITLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_MEDIA_GROUP_PODCAST_TITLE = undefined;
+	} else {
+		this.MUSIC_MEDIA_GROUP_PODCAST_TITLE = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_REPEAT_ALL) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_REPEAT_ALL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_REPEAT_ALL = undefined;
+	} else {
+		this.MUSIC_PLAYER_REPEAT_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_REPEAT_DEFAULT) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_REPEAT_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_REPEAT_DEFAULT = undefined;
+	} else {
+		this.MUSIC_PLAYER_REPEAT_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_REPEAT_NONE) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_REPEAT_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_REPEAT_NONE = undefined;
+	} else {
+		this.MUSIC_PLAYER_REPEAT_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_REPEAT_ONE) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_REPEAT_ONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_REPEAT_ONE = undefined;
+	} else {
+		this.MUSIC_PLAYER_REPEAT_ONE = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_SHUFFLE_ALBUMS) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_SHUFFLE_ALBUMS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_SHUFFLE_ALBUMS = undefined;
+	} else {
+		this.MUSIC_PLAYER_SHUFFLE_ALBUMS = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_SHUFFLE_DEFAULT) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_SHUFFLE_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_SHUFFLE_DEFAULT = undefined;
+	} else {
+		this.MUSIC_PLAYER_SHUFFLE_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_SHUFFLE_NONE) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_SHUFFLE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_SHUFFLE_NONE = undefined;
+	} else {
+		this.MUSIC_PLAYER_SHUFFLE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_SHUFFLE_SONGS) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_SHUFFLE_SONGS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_SHUFFLE_SONGS = undefined;
+	} else {
+		this.MUSIC_PLAYER_SHUFFLE_SONGS = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_STATE_INTERRUPTED) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_STATE_INTERRUPTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_STATE_INTERRUPTED = undefined;
+	} else {
+		this.MUSIC_PLAYER_STATE_INTERRUPTED = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_STATE_PAUSED) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_STATE_PAUSED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_STATE_PAUSED = undefined;
+	} else {
+		this.MUSIC_PLAYER_STATE_PAUSED = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_STATE_PLAYING) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_STATE_PLAYING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_STATE_PLAYING = undefined;
+	} else {
+		this.MUSIC_PLAYER_STATE_PLAYING = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_STATE_SEEK_BACKWARD) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_STATE_SEEK_BACKWARD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_STATE_SEEK_BACKWARD = undefined;
+	} else {
+		this.MUSIC_PLAYER_STATE_SEEK_BACKWARD = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_STATE_SEEK_FORWARD) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_STATE_SEEK_FORWARD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_STATE_SEEK_FORWARD = undefined;
+	} else {
+		this.MUSIC_PLAYER_STATE_SEEK_FORWARD = 0;
+	}
+	if (__SLAG_PROPERTIES.MUSIC_PLAYER_STATE_STOPPED) {
+		throw new Error('Ti.Media.MUSIC_PLAYER_STATE_STOPPED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MUSIC_PLAYER_STATE_STOPPED = undefined;
+	} else {
+		this.MUSIC_PLAYER_STATE_STOPPED = 0;
+	}
+	if (__SLAG_PROPERTIES.NO_CAMERA) {
+		throw new Error('Ti.Media.NO_CAMERA is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NO_CAMERA = undefined;
+	} else {
+		this.NO_CAMERA = 0;
+	}
+	if (__SLAG_PROPERTIES.NO_VIDEO) {
+		throw new Error('Ti.Media.NO_VIDEO is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NO_VIDEO = undefined;
+	} else {
+		this.NO_VIDEO = 0;
+	}
+	if (__SLAG_PROPERTIES.QUALITY_HIGH) {
+		throw new Error('Ti.Media.QUALITY_HIGH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.QUALITY_HIGH = undefined;
+	} else {
+		this.QUALITY_HIGH = 0;
+	}
+	if (__SLAG_PROPERTIES.QUALITY_LOW) {
+		throw new Error('Ti.Media.QUALITY_LOW is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.QUALITY_LOW = undefined;
+	} else {
+		this.QUALITY_LOW = 0;
+	}
+	if (__SLAG_PROPERTIES.QUALITY_MEDIUM) {
+		throw new Error('Ti.Media.QUALITY_MEDIUM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.QUALITY_MEDIUM = undefined;
+	} else {
+		this.QUALITY_MEDIUM = 0;
+	}
+	if (__SLAG_PROPERTIES.QUALITY_640x480) {
+		throw new Error('Ti.Media.QUALITY_640x480 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.QUALITY_640x480 = undefined;
+	} else {
+		this.QUALITY_640x480 = 0;
+	}
+	if (__SLAG_PROPERTIES.QUALITY_IFRAME_1280x720) {
+		throw new Error('Ti.Media.QUALITY_IFRAME_1280x720 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.QUALITY_IFRAME_1280x720 = undefined;
+	} else {
+		this.QUALITY_IFRAME_1280x720 = 0;
+	}
+	if (__SLAG_PROPERTIES.QUALITY_IFRAME_960x540) {
+		throw new Error('Ti.Media.QUALITY_IFRAME_960x540 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.QUALITY_IFRAME_960x540 = undefined;
+	} else {
+		this.QUALITY_IFRAME_960x540 = 0;
+	}
+	if (__SLAG_PROPERTIES.UNKNOWN_ERROR) {
+		throw new Error('Ti.Media.UNKNOWN_ERROR is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNKNOWN_ERROR = undefined;
+	} else {
+		this.UNKNOWN_ERROR = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_CONTROL_DEFAULT) {
+		throw new Error('Ti.Media.VIDEO_CONTROL_DEFAULT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_CONTROL_DEFAULT = undefined;
+	} else {
+		this.VIDEO_CONTROL_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_CONTROL_EMBEDDED) {
+		throw new Error('Ti.Media.VIDEO_CONTROL_EMBEDDED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_CONTROL_EMBEDDED = undefined;
+	} else {
+		this.VIDEO_CONTROL_EMBEDDED = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_CONTROL_FULLSCREEN) {
+		throw new Error('Ti.Media.VIDEO_CONTROL_FULLSCREEN is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_CONTROL_FULLSCREEN = undefined;
+	} else {
+		this.VIDEO_CONTROL_FULLSCREEN = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_CONTROL_HIDDEN) {
+		throw new Error('Ti.Media.VIDEO_CONTROL_HIDDEN is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_CONTROL_HIDDEN = undefined;
+	} else {
+		this.VIDEO_CONTROL_HIDDEN = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_CONTROL_NONE) {
+		throw new Error('Ti.Media.VIDEO_CONTROL_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_CONTROL_NONE = undefined;
+	} else {
+		this.VIDEO_CONTROL_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_CONTROL_VOLUME_ONLY) {
+		throw new Error('Ti.Media.VIDEO_CONTROL_VOLUME_ONLY was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.VIDEO_FINISH_REASON_PLAYBACK_ENDED) {
+		throw new Error('Ti.Media.VIDEO_FINISH_REASON_PLAYBACK_ENDED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_FINISH_REASON_PLAYBACK_ENDED = undefined;
+	} else {
+		this.VIDEO_FINISH_REASON_PLAYBACK_ENDED = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_FINISH_REASON_PLAYBACK_ERROR) {
+		throw new Error('Ti.Media.VIDEO_FINISH_REASON_PLAYBACK_ERROR is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_FINISH_REASON_PLAYBACK_ERROR = undefined;
+	} else {
+		this.VIDEO_FINISH_REASON_PLAYBACK_ERROR = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_FINISH_REASON_USER_EXITED) {
+		throw new Error('Ti.Media.VIDEO_FINISH_REASON_USER_EXITED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_FINISH_REASON_USER_EXITED = undefined;
+	} else {
+		this.VIDEO_FINISH_REASON_USER_EXITED = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_LOAD_STATE_PLAYABLE) {
+		throw new Error('Ti.Media.VIDEO_LOAD_STATE_PLAYABLE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_LOAD_STATE_PLAYABLE = undefined;
+	} else {
+		this.VIDEO_LOAD_STATE_PLAYABLE = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_LOAD_STATE_PLAYTHROUGH_OK) {
+		throw new Error('Ti.Media.VIDEO_LOAD_STATE_PLAYTHROUGH_OK is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_LOAD_STATE_PLAYTHROUGH_OK = undefined;
+	} else {
+		this.VIDEO_LOAD_STATE_PLAYTHROUGH_OK = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_LOAD_STATE_STALLED) {
+		throw new Error('Ti.Media.VIDEO_LOAD_STATE_STALLED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_LOAD_STATE_STALLED = undefined;
+	} else {
+		this.VIDEO_LOAD_STATE_STALLED = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_LOAD_STATE_UNKNOWN) {
+		throw new Error('Ti.Media.VIDEO_LOAD_STATE_UNKNOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_LOAD_STATE_UNKNOWN = undefined;
+	} else {
+		this.VIDEO_LOAD_STATE_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_MEDIA_TYPE_AUDIO) {
+		throw new Error('Ti.Media.VIDEO_MEDIA_TYPE_AUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_MEDIA_TYPE_AUDIO = undefined;
+	} else {
+		this.VIDEO_MEDIA_TYPE_AUDIO = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_MEDIA_TYPE_NONE) {
+		throw new Error('Ti.Media.VIDEO_MEDIA_TYPE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_MEDIA_TYPE_NONE = undefined;
+	} else {
+		this.VIDEO_MEDIA_TYPE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_MEDIA_TYPE_VIDEO) {
+		throw new Error('Ti.Media.VIDEO_MEDIA_TYPE_VIDEO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_MEDIA_TYPE_VIDEO = undefined;
+	} else {
+		this.VIDEO_MEDIA_TYPE_VIDEO = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_PLAYBACK_STATE_INTERRUPTED) {
+		throw new Error('Ti.Media.VIDEO_PLAYBACK_STATE_INTERRUPTED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_PLAYBACK_STATE_INTERRUPTED = undefined;
+	} else {
+		this.VIDEO_PLAYBACK_STATE_INTERRUPTED = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_PLAYBACK_STATE_PAUSED) {
+		throw new Error('Ti.Media.VIDEO_PLAYBACK_STATE_PAUSED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_PLAYBACK_STATE_PAUSED = undefined;
+	} else {
+		this.VIDEO_PLAYBACK_STATE_PAUSED = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_PLAYBACK_STATE_PLAYING) {
+		throw new Error('Ti.Media.VIDEO_PLAYBACK_STATE_PLAYING is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_PLAYBACK_STATE_PLAYING = undefined;
+	} else {
+		this.VIDEO_PLAYBACK_STATE_PLAYING = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_PLAYBACK_STATE_SEEKING_BACKWARD) {
+		throw new Error('Ti.Media.VIDEO_PLAYBACK_STATE_SEEKING_BACKWARD is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_PLAYBACK_STATE_SEEKING_BACKWARD = undefined;
+	} else {
+		this.VIDEO_PLAYBACK_STATE_SEEKING_BACKWARD = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_PLAYBACK_STATE_SEEKING_FORWARD) {
+		throw new Error('Ti.Media.VIDEO_PLAYBACK_STATE_SEEKING_FORWARD is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_PLAYBACK_STATE_SEEKING_FORWARD = undefined;
+	} else {
+		this.VIDEO_PLAYBACK_STATE_SEEKING_FORWARD = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_PLAYBACK_STATE_STOPPED) {
+		throw new Error('Ti.Media.VIDEO_PLAYBACK_STATE_STOPPED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_PLAYBACK_STATE_STOPPED = undefined;
+	} else {
+		this.VIDEO_PLAYBACK_STATE_STOPPED = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_REPEAT_MODE_NONE) {
+		throw new Error('Ti.Media.VIDEO_REPEAT_MODE_NONE is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_REPEAT_MODE_NONE = undefined;
+	} else {
+		this.VIDEO_REPEAT_MODE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_REPEAT_MODE_ONE) {
+		throw new Error('Ti.Media.VIDEO_REPEAT_MODE_ONE is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_REPEAT_MODE_ONE = undefined;
+	} else {
+		this.VIDEO_REPEAT_MODE_ONE = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_SCALING_ASPECT_FILL) {
+		throw new Error('Ti.Media.VIDEO_SCALING_ASPECT_FILL is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_SCALING_ASPECT_FILL = undefined;
+	} else {
+		this.VIDEO_SCALING_ASPECT_FILL = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_SCALING_ASPECT_FIT) {
+		throw new Error('Ti.Media.VIDEO_SCALING_ASPECT_FIT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_SCALING_ASPECT_FIT = undefined;
+	} else {
+		this.VIDEO_SCALING_ASPECT_FIT = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_SCALING_MODE_FILL) {
+		throw new Error('Ti.Media.VIDEO_SCALING_MODE_FILL is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_SCALING_MODE_FILL = undefined;
+	} else {
+		this.VIDEO_SCALING_MODE_FILL = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_SCALING_NONE) {
+		throw new Error('Ti.Media.VIDEO_SCALING_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_SCALING_NONE = undefined;
+	} else {
+		this.VIDEO_SCALING_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_SOURCE_TYPE_FILE) {
+		throw new Error('Ti.Media.VIDEO_SOURCE_TYPE_FILE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_SOURCE_TYPE_FILE = undefined;
+	} else {
+		this.VIDEO_SOURCE_TYPE_FILE = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_SOURCE_TYPE_STREAMING) {
+		throw new Error('Ti.Media.VIDEO_SOURCE_TYPE_STREAMING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_SOURCE_TYPE_STREAMING = undefined;
+	} else {
+		this.VIDEO_SOURCE_TYPE_STREAMING = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_SOURCE_TYPE_UNKNOWN) {
+		throw new Error('Ti.Media.VIDEO_SOURCE_TYPE_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_SOURCE_TYPE_UNKNOWN = undefined;
+	} else {
+		this.VIDEO_SOURCE_TYPE_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_TIME_OPTION_EXACT) {
+		throw new Error('Ti.Media.VIDEO_TIME_OPTION_EXACT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_TIME_OPTION_EXACT = undefined;
+	} else {
+		this.VIDEO_TIME_OPTION_EXACT = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_TIME_OPTION_NEAREST_KEYFRAME) {
+		throw new Error('Ti.Media.VIDEO_TIME_OPTION_NEAREST_KEYFRAME is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_TIME_OPTION_NEAREST_KEYFRAME = undefined;
+	} else {
+		this.VIDEO_TIME_OPTION_NEAREST_KEYFRAME = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_TIME_OPTION_CLOSEST_SYNC) {
+		throw new Error('Ti.Media.VIDEO_TIME_OPTION_CLOSEST_SYNC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_TIME_OPTION_CLOSEST_SYNC = undefined;
+	} else {
+		this.VIDEO_TIME_OPTION_CLOSEST_SYNC = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_TIME_OPTION_NEXT_SYNC) {
+		throw new Error('Ti.Media.VIDEO_TIME_OPTION_NEXT_SYNC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_TIME_OPTION_NEXT_SYNC = undefined;
+	} else {
+		this.VIDEO_TIME_OPTION_NEXT_SYNC = 0;
+	}
+	if (__SLAG_PROPERTIES.VIDEO_TIME_OPTION_PREVIOUS_SYNC) {
+		throw new Error('Ti.Media.VIDEO_TIME_OPTION_PREVIOUS_SYNC is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.VIDEO_TIME_OPTION_PREVIOUS_SYNC = undefined;
+	} else {
+		this.VIDEO_TIME_OPTION_PREVIOUS_SYNC = 0;
+	}
+	if (__SLAG_PROPERTIES.appMusicPlayer) {
+		throw new Error('Ti.Media.appMusicPlayer is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.appMusicPlayer = undefined;
+	} else {
+		this.appMusicPlayer = {};
+	}
+	if (__SLAG_PROPERTIES.audioLineType) {
+		throw new Error('Ti.Media.audioLineType was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.audioPlaying) {
+		throw new Error('Ti.Media.audioPlaying is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioPlaying = undefined;
+	} else {
+		this.audioPlaying = true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.audioSessionCategory = undefined;
+	} else {
+		this.audioSessionCategory = __SLAG_PROPERTIES.audioSessionCategory || 0;
+	}
+	if (__SLAG_PROPERTIES.audioSessionMode) {
+		throw new Error('Ti.Media.audioSessionMode was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.availableCameras) {
+		throw new Error('Ti.Media.availableCameras is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.availableCameras = undefined;
+	} else {
+		this.availableCameras = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.availableCameraMediaTypes = undefined;
+	} else {
+		this.availableCameraMediaTypes = __SLAG_PROPERTIES.availableCameraMediaTypes || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.availablePhotoGalleryMediaTypes = undefined;
+	} else {
+		this.availablePhotoGalleryMediaTypes = __SLAG_PROPERTIES.availablePhotoGalleryMediaTypes || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.availablePhotoMediaTypes = undefined;
+	} else {
+		this.availablePhotoMediaTypes = __SLAG_PROPERTIES.availablePhotoMediaTypes || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.averageMicrophonePower = undefined;
+	} else {
+		this.averageMicrophonePower = __SLAG_PROPERTIES.averageMicrophonePower || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cameraFlashMode = undefined;
+	} else {
+		this.cameraFlashMode = __SLAG_PROPERTIES.cameraFlashMode || 0;
+	}
+	if (__SLAG_PROPERTIES.canRecord) {
+		throw new Error('Ti.Media.canRecord is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canRecord = undefined;
+	} else {
+		this.canRecord = true;
+	}
+	if (__SLAG_PROPERTIES.currentRoute) {
+		throw new Error('Ti.Media.currentRoute is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentRoute = undefined;
+	} else {
+		this.currentRoute = {};
+	}
+	if (__SLAG_PROPERTIES.isCameraSupported) {
+		throw new Error('Ti.Media.isCameraSupported is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isCameraSupported = undefined;
+	} else {
+		this.isCameraSupported = true;
+	}
+	if (__SLAG_PROPERTIES.cameraAuthorizationStatus) {
+		throw new Error('Ti.Media.cameraAuthorizationStatus was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.cameraAuthorization) {
+		throw new Error('Ti.Media.cameraAuthorization is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cameraAuthorization = undefined;
+	} else {
+		this.cameraAuthorization = 0;
+	}
+	if (__SLAG_PROPERTIES.peakMicrophonePower) {
+		throw new Error('Ti.Media.peakMicrophonePower is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.peakMicrophonePower = undefined;
+	} else {
+		this.peakMicrophonePower = 0;
+	}
+	if (__SLAG_PROPERTIES.systemMusicPlayer) {
+		throw new Error('Ti.Media.systemMusicPlayer is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.systemMusicPlayer = undefined;
+	} else {
+		this.systemMusicPlayer = {};
+	}
+	if (__SLAG_PROPERTIES.volume) {
+		throw new Error('Ti.Media.volume is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.volume = undefined;
+	} else {
+		this.volume = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Media.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Media.prototype.beep = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.hideCamera = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.hideMusicLibrary = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.isMediaTypeSupported = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Media.prototype.openMusicLibrary = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.openPhotoGallery = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.previewImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.saveToPhotoGallery = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.setOverrideAudioRoute = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.showCamera = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.hasMusicLibraryPermissions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Media.prototype.requestMusicLibraryPermissions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.queryMusicLibrary = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Media.prototype.startMicrophoneMonitor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.stopMicrophoneMonitor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.takePicture = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.startVideoCapture = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.stopVideoCapture = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.switchCamera = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.hasCameraPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Media.prototype.requestCameraPermissions = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.hasPhotoGalleryPermissions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Media.prototype.requestPhotoGalleryPermissions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.requestCameraAccess = function () {
+	throw new Error('Ti.Media.requestCameraAccess was deprecated, since 5.1.0');
+};
+Media.prototype.takeScreenshot = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.vibrate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.requestAuthorization = function () {
+	throw new Error('Ti.Media.requestAuthorization was deprecated, since 5.1.0');
+};
+Media.prototype.hasAudioPermissions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Media.prototype.requestAudioPermissions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Media.prototype.createAudioPlayer = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var AudioPlayer = require('./Media/AudioPlayer');
+	return AudioPlayer(__SLAG_PROPERTY);
+};
+Media.prototype.createAudioRecorder = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var AudioRecorder = require('./Media/AudioRecorder');
+	return AudioRecorder(__SLAG_PROPERTY);
+};
+Media.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Media.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Media.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Media.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Media.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Media.prototype.getQUALITY_640x480 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Media.prototype.getQUALITY_IFRAME_1280x720 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Media.prototype.getQUALITY_IFRAME_960x540 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+Media.prototype.getAppMusicPlayer = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.appMusicPlayer;
+};
+Media.prototype.getAudioLineType = function () {
+	throw new Error('Ti.Media.getAudioLineType was deprecated, since 3.4.2');
+};
+Media.prototype.getAudioPlaying = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioPlaying;
+};
+Media.prototype.getAudioSessionCategory = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.audioSessionCategory;
+};
+Media.prototype.setAudioSessionCategory = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.audioSessionCategory = __SLAG__PROPERTY;
+};
+Media.prototype.getAudioSessionMode = function () {
+	throw new Error('Ti.Media.getAudioSessionMode was deprecated, since 3.4.2');
+};
+Media.prototype.setAudioSessionMode = function () {
+	throw new Error('Ti.Media.setAudioSessionMode was deprecated, since 3.4.2');
+};
+Media.prototype.getAvailableCameras = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.availableCameras;
+};
+Media.prototype.getAvailableCameraMediaTypes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.availableCameraMediaTypes;
+};
+Media.prototype.setAvailableCameraMediaTypes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.availableCameraMediaTypes = __SLAG__PROPERTY;
+};
+Media.prototype.getAvailablePhotoGalleryMediaTypes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.availablePhotoGalleryMediaTypes;
+};
+Media.prototype.setAvailablePhotoGalleryMediaTypes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.availablePhotoGalleryMediaTypes = __SLAG__PROPERTY;
+};
+Media.prototype.getAvailablePhotoMediaTypes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.availablePhotoMediaTypes;
+};
+Media.prototype.setAvailablePhotoMediaTypes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.availablePhotoMediaTypes = __SLAG__PROPERTY;
+};
+Media.prototype.getAverageMicrophonePower = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.averageMicrophonePower;
+};
+Media.prototype.setAverageMicrophonePower = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.averageMicrophonePower = __SLAG__PROPERTY;
+};
+Media.prototype.getCameraFlashMode = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cameraFlashMode;
+};
+Media.prototype.setCameraFlashMode = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cameraFlashMode = __SLAG__PROPERTY;
+};
+Media.prototype.getCanRecord = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.canRecord;
+};
+Media.prototype.getCurrentRoute = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentRoute;
+};
+Media.prototype.getIsCameraSupported = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isCameraSupported;
+};
+Media.prototype.getCameraAuthorizationStatus = function () {
+	throw new Error('Ti.Media.getCameraAuthorizationStatus was deprecated, since 5.2.0');
+};
+Media.prototype.getCameraAuthorization = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cameraAuthorization;
+};
+Media.prototype.getPeakMicrophonePower = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.peakMicrophonePower;
+};
+Media.prototype.getSystemMusicPlayer = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.systemMusicPlayer;
+};
+Media.prototype.getVolume = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.volume;
+};
+Media.prototype.createSound = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Sound = require('./Media/Sound');
+	return Sound(__SLAG_PROPERTY);
+};
+Media.prototype.createVideoPlayer = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var VideoPlayer = require('./Media/VideoPlayer');
+	return VideoPlayer(__SLAG_PROPERTY);
+};
+module.exports = function (properties) {
+	return new Media(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media/Android.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media/Android.js
@@ -1,0 +1,103 @@
+var crypto = require('crypto');
+function Android(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.Android.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media.Android';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Android.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Android.prototype.scanMediaFiles = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.setSystemWallpaper = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Android.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Android.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Android.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Android.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Android(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media/AudioPlayer.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media/AudioPlayer.js
@@ -1,0 +1,553 @@
+var crypto = require('crypto');
+function AudioPlayer(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'STATE_BUFFERING',
+			'STATE_INITIALIZED',
+			'STATE_PAUSED',
+			'STATE_PLAYING',
+			'STATE_STARTING',
+			'STATE_STOPPED',
+			'STATE_STOPPING',
+			'STATE_WAITING_FOR_DATA',
+			'STATE_WAITING_FOR_QUEUE',
+			'allowBackground',
+			'bitRate',
+			'duration',
+			'idle',
+			'paused',
+			'playing',
+			'progress',
+			'state',
+			'url',
+			'volume',
+			'waiting',
+			'bufferSize',
+			'time',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.AudioPlayer.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media.AudioPlayer';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.STATE_BUFFERING) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_BUFFERING is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_BUFFERING = undefined;
+	} else {
+		this.STATE_BUFFERING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_INITIALIZED) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_INITIALIZED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_INITIALIZED = undefined;
+	} else {
+		this.STATE_INITIALIZED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_PAUSED) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_PAUSED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_PAUSED = undefined;
+	} else {
+		this.STATE_PAUSED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_PLAYING) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_PLAYING is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_PLAYING = undefined;
+	} else {
+		this.STATE_PLAYING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_STARTING) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_STARTING is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_STARTING = undefined;
+	} else {
+		this.STATE_STARTING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_STOPPED) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_STOPPED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_STOPPED = undefined;
+	} else {
+		this.STATE_STOPPED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_STOPPING) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_STOPPING is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_STOPPING = undefined;
+	} else {
+		this.STATE_STOPPING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_WAITING_FOR_DATA) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_WAITING_FOR_DATA is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_WAITING_FOR_DATA = undefined;
+	} else {
+		this.STATE_WAITING_FOR_DATA = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_WAITING_FOR_QUEUE) {
+		throw new Error('Ti.Media.AudioPlayer.STATE_WAITING_FOR_QUEUE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_WAITING_FOR_QUEUE = undefined;
+	} else {
+		this.STATE_WAITING_FOR_QUEUE = 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowBackground = undefined;
+	} else {
+		this.allowBackground = __SLAG_PROPERTIES.allowBackground || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bitRate = undefined;
+	} else {
+		this.bitRate = __SLAG_PROPERTIES.bitRate || 0;
+	}
+	if (__SLAG_PROPERTIES.duration) {
+		throw new Error('Ti.Media.AudioPlayer.duration is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = 0;
+	}
+	if (__SLAG_PROPERTIES.idle) {
+		throw new Error('Ti.Media.AudioPlayer.idle is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.idle = undefined;
+	} else {
+		this.idle = true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paused = undefined;
+	} else {
+		this.paused = __SLAG_PROPERTIES.paused || true;
+	}
+	if (__SLAG_PROPERTIES.playing) {
+		throw new Error('Ti.Media.AudioPlayer.playing is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playing = undefined;
+	} else {
+		this.playing = true;
+	}
+	if (__SLAG_PROPERTIES.progress) {
+		throw new Error('Ti.Media.AudioPlayer.progress is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.progress = undefined;
+	} else {
+		this.progress = 0;
+	}
+	if (__SLAG_PROPERTIES.state) {
+		throw new Error('Ti.Media.AudioPlayer.state is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.state = undefined;
+	} else {
+		this.state = 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.volume = undefined;
+	} else {
+		this.volume = __SLAG_PROPERTIES.volume || 0;
+	}
+	if (__SLAG_PROPERTIES.waiting) {
+		throw new Error('Ti.Media.AudioPlayer.waiting is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.waiting = undefined;
+	} else {
+		this.waiting = true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bufferSize = undefined;
+	} else {
+		this.bufferSize = __SLAG_PROPERTIES.bufferSize || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.time = undefined;
+	} else {
+		this.time = __SLAG_PROPERTIES.time || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AudioPlayer.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AudioPlayer.prototype.getPaused = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paused;
+};
+AudioPlayer.prototype.isPaused = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+AudioPlayer.prototype.getPlaying = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playing;
+};
+AudioPlayer.prototype.isPlaying = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+AudioPlayer.prototype.pause = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.play = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.setPaused = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.paused = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.release = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.getAudioSessionId = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+AudioPlayer.prototype.start = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.stateDescription = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+AudioPlayer.prototype.stop = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioPlayer.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AudioPlayer.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+AudioPlayer.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+AudioPlayer.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getAllowBackground = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowBackground;
+};
+AudioPlayer.prototype.setAllowBackground = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowBackground = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getBitRate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bitRate;
+};
+AudioPlayer.prototype.setBitRate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bitRate = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getDuration = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.duration;
+};
+AudioPlayer.prototype.getIdle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.idle;
+};
+AudioPlayer.prototype.getPaused = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paused;
+};
+AudioPlayer.prototype.setPaused = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.paused = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getPlaying = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playing;
+};
+AudioPlayer.prototype.getProgress = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.progress;
+};
+AudioPlayer.prototype.getState = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.state;
+};
+AudioPlayer.prototype.getUrl = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+AudioPlayer.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getVolume = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.volume;
+};
+AudioPlayer.prototype.setVolume = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.volume = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getWaiting = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.waiting;
+};
+AudioPlayer.prototype.getBufferSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bufferSize;
+};
+AudioPlayer.prototype.setBufferSize = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bufferSize = __SLAG__PROPERTY;
+};
+AudioPlayer.prototype.getTime = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.time;
+};
+AudioPlayer.prototype.setTime = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.time = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new AudioPlayer(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media/AudioRecorder.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media/AudioRecorder.js
@@ -1,0 +1,177 @@
+var crypto = require('crypto');
+function AudioRecorder(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'compression',
+			'format',
+			'paused',
+			'recording',
+			'stopped',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.AudioRecorder.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media.AudioRecorder';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.compression = undefined;
+	} else {
+		this.compression = __SLAG_PROPERTIES.compression || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.format = undefined;
+	} else {
+		this.format = __SLAG_PROPERTIES.format || 0;
+	}
+	if (__SLAG_PROPERTIES.paused) {
+		throw new Error('Ti.Media.AudioRecorder.paused is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paused = undefined;
+	} else {
+		this.paused = true;
+	}
+	if (__SLAG_PROPERTIES.recording) {
+		throw new Error('Ti.Media.AudioRecorder.recording is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.recording = undefined;
+	} else {
+		this.recording = true;
+	}
+	if (__SLAG_PROPERTIES.stopped) {
+		throw new Error('Ti.Media.AudioRecorder.stopped is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.stopped = undefined;
+	} else {
+		this.stopped = true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AudioRecorder.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioRecorder.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioRecorder.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioRecorder.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AudioRecorder.prototype.pause = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioRecorder.prototype.resume = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioRecorder.prototype.start = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AudioRecorder.prototype.stop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+AudioRecorder.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AudioRecorder.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AudioRecorder.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+AudioRecorder.prototype.getCompression = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.compression;
+};
+AudioRecorder.prototype.setCompression = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.compression = __SLAG__PROPERTY;
+};
+AudioRecorder.prototype.getFormat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.format;
+};
+AudioRecorder.prototype.setFormat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.format = __SLAG__PROPERTY;
+};
+AudioRecorder.prototype.getPaused = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paused;
+};
+AudioRecorder.prototype.getRecording = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.recording;
+};
+AudioRecorder.prototype.getStopped = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.stopped;
+};
+module.exports = function (properties) {
+	return new AudioRecorder(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media/Item.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media/Item.js
@@ -1,0 +1,360 @@
+var crypto = require('crypto');
+function Item(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'albumArtist',
+			'albumTitle',
+			'albumTrackCount',
+			'albumTrackNumber',
+			'artist',
+			'artwork',
+			'composer',
+			'discCount',
+			'discNumber',
+			'genre',
+			'isCompilation',
+			'lyrics',
+			'mediaType',
+			'playCount',
+			'playbackDuration',
+			'podcastTitle',
+			'rating',
+			'skipCount',
+			'title',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.Item.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media.Item';
+	if (__SLAG_PROPERTIES.albumArtist) {
+		throw new Error('Ti.Media.Item.albumArtist is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.albumArtist = undefined;
+	} else {
+		this.albumArtist = '';
+	}
+	if (__SLAG_PROPERTIES.albumTitle) {
+		throw new Error('Ti.Media.Item.albumTitle is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.albumTitle = undefined;
+	} else {
+		this.albumTitle = '';
+	}
+	if (__SLAG_PROPERTIES.albumTrackCount) {
+		throw new Error('Ti.Media.Item.albumTrackCount is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.albumTrackCount = undefined;
+	} else {
+		this.albumTrackCount = 0;
+	}
+	if (__SLAG_PROPERTIES.albumTrackNumber) {
+		throw new Error('Ti.Media.Item.albumTrackNumber is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.albumTrackNumber = undefined;
+	} else {
+		this.albumTrackNumber = 0;
+	}
+	if (__SLAG_PROPERTIES.artist) {
+		throw new Error('Ti.Media.Item.artist is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.artist = undefined;
+	} else {
+		this.artist = '';
+	}
+	if (__SLAG_PROPERTIES.artwork) {
+		throw new Error('Ti.Media.Item.artwork is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.artwork = undefined;
+	} else {
+		this.artwork = {};
+	}
+	if (__SLAG_PROPERTIES.composer) {
+		throw new Error('Ti.Media.Item.composer is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.composer = undefined;
+	} else {
+		this.composer = '';
+	}
+	if (__SLAG_PROPERTIES.discCount) {
+		throw new Error('Ti.Media.Item.discCount is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.discCount = undefined;
+	} else {
+		this.discCount = 0;
+	}
+	if (__SLAG_PROPERTIES.discNumber) {
+		throw new Error('Ti.Media.Item.discNumber is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.discNumber = undefined;
+	} else {
+		this.discNumber = 0;
+	}
+	if (__SLAG_PROPERTIES.genre) {
+		throw new Error('Ti.Media.Item.genre is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.genre = undefined;
+	} else {
+		this.genre = '';
+	}
+	if (__SLAG_PROPERTIES.isCompilation) {
+		throw new Error('Ti.Media.Item.isCompilation is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isCompilation = undefined;
+	} else {
+		this.isCompilation = true;
+	}
+	if (__SLAG_PROPERTIES.lyrics) {
+		throw new Error('Ti.Media.Item.lyrics is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lyrics = undefined;
+	} else {
+		this.lyrics = '';
+	}
+	if (__SLAG_PROPERTIES.mediaType) {
+		throw new Error('Ti.Media.Item.mediaType is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaType = undefined;
+	} else {
+		this.mediaType = 0;
+	}
+	if (__SLAG_PROPERTIES.playCount) {
+		throw new Error('Ti.Media.Item.playCount is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playCount = undefined;
+	} else {
+		this.playCount = 0;
+	}
+	if (__SLAG_PROPERTIES.playbackDuration) {
+		throw new Error('Ti.Media.Item.playbackDuration is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playbackDuration = undefined;
+	} else {
+		this.playbackDuration = 0;
+	}
+	if (__SLAG_PROPERTIES.podcastTitle) {
+		throw new Error('Ti.Media.Item.podcastTitle is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.podcastTitle = undefined;
+	} else {
+		this.podcastTitle = '';
+	}
+	if (__SLAG_PROPERTIES.rating) {
+		throw new Error('Ti.Media.Item.rating is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rating = undefined;
+	} else {
+		this.rating = 0;
+	}
+	if (__SLAG_PROPERTIES.skipCount) {
+		throw new Error('Ti.Media.Item.skipCount is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.skipCount = undefined;
+	} else {
+		this.skipCount = 0;
+	}
+	if (__SLAG_PROPERTIES.title) {
+		throw new Error('Ti.Media.Item.title is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Item.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Item.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Item.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Item.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Item.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Item.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Item.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Item.prototype.getAlbumArtist = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.albumArtist;
+};
+Item.prototype.getAlbumTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.albumTitle;
+};
+Item.prototype.getAlbumTrackCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.albumTrackCount;
+};
+Item.prototype.getAlbumTrackNumber = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.albumTrackNumber;
+};
+Item.prototype.getArtist = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.artist;
+};
+Item.prototype.getArtwork = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.artwork;
+};
+Item.prototype.getComposer = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.composer;
+};
+Item.prototype.getDiscCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.discCount;
+};
+Item.prototype.getDiscNumber = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.discNumber;
+};
+Item.prototype.getGenre = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.genre;
+};
+Item.prototype.getIsCompilation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isCompilation;
+};
+Item.prototype.getLyrics = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lyrics;
+};
+Item.prototype.getMediaType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mediaType;
+};
+Item.prototype.getPlayCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playCount;
+};
+Item.prototype.getPlaybackDuration = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playbackDuration;
+};
+Item.prototype.getPodcastTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.podcastTitle;
+};
+Item.prototype.getRating = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rating;
+};
+Item.prototype.getSkipCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.skipCount;
+};
+Item.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+module.exports = function (properties) {
+	return new Item(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media/MusicPlayer.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media/MusicPlayer.js
@@ -1,0 +1,227 @@
+var crypto = require('crypto');
+function MusicPlayer(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'currentPlaybackTime',
+			'nowPlaying',
+			'playbackState',
+			'repeatMode',
+			'shuffleMode',
+			'volume',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.MusicPlayer.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media.MusicPlayer';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentPlaybackTime = undefined;
+	} else {
+		this.currentPlaybackTime = __SLAG_PROPERTIES.currentPlaybackTime || 0;
+	}
+	if (__SLAG_PROPERTIES.nowPlaying) {
+		throw new Error('Ti.Media.MusicPlayer.nowPlaying is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nowPlaying = undefined;
+	} else {
+		this.nowPlaying = {};
+	}
+	if (__SLAG_PROPERTIES.playbackState) {
+		throw new Error('Ti.Media.MusicPlayer.playbackState is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playbackState = undefined;
+	} else {
+		this.playbackState = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.repeatMode = undefined;
+	} else {
+		this.repeatMode = __SLAG_PROPERTIES.repeatMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shuffleMode = undefined;
+	} else {
+		this.shuffleMode = __SLAG_PROPERTIES.shuffleMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.volume = undefined;
+	} else {
+		this.volume = __SLAG_PROPERTIES.volume || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+MusicPlayer.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+MusicPlayer.prototype.pause = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.play = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.seekBackward = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.seekForward = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.setQueue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.skipToBeginning = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.skipToNext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.skipToPrevious = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.stop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.stopSeeking = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MusicPlayer.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+MusicPlayer.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+MusicPlayer.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+MusicPlayer.prototype.getCurrentPlaybackTime = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentPlaybackTime;
+};
+MusicPlayer.prototype.setCurrentPlaybackTime = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.currentPlaybackTime = __SLAG__PROPERTY;
+};
+MusicPlayer.prototype.getNowPlaying = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nowPlaying;
+};
+MusicPlayer.prototype.getPlaybackState = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playbackState;
+};
+MusicPlayer.prototype.getRepeatMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.repeatMode;
+};
+MusicPlayer.prototype.setRepeatMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.repeatMode = __SLAG__PROPERTY;
+};
+MusicPlayer.prototype.getShuffleMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shuffleMode;
+};
+MusicPlayer.prototype.setShuffleMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shuffleMode = __SLAG__PROPERTY;
+};
+MusicPlayer.prototype.getVolume = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.volume;
+};
+MusicPlayer.prototype.setVolume = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.volume = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new MusicPlayer(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media/Sound.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media/Sound.js
@@ -1,0 +1,415 @@
+var crypto = require('crypto');
+function Sound(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'STATE_BUFFERING',
+			'STATE_INITIALIZED',
+			'STATE_PAUSED',
+			'STATE_PLAYING',
+			'STATE_STARTING',
+			'STATE_STOPPED',
+			'STATE_STOPPING',
+			'STATE_WAITING_FOR_DATA',
+			'STATE_WAITING_FOR_QUEUE',
+			'allowBackground',
+			'duration',
+			'looping',
+			'paused',
+			'playing',
+			'time',
+			'url',
+			'volume',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.Sound.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media.Sound';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.STATE_BUFFERING) {
+		throw new Error('Ti.Media.Sound.STATE_BUFFERING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_BUFFERING = undefined;
+	} else {
+		this.STATE_BUFFERING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_INITIALIZED) {
+		throw new Error('Ti.Media.Sound.STATE_INITIALIZED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_INITIALIZED = undefined;
+	} else {
+		this.STATE_INITIALIZED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_PAUSED) {
+		throw new Error('Ti.Media.Sound.STATE_PAUSED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_PAUSED = undefined;
+	} else {
+		this.STATE_PAUSED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_PLAYING) {
+		throw new Error('Ti.Media.Sound.STATE_PLAYING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_PLAYING = undefined;
+	} else {
+		this.STATE_PLAYING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_STARTING) {
+		throw new Error('Ti.Media.Sound.STATE_STARTING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_STARTING = undefined;
+	} else {
+		this.STATE_STARTING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_STOPPED) {
+		throw new Error('Ti.Media.Sound.STATE_STOPPED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_STOPPED = undefined;
+	} else {
+		this.STATE_STOPPED = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_STOPPING) {
+		throw new Error('Ti.Media.Sound.STATE_STOPPING is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_STOPPING = undefined;
+	} else {
+		this.STATE_STOPPING = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_WAITING_FOR_DATA) {
+		throw new Error('Ti.Media.Sound.STATE_WAITING_FOR_DATA is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_WAITING_FOR_DATA = undefined;
+	} else {
+		this.STATE_WAITING_FOR_DATA = 0;
+	}
+	if (__SLAG_PROPERTIES.STATE_WAITING_FOR_QUEUE) {
+		throw new Error('Ti.Media.Sound.STATE_WAITING_FOR_QUEUE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STATE_WAITING_FOR_QUEUE = undefined;
+	} else {
+		this.STATE_WAITING_FOR_QUEUE = 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowBackground = undefined;
+	} else {
+		this.allowBackground = __SLAG_PROPERTIES.allowBackground || true;
+	}
+	if (__SLAG_PROPERTIES.duration) {
+		throw new Error('Ti.Media.Sound.duration is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.looping = undefined;
+	} else {
+		this.looping = __SLAG_PROPERTIES.looping || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paused = undefined;
+	} else {
+		this.paused = __SLAG_PROPERTIES.paused || true;
+	}
+	if (__SLAG_PROPERTIES.playing) {
+		throw new Error('Ti.Media.Sound.playing is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playing = undefined;
+	} else {
+		this.playing = true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.time = undefined;
+	} else {
+		this.time = __SLAG_PROPERTIES.time || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.volume = undefined;
+	} else {
+		this.volume = __SLAG_PROPERTIES.volume || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Sound.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Sound.prototype.isLooping = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Sound.prototype.isPaused = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Sound.prototype.isPlaying = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Sound.prototype.pause = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.play = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.release = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.reset = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.setLooping = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.looping = __SLAG__PROPERTY;
+};
+Sound.prototype.setPaused = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.paused = __SLAG__PROPERTY;
+};
+Sound.prototype.stop = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Sound.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Sound.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Sound.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Sound.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Sound.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Sound.prototype.getDuration = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.duration;
+};
+Sound.prototype.getTime = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.time;
+};
+Sound.prototype.setTime = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.time = __SLAG__PROPERTY;
+};
+Sound.prototype.getUrl = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+Sound.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+Sound.prototype.getVolume = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.volume;
+};
+Sound.prototype.setVolume = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.volume = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Sound(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Media/VideoPlayer.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Media/VideoPlayer.js
@@ -1,0 +1,2213 @@
+var crypto = require('crypto');
+function VideoPlayer(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'allowsAirPlay',
+			'autoplay',
+			'backgroundView',
+			'contentURL',
+			'currentPlaybackTime',
+			'duration',
+			'endPlaybackTime',
+			'fullscreen',
+			'initialPlaybackTime',
+			'loadState',
+			'media',
+			'mediaControlStyle',
+			'mediaTypes',
+			'movieControlMode',
+			'naturalSize',
+			'playableDuration',
+			'playbackState',
+			'playing',
+			'repeatMode',
+			'scalingMode',
+			'sourceType',
+			'url',
+			'useApplicationAudioSession',
+			'volume',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Media.VideoPlayer.apiName is read only property');
+	}
+	this.apiName = 'Ti.Media.VideoPlayer';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.Media.VideoPlayer.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.Media.VideoPlayer.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.Media.VideoPlayer.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.Media.VideoPlayer.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsAirPlay = undefined;
+	} else {
+		this.allowsAirPlay = __SLAG_PROPERTIES.allowsAirPlay || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoplay = undefined;
+	} else {
+		this.autoplay = __SLAG_PROPERTIES.autoplay || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundView = undefined;
+	} else {
+		this.backgroundView = __SLAG_PROPERTIES.backgroundView || {};
+	}
+	if (__SLAG_PROPERTIES.contentURL) {
+		throw new Error('Ti.Media.VideoPlayer.contentURL was deprecated, since 1.4.0');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentPlaybackTime = undefined;
+	} else {
+		this.currentPlaybackTime = __SLAG_PROPERTIES.currentPlaybackTime || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.endPlaybackTime = undefined;
+	} else {
+		this.endPlaybackTime = __SLAG_PROPERTIES.endPlaybackTime || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullscreen = undefined;
+	} else {
+		this.fullscreen = __SLAG_PROPERTIES.fullscreen || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.initialPlaybackTime = undefined;
+	} else {
+		this.initialPlaybackTime = __SLAG_PROPERTIES.initialPlaybackTime || 0;
+	}
+	if (__SLAG_PROPERTIES.loadState) {
+		throw new Error('Ti.Media.VideoPlayer.loadState is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.loadState = undefined;
+	} else {
+		this.loadState = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.media = undefined;
+	} else {
+		this.media = __SLAG_PROPERTIES.media || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaControlStyle = undefined;
+	} else {
+		this.mediaControlStyle = __SLAG_PROPERTIES.mediaControlStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mediaTypes = undefined;
+	} else {
+		this.mediaTypes = __SLAG_PROPERTIES.mediaTypes || 0;
+	}
+	if (__SLAG_PROPERTIES.movieControlMode) {
+		throw new Error('Ti.Media.VideoPlayer.movieControlMode was deprecated, since 1.8.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.naturalSize = undefined;
+	} else {
+		this.naturalSize = __SLAG_PROPERTIES.naturalSize || {};
+	}
+	if (__SLAG_PROPERTIES.playableDuration) {
+		throw new Error('Ti.Media.VideoPlayer.playableDuration is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playableDuration = undefined;
+	} else {
+		this.playableDuration = 0;
+	}
+	if (__SLAG_PROPERTIES.playbackState) {
+		throw new Error('Ti.Media.VideoPlayer.playbackState is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playbackState = undefined;
+	} else {
+		this.playbackState = 0;
+	}
+	if (__SLAG_PROPERTIES.playing) {
+		throw new Error('Ti.Media.VideoPlayer.playing is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.playing = undefined;
+	} else {
+		this.playing = true;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.repeatMode = undefined;
+	} else {
+		this.repeatMode = __SLAG_PROPERTIES.repeatMode || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scalingMode = undefined;
+	} else {
+		this.scalingMode = __SLAG_PROPERTIES.scalingMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sourceType = undefined;
+	} else {
+		this.sourceType = __SLAG_PROPERTIES.sourceType || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	if (__SLAG_PROPERTIES.useApplicationAudioSession) {
+		throw new Error('Ti.Media.VideoPlayer.useApplicationAudioSession was deprecated, since 3.5.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.volume = undefined;
+	} else {
+		this.volume = __SLAG_PROPERTIES.volume || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+VideoPlayer.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+VideoPlayer.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+VideoPlayer.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.finishLayout = function () {
+	throw new Error('Ti.Media.VideoPlayer.finishLayout was deprecated, since 3.0.0');
+};
+VideoPlayer.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+VideoPlayer.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.startLayout = function () {
+	throw new Error('Ti.Media.VideoPlayer.startLayout was deprecated, since 3.0.0');
+};
+VideoPlayer.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+VideoPlayer.prototype.updateLayout = function () {
+	throw new Error('Ti.Media.VideoPlayer.updateLayout was deprecated, since 3.0.0');
+};
+VideoPlayer.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+VideoPlayer.prototype.cancelAllThumbnailImageRequests = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.pause = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.play = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.release = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.requestThumbnailImagesAtTimes = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.stop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+VideoPlayer.prototype.thumbnailImageAtTime = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+VideoPlayer.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+VideoPlayer.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+VideoPlayer.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+VideoPlayer.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+VideoPlayer.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+VideoPlayer.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+VideoPlayer.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+VideoPlayer.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+VideoPlayer.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+VideoPlayer.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+VideoPlayer.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+VideoPlayer.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+VideoPlayer.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+VideoPlayer.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+VideoPlayer.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+VideoPlayer.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+VideoPlayer.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+VideoPlayer.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+VideoPlayer.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+VideoPlayer.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+VideoPlayer.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+VideoPlayer.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+VideoPlayer.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+VideoPlayer.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+VideoPlayer.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+VideoPlayer.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+VideoPlayer.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+VideoPlayer.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+VideoPlayer.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+VideoPlayer.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+VideoPlayer.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+VideoPlayer.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+VideoPlayer.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+VideoPlayer.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+VideoPlayer.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+VideoPlayer.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+VideoPlayer.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+VideoPlayer.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+VideoPlayer.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+VideoPlayer.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+VideoPlayer.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+VideoPlayer.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+VideoPlayer.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+VideoPlayer.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+VideoPlayer.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+VideoPlayer.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+VideoPlayer.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+VideoPlayer.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+VideoPlayer.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+VideoPlayer.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+VideoPlayer.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+VideoPlayer.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+VideoPlayer.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+VideoPlayer.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+VideoPlayer.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+VideoPlayer.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+VideoPlayer.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+VideoPlayer.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+VideoPlayer.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+VideoPlayer.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+VideoPlayer.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+VideoPlayer.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+VideoPlayer.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+VideoPlayer.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAllowsAirPlay = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsAirPlay;
+};
+VideoPlayer.prototype.setAllowsAirPlay = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsAirPlay = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getAutoplay = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoplay;
+};
+VideoPlayer.prototype.setAutoplay = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoplay = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getBackgroundView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundView;
+};
+VideoPlayer.prototype.setBackgroundView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundView = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getContentURL = function () {
+	throw new Error('Ti.Media.VideoPlayer.getContentURL was deprecated, since 1.4.0');
+};
+VideoPlayer.prototype.setContentURL = function () {
+	throw new Error('Ti.Media.VideoPlayer.setContentURL was deprecated, since 1.4.0');
+};
+VideoPlayer.prototype.getCurrentPlaybackTime = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentPlaybackTime;
+};
+VideoPlayer.prototype.setCurrentPlaybackTime = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.currentPlaybackTime = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getDuration = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.duration;
+};
+VideoPlayer.prototype.setDuration = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.duration = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getEndPlaybackTime = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.endPlaybackTime;
+};
+VideoPlayer.prototype.setEndPlaybackTime = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.endPlaybackTime = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getFullscreen = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fullscreen;
+};
+VideoPlayer.prototype.setFullscreen = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fullscreen = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getInitialPlaybackTime = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.initialPlaybackTime;
+};
+VideoPlayer.prototype.setInitialPlaybackTime = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.initialPlaybackTime = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getLoadState = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.loadState;
+};
+VideoPlayer.prototype.setMedia = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.media = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getMediaControlStyle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mediaControlStyle;
+};
+VideoPlayer.prototype.setMediaControlStyle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mediaControlStyle = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getMediaTypes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mediaTypes;
+};
+VideoPlayer.prototype.setMediaTypes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mediaTypes = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getMovieControlMode = function () {
+	throw new Error('Ti.Media.VideoPlayer.getMovieControlMode was deprecated, since 1.8.0');
+};
+VideoPlayer.prototype.setMovieControlMode = function () {
+	throw new Error('Ti.Media.VideoPlayer.setMovieControlMode was deprecated, since 1.8.0');
+};
+VideoPlayer.prototype.getNaturalSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.naturalSize;
+};
+VideoPlayer.prototype.setNaturalSize = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.naturalSize = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getPlayableDuration = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playableDuration;
+};
+VideoPlayer.prototype.getPlaybackState = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playbackState;
+};
+VideoPlayer.prototype.getPlaying = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.playing;
+};
+VideoPlayer.prototype.getRepeatMode = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.repeatMode;
+};
+VideoPlayer.prototype.setRepeatMode = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.repeatMode = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getScalingMode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scalingMode;
+};
+VideoPlayer.prototype.setScalingMode = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scalingMode = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getSourceType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sourceType;
+};
+VideoPlayer.prototype.setSourceType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.sourceType = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getUrl = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+VideoPlayer.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+VideoPlayer.prototype.getUseApplicationAudioSession = function () {
+	throw new Error('Ti.Media.VideoPlayer.getUseApplicationAudioSession was deprecated, since 3.5.0');
+};
+VideoPlayer.prototype.setUseApplicationAudioSession = function () {
+	throw new Error('Ti.Media.VideoPlayer.setUseApplicationAudioSession was deprecated, since 3.5.0');
+};
+VideoPlayer.prototype.getVolume = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.volume;
+};
+VideoPlayer.prototype.setVolume = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.volume = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new VideoPlayer(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Module.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Module.js
@@ -1,0 +1,118 @@
+var crypto = require('crypto');
+function Module(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Module.apiName is read only property');
+	}
+	this.apiName = 'Ti.Module';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Module.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Module.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Module.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Module.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Module.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Module.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Module.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Module.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Module.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Module(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network.js
@@ -1,0 +1,599 @@
+var crypto = require('crypto');
+function Network(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'INADDR_ANY',
+			'NETWORK_LAN',
+			'NETWORK_MOBILE',
+			'NETWORK_NONE',
+			'NETWORK_UNKNOWN',
+			'NETWORK_WIFI',
+			'NOTIFICATION_TYPE_ALERT',
+			'NOTIFICATION_TYPE_BADGE',
+			'NOTIFICATION_TYPE_SOUND',
+			'NOTIFICATION_TYPE_NEWSSTAND',
+			'READ_MODE',
+			'READ_WRITE_MODE',
+			'SOCKET_CLOSED',
+			'SOCKET_CONNECTED',
+			'SOCKET_ERROR',
+			'SOCKET_INITIALIZED',
+			'SOCKET_LISTENING',
+			'WRITE_MODE',
+			'TLS_VERSION_1_0',
+			'TLS_VERSION_1_1',
+			'TLS_VERSION_1_2',
+			'PROGRESS_UNKNOWN',
+			'allHTTPCookies',
+			'networkType',
+			'networkTypeName',
+			'online',
+			'remoteDeviceUUID',
+			'remoteNotificationTypes',
+			'remoteNotificationsEnabled',
+			'httpURLFormatter',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.INADDR_ANY) {
+		throw new Error('Ti.Network.INADDR_ANY was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.NETWORK_LAN) {
+		throw new Error('Ti.Network.NETWORK_LAN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NETWORK_LAN = undefined;
+	} else {
+		this.NETWORK_LAN = 0;
+	}
+	if (__SLAG_PROPERTIES.NETWORK_MOBILE) {
+		throw new Error('Ti.Network.NETWORK_MOBILE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NETWORK_MOBILE = undefined;
+	} else {
+		this.NETWORK_MOBILE = 0;
+	}
+	if (__SLAG_PROPERTIES.NETWORK_NONE) {
+		throw new Error('Ti.Network.NETWORK_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NETWORK_NONE = undefined;
+	} else {
+		this.NETWORK_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.NETWORK_UNKNOWN) {
+		throw new Error('Ti.Network.NETWORK_UNKNOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NETWORK_UNKNOWN = undefined;
+	} else {
+		this.NETWORK_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.NETWORK_WIFI) {
+		throw new Error('Ti.Network.NETWORK_WIFI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NETWORK_WIFI = undefined;
+	} else {
+		this.NETWORK_WIFI = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTIFICATION_TYPE_ALERT) {
+		throw new Error('Ti.Network.NOTIFICATION_TYPE_ALERT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTIFICATION_TYPE_ALERT = undefined;
+	} else {
+		this.NOTIFICATION_TYPE_ALERT = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTIFICATION_TYPE_BADGE) {
+		throw new Error('Ti.Network.NOTIFICATION_TYPE_BADGE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTIFICATION_TYPE_BADGE = undefined;
+	} else {
+		this.NOTIFICATION_TYPE_BADGE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTIFICATION_TYPE_SOUND) {
+		throw new Error('Ti.Network.NOTIFICATION_TYPE_SOUND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTIFICATION_TYPE_SOUND = undefined;
+	} else {
+		this.NOTIFICATION_TYPE_SOUND = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTIFICATION_TYPE_NEWSSTAND) {
+		throw new Error('Ti.Network.NOTIFICATION_TYPE_NEWSSTAND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTIFICATION_TYPE_NEWSSTAND = undefined;
+	} else {
+		this.NOTIFICATION_TYPE_NEWSSTAND = 0;
+	}
+	if (__SLAG_PROPERTIES.READ_MODE) {
+		throw new Error('Ti.Network.READ_MODE was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.READ_WRITE_MODE) {
+		throw new Error('Ti.Network.READ_WRITE_MODE was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.SOCKET_CLOSED) {
+		throw new Error('Ti.Network.SOCKET_CLOSED was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.SOCKET_CONNECTED) {
+		throw new Error('Ti.Network.SOCKET_CONNECTED was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.SOCKET_ERROR) {
+		throw new Error('Ti.Network.SOCKET_ERROR was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.SOCKET_INITIALIZED) {
+		throw new Error('Ti.Network.SOCKET_INITIALIZED was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.SOCKET_LISTENING) {
+		throw new Error('Ti.Network.SOCKET_LISTENING was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.WRITE_MODE) {
+		throw new Error('Ti.Network.WRITE_MODE was deprecated, since 1.7.0');
+	}
+	if (__SLAG_PROPERTIES.TLS_VERSION_1_0) {
+		throw new Error('Ti.Network.TLS_VERSION_1_0 is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TLS_VERSION_1_0 = undefined;
+	} else {
+		this.TLS_VERSION_1_0 = 0;
+	}
+	if (__SLAG_PROPERTIES.TLS_VERSION_1_1) {
+		throw new Error('Ti.Network.TLS_VERSION_1_1 is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TLS_VERSION_1_1 = undefined;
+	} else {
+		this.TLS_VERSION_1_1 = 0;
+	}
+	if (__SLAG_PROPERTIES.TLS_VERSION_1_2) {
+		throw new Error('Ti.Network.TLS_VERSION_1_2 is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TLS_VERSION_1_2 = undefined;
+	} else {
+		this.TLS_VERSION_1_2 = 0;
+	}
+	if (__SLAG_PROPERTIES.PROGRESS_UNKNOWN) {
+		throw new Error('Ti.Network.PROGRESS_UNKNOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROGRESS_UNKNOWN = undefined;
+	} else {
+		this.PROGRESS_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.allHTTPCookies) {
+		throw new Error('Ti.Network.allHTTPCookies is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allHTTPCookies = undefined;
+	} else {
+		this.allHTTPCookies = [];
+	}
+	if (__SLAG_PROPERTIES.networkType) {
+		throw new Error('Ti.Network.networkType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.networkType = undefined;
+	} else {
+		this.networkType = 0;
+	}
+	if (__SLAG_PROPERTIES.networkTypeName) {
+		throw new Error('Ti.Network.networkTypeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.networkTypeName = undefined;
+	} else {
+		this.networkTypeName = '';
+	}
+	if (__SLAG_PROPERTIES.online) {
+		throw new Error('Ti.Network.online is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.online = undefined;
+	} else {
+		this.online = true;
+	}
+	if (__SLAG_PROPERTIES.remoteDeviceUUID) {
+		throw new Error('Ti.Network.remoteDeviceUUID is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.remoteDeviceUUID = undefined;
+	} else {
+		this.remoteDeviceUUID = '';
+	}
+	if (__SLAG_PROPERTIES.remoteNotificationTypes) {
+		throw new Error('Ti.Network.remoteNotificationTypes is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.remoteNotificationTypes = undefined;
+	} else {
+		this.remoteNotificationTypes = 0;
+	}
+	if (__SLAG_PROPERTIES.remoteNotificationsEnabled) {
+		throw new Error('Ti.Network.remoteNotificationsEnabled is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.remoteNotificationsEnabled = undefined;
+	} else {
+		this.remoteNotificationsEnabled = true;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.httpURLFormatter = undefined;
+	} else {
+		this.httpURLFormatter = __SLAG_PROPERTIES.httpURLFormatter || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Network.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Network.prototype.addConnectivityListener = function () {
+	throw new Error('Ti.Network.addConnectivityListener was deprecated, since 1.7.0');
+};
+Network.prototype.addHTTPCookie = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.addSystemCookie = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.createBonjourBrowser = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var BonjourBrowser = require('./Network/BonjourBrowser');
+	return BonjourBrowser(__SLAG_PROPERTY);
+};
+Network.prototype.createBonjourService = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var BonjourService = require('./Network/BonjourService');
+	return BonjourService(__SLAG_PROPERTY);
+};
+Network.prototype.createTCPSocket = function () {
+	throw new Error('Ti.Network.createTCPSocket was deprecated, since 1.7.0');
+};
+Network.prototype.decodeURIComponent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Network.prototype.encodeURIComponent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Network.prototype.getHTTPCookies = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Network.prototype.getHTTPCookiesForDomain = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Network.prototype.getSystemCookies = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Network.prototype.removeAllHTTPCookies = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.removeAllSystemCookies = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.removeHTTPCookie = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.removeHTTPCookiesForDomain = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.removeSystemCookie = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.registerForPushNotifications = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.removeConnectivityListener = function () {
+	throw new Error('Ti.Network.removeConnectivityListener was deprecated, since 1.7.0');
+};
+Network.prototype.unregisterForPushNotifications = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Network.prototype.createCookie = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Cookie = require('./Network/Cookie');
+	return Cookie(__SLAG_PROPERTY);
+};
+Network.prototype.createHTTPClient = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var HTTPClient = require('./Network/HTTPClient');
+	return HTTPClient(__SLAG_PROPERTY);
+};
+Network.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Network.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Network.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Network.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Network.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Network.prototype.getAllHTTPCookies = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allHTTPCookies;
+};
+Network.prototype.getNetworkType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.networkType;
+};
+Network.prototype.getNetworkTypeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.networkTypeName;
+};
+Network.prototype.getOnline = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.online;
+};
+Network.prototype.getRemoteDeviceUUID = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.remoteDeviceUUID;
+};
+Network.prototype.getRemoteNotificationTypes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.remoteNotificationTypes;
+};
+Network.prototype.getRemoteNotificationsEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.remoteNotificationsEnabled;
+};
+Network.prototype.getHttpURLFormatter = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.httpURLFormatter;
+};
+Network.prototype.setHttpURLFormatter = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.httpURLFormatter = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Network(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network/BonjourBrowser.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network/BonjourBrowser.js
@@ -1,0 +1,139 @@
+var crypto = require('crypto');
+function BonjourBrowser(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'domain',
+			'isSearching',
+			'serviceType',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.BonjourBrowser.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network.BonjourBrowser';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.domain = undefined;
+	} else {
+		this.domain = __SLAG_PROPERTIES.domain || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isSearching = undefined;
+	} else {
+		this.isSearching = __SLAG_PROPERTIES.isSearching || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.serviceType = undefined;
+	} else {
+		this.serviceType = __SLAG_PROPERTIES.serviceType || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+BonjourBrowser.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourBrowser.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourBrowser.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourBrowser.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+BonjourBrowser.prototype.search = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourBrowser.prototype.stopSearch = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourBrowser.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+BonjourBrowser.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+BonjourBrowser.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+BonjourBrowser.prototype.getDomain = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.domain;
+};
+BonjourBrowser.prototype.setDomain = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.domain = __SLAG__PROPERTY;
+};
+BonjourBrowser.prototype.getIsSearching = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isSearching;
+};
+BonjourBrowser.prototype.setIsSearching = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.isSearching = __SLAG__PROPERTY;
+};
+BonjourBrowser.prototype.getServiceType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.serviceType;
+};
+BonjourBrowser.prototype.setServiceType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.serviceType = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new BonjourBrowser(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network/BonjourService.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network/BonjourService.js
@@ -1,0 +1,180 @@
+var crypto = require('crypto');
+function BonjourService(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'domain',
+			'isLocal',
+			'name',
+			'socket',
+			'type',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.BonjourService.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network.BonjourService';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.domain = undefined;
+	} else {
+		this.domain = __SLAG_PROPERTIES.domain || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isLocal = undefined;
+	} else {
+		this.isLocal = __SLAG_PROPERTIES.isLocal || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_PROPERTIES.name || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.socket = undefined;
+	} else {
+		this.socket = __SLAG_PROPERTIES.socket || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+BonjourService.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourService.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourService.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourService.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+BonjourService.prototype.publish = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourService.prototype.resolve = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourService.prototype.stop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BonjourService.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+BonjourService.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+BonjourService.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+BonjourService.prototype.getDomain = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.domain;
+};
+BonjourService.prototype.setDomain = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.domain = __SLAG__PROPERTY;
+};
+BonjourService.prototype.getIsLocal = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isLocal;
+};
+BonjourService.prototype.setIsLocal = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.isLocal = __SLAG__PROPERTY;
+};
+BonjourService.prototype.getName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+BonjourService.prototype.setName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.name = __SLAG__PROPERTY;
+};
+BonjourService.prototype.getSocket = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.socket;
+};
+BonjourService.prototype.setSocket = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.socket = __SLAG__PROPERTY;
+};
+BonjourService.prototype.getType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+BonjourService.prototype.setType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.type = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new BonjourService(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network/Cookie.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network/Cookie.js
@@ -1,0 +1,384 @@
+var crypto = require('crypto');
+function Cookie(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'comment',
+			'domain',
+			'expiryDate',
+			'maxAge',
+			'httponly',
+			'name',
+			'originalUrl',
+			'path',
+			'secure',
+			'value',
+			'version',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.Cookie.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network.Cookie';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.comment = undefined;
+	} else {
+		this.comment = __SLAG_PROPERTIES.comment || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.domain = undefined;
+	} else {
+		this.domain = __SLAG_PROPERTIES.domain || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.expiryDate = undefined;
+	} else {
+		this.expiryDate = __SLAG_PROPERTIES.expiryDate || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxAge = undefined;
+	} else {
+		this.maxAge = __SLAG_PROPERTIES.maxAge || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.httponly = undefined;
+	} else {
+		this.httponly = __SLAG_PROPERTIES.httponly || true;
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.Network.Cookie.name is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.originalUrl = undefined;
+	} else {
+		this.originalUrl = __SLAG_PROPERTIES.originalUrl || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.path = undefined;
+	} else {
+		this.path = __SLAG_PROPERTIES.path || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.secure = undefined;
+	} else {
+		this.secure = __SLAG_PROPERTIES.secure || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.version = undefined;
+	} else {
+		this.version = __SLAG_PROPERTIES.version || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Cookie.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Cookie.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Cookie.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Cookie.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Cookie.prototype.isValid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Cookie.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Cookie.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Cookie.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Cookie.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Cookie.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Cookie.prototype.getComment = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.comment;
+};
+Cookie.prototype.setComment = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.comment = __SLAG__PROPERTY;
+};
+Cookie.prototype.getDomain = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.domain;
+};
+Cookie.prototype.setDomain = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.domain = __SLAG__PROPERTY;
+};
+Cookie.prototype.getExpiryDate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.expiryDate;
+};
+Cookie.prototype.setExpiryDate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.expiryDate = __SLAG__PROPERTY;
+};
+Cookie.prototype.getMaxAge = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxAge;
+};
+Cookie.prototype.setMaxAge = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxAge = __SLAG__PROPERTY;
+};
+Cookie.prototype.getHttponly = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.httponly;
+};
+Cookie.prototype.setHttponly = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.httponly = __SLAG__PROPERTY;
+};
+Cookie.prototype.getName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+Cookie.prototype.getOriginalUrl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.originalUrl;
+};
+Cookie.prototype.setOriginalUrl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.originalUrl = __SLAG__PROPERTY;
+};
+Cookie.prototype.getPath = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.path;
+};
+Cookie.prototype.setPath = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.path = __SLAG__PROPERTY;
+};
+Cookie.prototype.getSecure = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.secure;
+};
+Cookie.prototype.setSecure = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.secure = __SLAG__PROPERTY;
+};
+Cookie.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+Cookie.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Cookie.prototype.getVersion = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.version;
+};
+Cookie.prototype.setVersion = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.version = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Cookie(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network/HTTPClient.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network/HTTPClient.js
@@ -1,0 +1,958 @@
+var crypto = require('crypto');
+function HTTPClient(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'DONE',
+			'HEADERS_RECEIVED',
+			'LOADING',
+			'OPENED',
+			'UNSENT',
+			'allResponseHeaders',
+			'autoEncodeUrl',
+			'autoRedirect',
+			'connected',
+			'connectionType',
+			'domain',
+			'enableKeepAlive',
+			'file',
+			'location',
+			'ondatastream',
+			'onerror',
+			'onload',
+			'onreadystatechange',
+			'onsendstream',
+			'password',
+			'readyState',
+			'responseData',
+			'responseText',
+			'responseXML',
+			'securityManager',
+			'status',
+			'statusText',
+			'timeout',
+			'username',
+			'validatesSecureCertificate',
+			'withCredentials',
+			'tlsVersion',
+			'cache',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.HTTPClient.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network.HTTPClient';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.DONE) {
+		throw new Error('Ti.Network.HTTPClient.DONE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DONE = undefined;
+	} else {
+		this.DONE = 0;
+	}
+	if (__SLAG_PROPERTIES.HEADERS_RECEIVED) {
+		throw new Error('Ti.Network.HTTPClient.HEADERS_RECEIVED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.HEADERS_RECEIVED = undefined;
+	} else {
+		this.HEADERS_RECEIVED = 0;
+	}
+	if (__SLAG_PROPERTIES.LOADING) {
+		throw new Error('Ti.Network.HTTPClient.LOADING is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LOADING = undefined;
+	} else {
+		this.LOADING = 0;
+	}
+	if (__SLAG_PROPERTIES.OPENED) {
+		throw new Error('Ti.Network.HTTPClient.OPENED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.OPENED = undefined;
+	} else {
+		this.OPENED = 0;
+	}
+	if (__SLAG_PROPERTIES.UNSENT) {
+		throw new Error('Ti.Network.HTTPClient.UNSENT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNSENT = undefined;
+	} else {
+		this.UNSENT = 0;
+	}
+	if (__SLAG_PROPERTIES.allResponseHeaders) {
+		throw new Error('Ti.Network.HTTPClient.allResponseHeaders is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allResponseHeaders = undefined;
+	} else {
+		this.allResponseHeaders = '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoEncodeUrl = undefined;
+	} else {
+		this.autoEncodeUrl = __SLAG_PROPERTIES.autoEncodeUrl || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoRedirect = undefined;
+	} else {
+		this.autoRedirect = __SLAG_PROPERTIES.autoRedirect || true;
+	}
+	if (__SLAG_PROPERTIES.connected) {
+		throw new Error('Ti.Network.HTTPClient.connected is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.connected = undefined;
+	} else {
+		this.connected = true;
+	}
+	if (__SLAG_PROPERTIES.connectionType) {
+		throw new Error('Ti.Network.HTTPClient.connectionType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.connectionType = undefined;
+	} else {
+		this.connectionType = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.domain = undefined;
+	} else {
+		this.domain = __SLAG_PROPERTIES.domain || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enableKeepAlive = undefined;
+	} else {
+		this.enableKeepAlive = __SLAG_PROPERTIES.enableKeepAlive || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.file = undefined;
+	} else {
+		this.file = __SLAG_PROPERTIES.file || '';
+	}
+	if (__SLAG_PROPERTIES.location) {
+		throw new Error('Ti.Network.HTTPClient.location is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.location = undefined;
+	} else {
+		this.location = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ondatastream = undefined;
+	} else {
+		this.ondatastream = __SLAG_PROPERTIES.ondatastream || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onerror = undefined;
+	} else {
+		this.onerror = __SLAG_PROPERTIES.onerror || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onload = undefined;
+	} else {
+		this.onload = __SLAG_PROPERTIES.onload || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onreadystatechange = undefined;
+	} else {
+		this.onreadystatechange = __SLAG_PROPERTIES.onreadystatechange || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onsendstream = undefined;
+	} else {
+		this.onsendstream = __SLAG_PROPERTIES.onsendstream || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.password = undefined;
+	} else {
+		this.password = __SLAG_PROPERTIES.password || '';
+	}
+	if (__SLAG_PROPERTIES.readyState) {
+		throw new Error('Ti.Network.HTTPClient.readyState is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.readyState = undefined;
+	} else {
+		this.readyState = 0;
+	}
+	if (__SLAG_PROPERTIES.responseData) {
+		throw new Error('Ti.Network.HTTPClient.responseData is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.responseData = undefined;
+	} else {
+		this.responseData = {};
+	}
+	if (__SLAG_PROPERTIES.responseText) {
+		throw new Error('Ti.Network.HTTPClient.responseText is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.responseText = undefined;
+	} else {
+		this.responseText = '';
+	}
+	if (__SLAG_PROPERTIES.responseXML) {
+		throw new Error('Ti.Network.HTTPClient.responseXML is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.responseXML = undefined;
+	} else {
+		this.responseXML = {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.securityManager = undefined;
+	} else {
+		this.securityManager = __SLAG_PROPERTIES.securityManager || {};
+	}
+	if (__SLAG_PROPERTIES.status) {
+		throw new Error('Ti.Network.HTTPClient.status is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.status = undefined;
+	} else {
+		this.status = 0;
+	}
+	if (__SLAG_PROPERTIES.statusText) {
+		throw new Error('Ti.Network.HTTPClient.statusText is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.statusText = undefined;
+	} else {
+		this.statusText = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.timeout = undefined;
+	} else {
+		this.timeout = __SLAG_PROPERTIES.timeout || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.username = undefined;
+	} else {
+		this.username = __SLAG_PROPERTIES.username || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.validatesSecureCertificate = undefined;
+	} else {
+		this.validatesSecureCertificate = __SLAG_PROPERTIES.validatesSecureCertificate || true;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.withCredentials = undefined;
+	} else {
+		this.withCredentials = __SLAG_PROPERTIES.withCredentials || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tlsVersion = undefined;
+	} else {
+		this.tlsVersion = __SLAG_PROPERTIES.tlsVersion || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cache = undefined;
+	} else {
+		this.cache = __SLAG_PROPERTIES.cache || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+HTTPClient.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+HTTPClient.prototype.abort = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.addAuthFactory = function () {
+	throw new Error('Ti.Network.HTTPClient.addAuthFactory was deprecated, since 5.0.0');
+};
+HTTPClient.prototype.addKeyManager = function () {
+	throw new Error('Ti.Network.HTTPClient.addKeyManager was deprecated, since 3.3.0');
+};
+HTTPClient.prototype.addTrustManager = function () {
+	throw new Error('Ti.Network.HTTPClient.addTrustManager was deprecated, since 3.3.0');
+};
+HTTPClient.prototype.clearCookies = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.getResponseHeader = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+HTTPClient.prototype.open = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.send = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.setRequestHeader = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+HTTPClient.prototype.setTimeout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.timeout = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+HTTPClient.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+HTTPClient.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+HTTPClient.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getAllResponseHeaders = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allResponseHeaders;
+};
+HTTPClient.prototype.getAutoEncodeUrl = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoEncodeUrl;
+};
+HTTPClient.prototype.setAutoEncodeUrl = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoEncodeUrl = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getAutoRedirect = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoRedirect;
+};
+HTTPClient.prototype.setAutoRedirect = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoRedirect = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getConnected = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.connected;
+};
+HTTPClient.prototype.getConnectionType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.connectionType;
+};
+HTTPClient.prototype.getDomain = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.domain;
+};
+HTTPClient.prototype.setDomain = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.domain = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getEnableKeepAlive = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enableKeepAlive;
+};
+HTTPClient.prototype.setEnableKeepAlive = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enableKeepAlive = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getFile = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.file;
+};
+HTTPClient.prototype.setFile = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.file = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getLocation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.location;
+};
+HTTPClient.prototype.getOndatastream = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ondatastream;
+};
+HTTPClient.prototype.setOndatastream = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ondatastream = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getOnerror = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onerror;
+};
+HTTPClient.prototype.setOnerror = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onerror = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getOnload = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onload;
+};
+HTTPClient.prototype.setOnload = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onload = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getOnreadystatechange = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onreadystatechange;
+};
+HTTPClient.prototype.setOnreadystatechange = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onreadystatechange = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getOnsendstream = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onsendstream;
+};
+HTTPClient.prototype.setOnsendstream = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onsendstream = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getPassword = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.password;
+};
+HTTPClient.prototype.setPassword = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.password = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getReadyState = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.readyState;
+};
+HTTPClient.prototype.getResponseData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.responseData;
+};
+HTTPClient.prototype.getResponseText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.responseText;
+};
+HTTPClient.prototype.getResponseXML = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.responseXML;
+};
+HTTPClient.prototype.getSecurityManager = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.securityManager;
+};
+HTTPClient.prototype.setSecurityManager = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.securityManager = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getStatus = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.status;
+};
+HTTPClient.prototype.getStatusText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.statusText;
+};
+HTTPClient.prototype.getTimeout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.timeout;
+};
+HTTPClient.prototype.setTimeout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.timeout = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getUsername = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.username;
+};
+HTTPClient.prototype.setUsername = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.username = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getValidatesSecureCertificate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.validatesSecureCertificate;
+};
+HTTPClient.prototype.setValidatesSecureCertificate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.validatesSecureCertificate = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getWithCredentials = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.withCredentials;
+};
+HTTPClient.prototype.setWithCredentials = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.withCredentials = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getTlsVersion = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tlsVersion;
+};
+HTTPClient.prototype.setTlsVersion = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tlsVersion = __SLAG__PROPERTY;
+};
+HTTPClient.prototype.getCache = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cache;
+};
+HTTPClient.prototype.setCache = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cache = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new HTTPClient(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network/Socket.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network/Socket.js
@@ -1,0 +1,184 @@
+var crypto = require('crypto');
+function Socket(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'INITIALIZED',
+			'CONNECTED',
+			'LISTENING',
+			'CLOSED',
+			'ERROR',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.Socket.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network.Socket';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.INITIALIZED) {
+		throw new Error('Ti.Network.Socket.INITIALIZED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INITIALIZED = undefined;
+	} else {
+		this.INITIALIZED = 0;
+	}
+	if (__SLAG_PROPERTIES.CONNECTED) {
+		throw new Error('Ti.Network.Socket.CONNECTED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONNECTED = undefined;
+	} else {
+		this.CONNECTED = 0;
+	}
+	if (__SLAG_PROPERTIES.LISTENING) {
+		throw new Error('Ti.Network.Socket.LISTENING is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LISTENING = undefined;
+	} else {
+		this.LISTENING = 0;
+	}
+	if (__SLAG_PROPERTIES.CLOSED) {
+		throw new Error('Ti.Network.Socket.CLOSED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CLOSED = undefined;
+	} else {
+		this.CLOSED = 0;
+	}
+	if (__SLAG_PROPERTIES.ERROR) {
+		throw new Error('Ti.Network.Socket.ERROR is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ERROR = undefined;
+	} else {
+		this.ERROR = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Socket.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Socket.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Socket.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Socket.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Socket.prototype.createTCP = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TCP = require('./Socket/TCP');
+	return TCP(__SLAG_PROPERTY);
+};
+Socket.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Socket.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Socket.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Socket.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Socket.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Socket(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network/Socket/TCP.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network/Socket/TCP.js
@@ -1,0 +1,392 @@
+var crypto = require('crypto');
+function TCP(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'host',
+			'port',
+			'listenQueueSize',
+			'timeout',
+			'connected',
+			'error',
+			'accepted',
+			'state',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.Socket.TCP.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network.Socket.TCP';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.host = undefined;
+	} else {
+		this.host = __SLAG_PROPERTIES.host || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.port = undefined;
+	} else {
+		this.port = __SLAG_PROPERTIES.port || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.listenQueueSize = undefined;
+	} else {
+		this.listenQueueSize = __SLAG_PROPERTIES.listenQueueSize || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.timeout = undefined;
+	} else {
+		this.timeout = __SLAG_PROPERTIES.timeout || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.connected = undefined;
+	} else {
+		this.connected = __SLAG_PROPERTIES.connected || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accepted = undefined;
+	} else {
+		this.accepted = __SLAG_PROPERTIES.accepted || {};
+	}
+	if (__SLAG_PROPERTIES.state) {
+		throw new Error('Ti.Network.Socket.TCP.state is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.state = undefined;
+	} else {
+		this.state = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TCP.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCP.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCP.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCP.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TCP.prototype.read = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+TCP.prototype.write = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+TCP.prototype.isWritable = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+TCP.prototype.isReadable = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+TCP.prototype.close = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCP.prototype.connect = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCP.prototype.listen = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCP.prototype.accept = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCP.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TCP.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TCP.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TCP.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TCP.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TCP.prototype.getHost = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.host;
+};
+TCP.prototype.setHost = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.host = __SLAG__PROPERTY;
+};
+TCP.prototype.getPort = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.port;
+};
+TCP.prototype.setPort = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.port = __SLAG__PROPERTY;
+};
+TCP.prototype.getListenQueueSize = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.listenQueueSize;
+};
+TCP.prototype.setListenQueueSize = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.listenQueueSize = __SLAG__PROPERTY;
+};
+TCP.prototype.getTimeout = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.timeout;
+};
+TCP.prototype.setTimeout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.timeout = __SLAG__PROPERTY;
+};
+TCP.prototype.getConnected = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.connected;
+};
+TCP.prototype.setConnected = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.connected = __SLAG__PROPERTY;
+};
+TCP.prototype.getError = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.error;
+};
+TCP.prototype.setError = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.error = __SLAG__PROPERTY;
+};
+TCP.prototype.getAccepted = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accepted;
+};
+TCP.prototype.setAccepted = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accepted = __SLAG__PROPERTY;
+};
+TCP.prototype.getState = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.state;
+};
+module.exports = function (properties) {
+	return new TCP(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Network/TCPSocket.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Network/TCPSocket.js
@@ -1,0 +1,185 @@
+var crypto = require('crypto');
+function TCPSocket(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'hostName',
+			'isValid',
+			'mode',
+			'port',
+			'stripTerminator',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Network.TCPSocket.apiName is read only property');
+	}
+	this.apiName = 'Ti.Network.TCPSocket';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hostName = undefined;
+	} else {
+		this.hostName = __SLAG_PROPERTIES.hostName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isValid = undefined;
+	} else {
+		this.isValid = __SLAG_PROPERTIES.isValid || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mode = undefined;
+	} else {
+		this.mode = __SLAG_PROPERTIES.mode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.port = undefined;
+	} else {
+		this.port = __SLAG_PROPERTIES.port || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.stripTerminator = undefined;
+	} else {
+		this.stripTerminator = __SLAG_PROPERTIES.stripTerminator || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TCPSocket.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCPSocket.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCPSocket.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCPSocket.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TCPSocket.prototype.close = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCPSocket.prototype.connect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCPSocket.prototype.listen = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCPSocket.prototype.write = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TCPSocket.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TCPSocket.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TCPSocket.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TCPSocket.prototype.getHostName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hostName;
+};
+TCPSocket.prototype.setHostName = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hostName = __SLAG__PROPERTY;
+};
+TCPSocket.prototype.getIsValid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isValid;
+};
+TCPSocket.prototype.setIsValid = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.isValid = __SLAG__PROPERTY;
+};
+TCPSocket.prototype.getMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mode;
+};
+TCPSocket.prototype.setMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mode = __SLAG__PROPERTY;
+};
+TCPSocket.prototype.getPort = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.port;
+};
+TCPSocket.prototype.setPort = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.port = __SLAG__PROPERTY;
+};
+TCPSocket.prototype.getStripTerminator = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.stripTerminator;
+};
+TCPSocket.prototype.setStripTerminator = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.stripTerminator = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TCPSocket(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Platform.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Platform.js
@@ -1,0 +1,656 @@
+var crypto = require('crypto');
+function Platform(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'BATTERY_STATE_CHARGING',
+			'BATTERY_STATE_FULL',
+			'BATTERY_STATE_UNKNOWN',
+			'BATTERY_STATE_UNPLUGGED',
+			'address',
+			'architecture',
+			'availableMemory',
+			'batteryLevel',
+			'batteryMonitoring',
+			'batteryState',
+			'displayCaps',
+			'id',
+			'locale',
+			'macaddress',
+			'manufacturer',
+			'model',
+			'name',
+			'netmask',
+			'osname',
+			'ostype',
+			'processorCount',
+			'runtime',
+			'username',
+			'version',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Platform.apiName is read only property');
+	}
+	this.apiName = 'Ti.Platform';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.BATTERY_STATE_CHARGING) {
+		throw new Error('Ti.Platform.BATTERY_STATE_CHARGING is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BATTERY_STATE_CHARGING = undefined;
+	} else {
+		this.BATTERY_STATE_CHARGING = 0;
+	}
+	if (__SLAG_PROPERTIES.BATTERY_STATE_FULL) {
+		throw new Error('Ti.Platform.BATTERY_STATE_FULL is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BATTERY_STATE_FULL = undefined;
+	} else {
+		this.BATTERY_STATE_FULL = 0;
+	}
+	if (__SLAG_PROPERTIES.BATTERY_STATE_UNKNOWN) {
+		throw new Error('Ti.Platform.BATTERY_STATE_UNKNOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BATTERY_STATE_UNKNOWN = undefined;
+	} else {
+		this.BATTERY_STATE_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.BATTERY_STATE_UNPLUGGED) {
+		throw new Error('Ti.Platform.BATTERY_STATE_UNPLUGGED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BATTERY_STATE_UNPLUGGED = undefined;
+	} else {
+		this.BATTERY_STATE_UNPLUGGED = 0;
+	}
+	if (__SLAG_PROPERTIES.address) {
+		throw new Error('Ti.Platform.address is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.address = undefined;
+	} else {
+		this.address = '';
+	}
+	if (__SLAG_PROPERTIES.architecture) {
+		throw new Error('Ti.Platform.architecture is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.architecture = undefined;
+	} else {
+		this.architecture = __SLAG_DEVICE.architecture || '';
+	}
+	if (__SLAG_PROPERTIES.availableMemory) {
+		throw new Error('Ti.Platform.availableMemory is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.availableMemory = undefined;
+	} else {
+		this.availableMemory = 0;
+	}
+	if (__SLAG_PROPERTIES.batteryLevel) {
+		throw new Error('Ti.Platform.batteryLevel is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.batteryLevel = undefined;
+	} else {
+		this.batteryLevel = 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.batteryMonitoring = undefined;
+	} else {
+		this.batteryMonitoring = __SLAG_PROPERTIES.batteryMonitoring || true;
+	}
+	if (__SLAG_PROPERTIES.batteryState) {
+		throw new Error('Ti.Platform.batteryState is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.batteryState = undefined;
+	} else {
+		this.batteryState = 0;
+	}
+	if (__SLAG_PROPERTIES.displayCaps) {
+		throw new Error('Ti.Platform.displayCaps is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.displayCaps = undefined;
+	} else {
+		this.displayCaps = {};
+	}
+	if (__SLAG_PROPERTIES.id) {
+		throw new Error('Ti.Platform.id is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.id = undefined;
+	} else {
+		this.id = '';
+	}
+	if (__SLAG_PROPERTIES.locale) {
+		throw new Error('Ti.Platform.locale is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.locale = undefined;
+	} else {
+		this.locale = '';
+	}
+	if (__SLAG_PROPERTIES.macaddress) {
+		throw new Error('Ti.Platform.macaddress is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.macaddress = undefined;
+	} else {
+		this.macaddress = '';
+	}
+	if (__SLAG_PROPERTIES.manufacturer) {
+		throw new Error('Ti.Platform.manufacturer is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.manufacturer = undefined;
+	} else {
+		this.manufacturer = '';
+	}
+	if (__SLAG_PROPERTIES.model) {
+		throw new Error('Ti.Platform.model is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.model = undefined;
+	} else {
+		this.model = __SLAG_DEVICE.model || '';
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.Platform.name is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = __SLAG_DEVICE.name || '';
+	}
+	if (__SLAG_PROPERTIES.netmask) {
+		throw new Error('Ti.Platform.netmask is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.netmask = undefined;
+	} else {
+		this.netmask = '';
+	}
+	if (__SLAG_PROPERTIES.osname) {
+		throw new Error('Ti.Platform.osname is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.osname = undefined;
+	} else {
+		this.osname = __SLAG_DEVICE.osname || '';
+	}
+	if (__SLAG_PROPERTIES.ostype) {
+		throw new Error('Ti.Platform.ostype is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ostype = undefined;
+	} else {
+		this.ostype = __SLAG_DEVICE.ostype || '';
+	}
+	if (__SLAG_PROPERTIES.processorCount) {
+		throw new Error('Ti.Platform.processorCount is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.processorCount = undefined;
+	} else {
+		this.processorCount = 0;
+	}
+	if (__SLAG_PROPERTIES.runtime) {
+		throw new Error('Ti.Platform.runtime is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.runtime = undefined;
+	} else {
+		this.runtime = '';
+	}
+	if (__SLAG_PROPERTIES.username) {
+		throw new Error('Ti.Platform.username is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.username = undefined;
+	} else {
+		this.username = '';
+	}
+	if (__SLAG_PROPERTIES.version) {
+		throw new Error('Ti.Platform.version is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.version = undefined;
+	} else {
+		this.version = __SLAG_DEVICE.version || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Platform.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Platform.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Platform.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Platform.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Platform.prototype.canOpenURL = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Platform.prototype.createUUID = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var UUID = require('./Platform/UUID');
+	return UUID(__SLAG_PROPERTY);
+};
+Platform.prototype.openURL = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Platform.prototype.is24HourTimeFormat = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Platform.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Platform.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Platform.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Platform.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Platform.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Platform.prototype.getAddress = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.address;
+};
+Platform.prototype.getArchitecture = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.architecture;
+};
+Platform.prototype.getAvailableMemory = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.availableMemory;
+};
+Platform.prototype.getBatteryLevel = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.batteryLevel;
+};
+Platform.prototype.getBatteryMonitoring = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.batteryMonitoring;
+};
+Platform.prototype.setBatteryMonitoring = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.batteryMonitoring = __SLAG__PROPERTY;
+};
+Platform.prototype.getBatteryState = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.batteryState;
+};
+Platform.prototype.getDisplayCaps = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.displayCaps;
+};
+Platform.prototype.getId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.id;
+};
+Platform.prototype.getLocale = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.locale;
+};
+Platform.prototype.getMacaddress = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.macaddress;
+};
+Platform.prototype.getManufacturer = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.manufacturer;
+};
+Platform.prototype.getModel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.model;
+};
+Platform.prototype.getName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+Platform.prototype.getNetmask = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.netmask;
+};
+Platform.prototype.getOsname = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.osname;
+};
+Platform.prototype.getOstype = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ostype;
+};
+Platform.prototype.getProcessorCount = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.processorCount;
+};
+Platform.prototype.getRuntime = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.runtime;
+};
+Platform.prototype.getUsername = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.username;
+};
+Platform.prototype.getVersion = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.version;
+};
+module.exports = function (properties) {
+	return new Platform(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Platform/Android.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Platform/Android.js
@@ -1,0 +1,162 @@
+var crypto = require('crypto');
+function Android(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'API_LEVEL',
+			'PHYSICAL_SIZE_CATEGORY_LARGE',
+			'PHYSICAL_SIZE_CATEGORY_NORMAL',
+			'PHYSICAL_SIZE_CATEGORY_SMALL',
+			'PHYSICAL_SIZE_CATEGORY_UNDEFINED',
+			'PHYSICAL_SIZE_CATEGORY_XLARGE',
+			'physicalSizeCategory',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Platform.Android.apiName is read only property');
+	}
+	this.apiName = 'Ti.Platform.Android';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.API_LEVEL) {
+		throw new Error('Ti.Platform.Android.API_LEVEL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.API_LEVEL = undefined;
+	} else {
+		this.API_LEVEL = 0;
+	}
+	if (__SLAG_PROPERTIES.PHYSICAL_SIZE_CATEGORY_LARGE) {
+		throw new Error('Ti.Platform.Android.PHYSICAL_SIZE_CATEGORY_LARGE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PHYSICAL_SIZE_CATEGORY_LARGE = undefined;
+	} else {
+		this.PHYSICAL_SIZE_CATEGORY_LARGE = 0;
+	}
+	if (__SLAG_PROPERTIES.PHYSICAL_SIZE_CATEGORY_NORMAL) {
+		throw new Error('Ti.Platform.Android.PHYSICAL_SIZE_CATEGORY_NORMAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PHYSICAL_SIZE_CATEGORY_NORMAL = undefined;
+	} else {
+		this.PHYSICAL_SIZE_CATEGORY_NORMAL = 0;
+	}
+	if (__SLAG_PROPERTIES.PHYSICAL_SIZE_CATEGORY_SMALL) {
+		throw new Error('Ti.Platform.Android.PHYSICAL_SIZE_CATEGORY_SMALL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PHYSICAL_SIZE_CATEGORY_SMALL = undefined;
+	} else {
+		this.PHYSICAL_SIZE_CATEGORY_SMALL = 0;
+	}
+	if (__SLAG_PROPERTIES.PHYSICAL_SIZE_CATEGORY_UNDEFINED) {
+		throw new Error('Ti.Platform.Android.PHYSICAL_SIZE_CATEGORY_UNDEFINED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PHYSICAL_SIZE_CATEGORY_UNDEFINED = undefined;
+	} else {
+		this.PHYSICAL_SIZE_CATEGORY_UNDEFINED = 0;
+	}
+	if (__SLAG_PROPERTIES.PHYSICAL_SIZE_CATEGORY_XLARGE) {
+		throw new Error('Ti.Platform.Android.PHYSICAL_SIZE_CATEGORY_XLARGE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PHYSICAL_SIZE_CATEGORY_XLARGE = undefined;
+	} else {
+		this.PHYSICAL_SIZE_CATEGORY_XLARGE = 0;
+	}
+	if (__SLAG_PROPERTIES.physicalSizeCategory) {
+		throw new Error('Ti.Platform.Android.physicalSizeCategory is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.physicalSizeCategory = undefined;
+	} else {
+		this.physicalSizeCategory = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Android.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Android.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Android.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Android.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Android.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Android.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Android.prototype.getPhysicalSizeCategory = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.physicalSizeCategory;
+};
+module.exports = function (properties) {
+	return new Android(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Platform/DisplayCaps.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Platform/DisplayCaps.js
@@ -1,0 +1,261 @@
+var crypto = require('crypto');
+function DisplayCaps(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'density',
+			'dpi',
+			'logicalDensityFactor',
+			'platformHeight',
+			'platformWidth',
+			'xdpi',
+			'ydpi',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Platform.DisplayCaps.apiName is read only property');
+	}
+	this.apiName = 'Ti.Platform.DisplayCaps';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.density) {
+		throw new Error('Ti.Platform.DisplayCaps.density is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.density = undefined;
+	} else {
+		this.density = __SLAG_DEVICE.displayCaps.density || '';
+	}
+	if (__SLAG_PROPERTIES.dpi) {
+		throw new Error('Ti.Platform.DisplayCaps.dpi is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.dpi = undefined;
+	} else {
+		this.dpi = __SLAG_DEVICE.displayCaps.dpi || 0;
+	}
+	if (__SLAG_PROPERTIES.logicalDensityFactor) {
+		throw new Error('Ti.Platform.DisplayCaps.logicalDensityFactor is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.logicalDensityFactor = undefined;
+	} else {
+		this.logicalDensityFactor = 0;
+	}
+	if (__SLAG_PROPERTIES.platformHeight) {
+		throw new Error('Ti.Platform.DisplayCaps.platformHeight is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.platformHeight = undefined;
+	} else {
+		this.platformHeight = __SLAG_DEVICE.displayCaps.platformHeight || 0;
+	}
+	if (__SLAG_PROPERTIES.platformWidth) {
+		throw new Error('Ti.Platform.DisplayCaps.platformWidth is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.platformWidth = undefined;
+	} else {
+		this.platformWidth = __SLAG_DEVICE.displayCaps.platformWidth || 0;
+	}
+	if (__SLAG_PROPERTIES.xdpi) {
+		throw new Error('Ti.Platform.DisplayCaps.xdpi is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.xdpi = undefined;
+	} else {
+		this.xdpi = 0;
+	}
+	if (__SLAG_PROPERTIES.ydpi) {
+		throw new Error('Ti.Platform.DisplayCaps.ydpi is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ydpi = undefined;
+	} else {
+		this.ydpi = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DisplayCaps.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DisplayCaps.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DisplayCaps.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DisplayCaps.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DisplayCaps.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DisplayCaps.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DisplayCaps.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DisplayCaps.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+DisplayCaps.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+DisplayCaps.prototype.getDensity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.density;
+};
+DisplayCaps.prototype.getDpi = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.dpi;
+};
+DisplayCaps.prototype.getLogicalDensityFactor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.logicalDensityFactor;
+};
+DisplayCaps.prototype.getPlatformHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.platformHeight;
+};
+DisplayCaps.prototype.getPlatformWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.platformWidth;
+};
+DisplayCaps.prototype.getXdpi = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.xdpi;
+};
+DisplayCaps.prototype.getYdpi = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ydpi;
+};
+module.exports = function (properties) {
+	return new DisplayCaps(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Proxy.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Proxy.js
@@ -1,0 +1,118 @@
+var crypto = require('crypto');
+function Proxy(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Proxy.apiName is read only property');
+	}
+	this.apiName = 'Ti.Proxy';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Proxy.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Proxy.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Proxy.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Proxy.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Proxy.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Proxy.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Proxy.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Proxy.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Proxy.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Proxy(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Stream.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Stream.js
@@ -1,0 +1,201 @@
+var crypto = require('crypto');
+function Stream(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'MODE_READ',
+			'MODE_WRITE',
+			'MODE_APPEND',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Stream.apiName is read only property');
+	}
+	this.apiName = 'Ti.Stream';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.MODE_READ) {
+		throw new Error('Ti.Stream.MODE_READ is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODE_READ = undefined;
+	} else {
+		this.MODE_READ = 0;
+	}
+	if (__SLAG_PROPERTIES.MODE_WRITE) {
+		throw new Error('Ti.Stream.MODE_WRITE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODE_WRITE = undefined;
+	} else {
+		this.MODE_WRITE = 0;
+	}
+	if (__SLAG_PROPERTIES.MODE_APPEND) {
+		throw new Error('Ti.Stream.MODE_APPEND is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODE_APPEND = undefined;
+	} else {
+		this.MODE_APPEND = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Stream.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stream.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stream.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stream.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Stream.prototype.createStream = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Stream = require('./Stream/Stream');
+	return Stream(__SLAG_PROPERTY);
+};
+Stream.prototype.read = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stream.prototype.readAll = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Stream.prototype.write = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stream.prototype.writeStream = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stream.prototype.pump = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stream.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Stream.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Stream.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Stream.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Stream.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Stream(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI.js
@@ -1,0 +1,2658 @@
+var crypto = require('crypto');
+function UI(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ANIMATION_CURVE_EASE_IN',
+			'ANIMATION_CURVE_EASE_IN_OUT',
+			'ANIMATION_CURVE_EASE_OUT',
+			'ANIMATION_CURVE_LINEAR',
+			'ATTRIBUTE_FONT',
+			'ATTRIBUTE_FOREGROUND_COLOR',
+			'ATTRIBUTE_BACKGROUND_COLOR',
+			'ATTRIBUTE_LIGATURE',
+			'ATTRIBUTE_LETTERPRESS_STYLE',
+			'ATTRIBUTE_KERN',
+			'ATTRIBUTE_STRIKETHROUGH_STYLE',
+			'ATTRIBUTE_UNDERLINES_STYLE',
+			'ATTRIBUTE_STROKE_COLOR',
+			'ATTRIBUTE_STROKE_WIDTH',
+			'ATTRIBUTE_SHADOW',
+			'ATTRIBUTE_WRITING_DIRECTION',
+			'ATTRIBUTE_TEXT_EFFECT',
+			'ATTRIBUTE_LINK',
+			'ATTRIBUTE_BASELINE_OFFSET',
+			'ATTRIBUTE_UNDERLINE_COLOR',
+			'ATTRIBUTE_STRIKETHROUGH_COLOR',
+			'ATTRIBUTE_OBLIQUENESS',
+			'ATTRIBUTE_EXPANSION',
+			'ATTRIBUTE_LINE_BREAK',
+			'ATTRIBUTE_UNDERLINE_STYLE_NONE',
+			'ATTRIBUTE_UNDERLINE_STYLE_SINGLE',
+			'ATTRIBUTE_UNDERLINE_STYLE_THICK',
+			'ATTRIBUTE_UNDERLINE_STYLE_DOUBLE',
+			'ATTRIBUTE_UNDERLINE_PATTERN_SOLID',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DOT',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DASH',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT',
+			'ATTRIBUTE_UNDERLINE_BY_WORD',
+			'ATTRIBUTE_WRITING_DIRECTION_EMBEDDING',
+			'ATTRIBUTE_WRITING_DIRECTION_OVERRIDE',
+			'ATTRIBUTE_WRITING_DIRECTION_NATURAL',
+			'ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT',
+			'ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT',
+			'ATTRIBUTE_LINE_BREAK_BY_WORD_WRAPPING',
+			'ATTRIBUTE_LINE_BREAK_BY_CHAR_WRAPPING',
+			'ATTRIBUTE_LINE_BREAK_BY_CLIPPING',
+			'ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_HEAD',
+			'ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE',
+			'ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_TAIL',
+			'AUTODETECT_ADDRESS',
+			'AUTODETECT_ALL',
+			'AUTODETECT_CALENDAR',
+			'AUTODETECT_LINK',
+			'AUTODETECT_NONE',
+			'AUTODETECT_PHONE',
+			'AUTOLINK_MAP_ADDRESSES',
+			'AUTOLINK_ALL',
+			'AUTOLINK_CALENDAR',
+			'AUTOLINK_URLS',
+			'AUTOLINK_NONE',
+			'AUTOLINK_PHONE_NUMBERS',
+			'AUTOLINK_EMAIL_ADDRESSES',
+			'BLEND_MODE_CLEAR',
+			'BLEND_MODE_COLOR',
+			'BLEND_MODE_COLOR_BURN',
+			'BLEND_MODE_COLOR_DODGE',
+			'BLEND_MODE_COPY',
+			'BLEND_MODE_DARKEN',
+			'BLEND_MODE_DESTINATION_ATOP',
+			'BLEND_MODE_DESTINATION_IN',
+			'BLEND_MODE_DESTINATION_OUT',
+			'BLEND_MODE_DESTINATION_OVER',
+			'BLEND_MODE_DIFFERENCE',
+			'BLEND_MODE_EXCLUSION',
+			'BLEND_MODE_HARD_LIGHT',
+			'BLEND_MODE_HUE',
+			'BLEND_MODE_LIGHTEN',
+			'BLEND_MODE_LUMINOSITY',
+			'BLEND_MODE_MULTIPLY',
+			'BLEND_MODE_NORMAL',
+			'BLEND_MODE_OVERLAY',
+			'BLEND_MODE_PLUS_DARKER',
+			'BLEND_MODE_PLUS_LIGHTER',
+			'BLEND_MODE_SATURATION',
+			'BLEND_MODE_SCREEN',
+			'BLEND_MODE_SOFT_LIGHT',
+			'BLEND_MODE_SOURCE_ATOP',
+			'BLEND_MODE_SOURCE_IN',
+			'BLEND_MODE_SOURCE_OUT',
+			'BLEND_MODE_XOR',
+			'TEXT_ELLIPSIZE_TRUNCATE_WORD_WRAP',
+			'TEXT_ELLIPSIZE_TRUNCATE_CHAR_WRAP',
+			'TEXT_ELLIPSIZE_TRUNCATE_CLIP',
+			'TEXT_ELLIPSIZE_TRUNCATE_START',
+			'TEXT_ELLIPSIZE_TRUNCATE_MIDDLE',
+			'TEXT_ELLIPSIZE_TRUNCATE_END',
+			'TEXT_ELLIPSIZE_TRUNCATE_MARQUEE',
+			'TEXT_ELLIPSIZE_TRUNCATE_NONE',
+			'EXTEND_EDGE_TOP',
+			'EXTEND_EDGE_BOTTOM',
+			'EXTEND_EDGE_LEFT',
+			'EXTEND_EDGE_RIGHT',
+			'EXTEND_EDGE_NONE',
+			'EXTEND_EDGE_ALL',
+			'FACE_DOWN',
+			'FACE_UP',
+			'FILL',
+			'INHERIT',
+			'INPUT_BORDERSTYLE_BEZEL',
+			'INPUT_BORDERSTYLE_LINE',
+			'INPUT_BORDERSTYLE_NONE',
+			'INPUT_BORDERSTYLE_ROUNDED',
+			'INPUT_BUTTONMODE_ALWAYS',
+			'INPUT_BUTTONMODE_NEVER',
+			'INPUT_BUTTONMODE_ONBLUR',
+			'INPUT_BUTTONMODE_ONFOCUS',
+			'INPUT_TYPE_CLASS_NUMBER',
+			'INPUT_TYPE_CLASS_TEXT',
+			'KEYBOARD_APPEARANCE_ALERT',
+			'KEYBOARD_APPEARANCE_DEFAULT',
+			'KEYBOARD_APPEARANCE_DARK',
+			'KEYBOARD_APPEARANCE_LIGHT',
+			'KEYBOARD_ASCII',
+			'KEYBOARD_DECIMAL_PAD',
+			'KEYBOARD_DEFAULT',
+			'KEYBOARD_EMAIL',
+			'KEYBOARD_NAMEPHONE_PAD',
+			'KEYBOARD_NUMBERS_PUNCTUATION',
+			'KEYBOARD_NUMBER_PAD',
+			'KEYBOARD_PHONE_PAD',
+			'KEYBOARD_URL',
+			'KEYBOARD_TYPE_DECIMAL_PAD',
+			'KEYBOARD_TYPE_ASCII',
+			'KEYBOARD_TYPE_DEFAULT',
+			'KEYBOARD_TYPE_EMAIL',
+			'KEYBOARD_TYPE_NAMEPHONE_PAD',
+			'KEYBOARD_TYPE_NUMBERS_PUNCTUATION',
+			'KEYBOARD_TYPE_NUMBER_PAD',
+			'KEYBOARD_TYPE_PHONE_PAD',
+			'KEYBOARD_TYPE_WEBSEARCH',
+			'KEYBOARD_TYPE_TWITTER',
+			'KEYBOARD_TYPE_URL',
+			'LANDSCAPE_LEFT',
+			'LANDSCAPE_RIGHT',
+			'LIST_ACCESSORY_TYPE_NONE',
+			'LIST_ACCESSORY_TYPE_CHECKMARK',
+			'LIST_ACCESSORY_TYPE_DETAIL',
+			'LIST_ACCESSORY_TYPE_DISCLOSURE',
+			'LIST_ITEM_TEMPLATE_DEFAULT',
+			'LIST_ITEM_TEMPLATE_SETTINGS',
+			'LIST_ITEM_TEMPLATE_CONTACTS',
+			'LIST_ITEM_TEMPLATE_SUBTITLE',
+			'NOTIFICATION_DURATION_LONG',
+			'NOTIFICATION_DURATION_SHORT',
+			'CLIPBOARD_OPTION_LOCAL_ONLY',
+			'CLIPBOARD_OPTION_EXPIRATION_DATE',
+			'PICKER_TYPE_COUNT_DOWN_TIMER',
+			'PICKER_TYPE_DATE',
+			'PICKER_TYPE_DATE_AND_TIME',
+			'PICKER_TYPE_PLAIN',
+			'PICKER_TYPE_TIME',
+			'PORTRAIT',
+			'RETURNKEY_CONTINUE',
+			'RETURNKEY_DEFAULT',
+			'RETURNKEY_DONE',
+			'RETURNKEY_EMERGENCY_CALL',
+			'RETURNKEY_GO',
+			'RETURNKEY_GOOGLE',
+			'RETURNKEY_JOIN',
+			'RETURNKEY_NEXT',
+			'RETURNKEY_ROUTE',
+			'RETURNKEY_SEARCH',
+			'RETURNKEY_SEND',
+			'RETURNKEY_YAHOO',
+			'SIZE',
+			'TABLE_VIEW_SEPARATOR_STYLE_NONE',
+			'TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE',
+			'TEXT_ALIGNMENT_CENTER',
+			'TEXT_ALIGNMENT_LEFT',
+			'TEXT_ALIGNMENT_RIGHT',
+			'TEXT_AUTOCAPITALIZATION_ALL',
+			'TEXT_AUTOCAPITALIZATION_NONE',
+			'TEXT_AUTOCAPITALIZATION_SENTENCES',
+			'TEXT_AUTOCAPITALIZATION_WORDS',
+			'TEXT_STYLE_HEADLINE',
+			'TEXT_STYLE_SUBHEADLINE',
+			'TEXT_STYLE_BODY',
+			'TEXT_STYLE_FOOTNOTE',
+			'TEXT_STYLE_CAPTION1',
+			'TEXT_STYLE_CAPTION2',
+			'TEXT_STYLE_CALLOUT',
+			'TEXT_STYLE_TITLE1',
+			'TEXT_STYLE_TITLE2',
+			'TEXT_STYLE_TITLE3',
+			'TEXT_VERTICAL_ALIGNMENT_BOTTOM',
+			'TEXT_VERTICAL_ALIGNMENT_CENTER',
+			'TEXT_VERTICAL_ALIGNMENT_TOP',
+			'UNIT_CM',
+			'UNIT_DIP',
+			'UNIT_IN',
+			'UNIT_MM',
+			'UNIT_PX',
+			'UNKNOWN',
+			'UPSIDE_PORTRAIT',
+			'URL_ERROR_AUTHENTICATION',
+			'URL_ERROR_BAD_URL',
+			'URL_ERROR_CONNECT',
+			'URL_ERROR_SSL_FAILED',
+			'URL_ERROR_FILE',
+			'URL_ERROR_FILE_NOT_FOUND',
+			'URL_ERROR_HOST_LOOKUP',
+			'URL_ERROR_REDIRECT_LOOP',
+			'URL_ERROR_TIMEOUT',
+			'URL_ERROR_UNKNOWN',
+			'URL_ERROR_UNSUPPORTED_SCHEME',
+			'backgroundColor',
+			'backgroundImage',
+			'currentTab',
+			'currentWindow',
+			'orientation',
+			'tintColor',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_EASE_IN) {
+		throw new Error('Ti.UI.ANIMATION_CURVE_EASE_IN is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_CURVE_EASE_IN = undefined;
+	} else {
+		this.ANIMATION_CURVE_EASE_IN = 0;
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_EASE_IN_OUT) {
+		throw new Error('Ti.UI.ANIMATION_CURVE_EASE_IN_OUT is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_CURVE_EASE_IN_OUT = undefined;
+	} else {
+		this.ANIMATION_CURVE_EASE_IN_OUT = 0;
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_EASE_OUT) {
+		throw new Error('Ti.UI.ANIMATION_CURVE_EASE_OUT is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_CURVE_EASE_OUT = undefined;
+	} else {
+		this.ANIMATION_CURVE_EASE_OUT = 0;
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_LINEAR) {
+		throw new Error('Ti.UI.ANIMATION_CURVE_LINEAR is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_CURVE_LINEAR = undefined;
+	} else {
+		this.ANIMATION_CURVE_LINEAR = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_FONT) {
+		throw new Error('Ti.UI.ATTRIBUTE_FONT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_FONT = undefined;
+	} else {
+		this.ATTRIBUTE_FONT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_FOREGROUND_COLOR) {
+		throw new Error('Ti.UI.ATTRIBUTE_FOREGROUND_COLOR is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_FOREGROUND_COLOR = undefined;
+	} else {
+		this.ATTRIBUTE_FOREGROUND_COLOR = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_BACKGROUND_COLOR) {
+		throw new Error('Ti.UI.ATTRIBUTE_BACKGROUND_COLOR is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_BACKGROUND_COLOR = undefined;
+	} else {
+		this.ATTRIBUTE_BACKGROUND_COLOR = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LIGATURE) {
+		throw new Error('Ti.UI.ATTRIBUTE_LIGATURE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LIGATURE = undefined;
+	} else {
+		this.ATTRIBUTE_LIGATURE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LETTERPRESS_STYLE) {
+		throw new Error('Ti.UI.ATTRIBUTE_LETTERPRESS_STYLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LETTERPRESS_STYLE = undefined;
+	} else {
+		this.ATTRIBUTE_LETTERPRESS_STYLE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_KERN) {
+		throw new Error('Ti.UI.ATTRIBUTE_KERN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_KERN = undefined;
+	} else {
+		this.ATTRIBUTE_KERN = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STRIKETHROUGH_STYLE) {
+		throw new Error('Ti.UI.ATTRIBUTE_STRIKETHROUGH_STYLE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_STRIKETHROUGH_STYLE = undefined;
+	} else {
+		this.ATTRIBUTE_STRIKETHROUGH_STYLE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINES_STYLE) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINES_STYLE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINES_STYLE = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINES_STYLE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STROKE_COLOR) {
+		throw new Error('Ti.UI.ATTRIBUTE_STROKE_COLOR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_STROKE_COLOR = undefined;
+	} else {
+		this.ATTRIBUTE_STROKE_COLOR = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STROKE_WIDTH) {
+		throw new Error('Ti.UI.ATTRIBUTE_STROKE_WIDTH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_STROKE_WIDTH = undefined;
+	} else {
+		this.ATTRIBUTE_STROKE_WIDTH = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_SHADOW) {
+		throw new Error('Ti.UI.ATTRIBUTE_SHADOW is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_SHADOW = undefined;
+	} else {
+		this.ATTRIBUTE_SHADOW = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION) {
+		throw new Error('Ti.UI.ATTRIBUTE_WRITING_DIRECTION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_WRITING_DIRECTION = undefined;
+	} else {
+		this.ATTRIBUTE_WRITING_DIRECTION = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_TEXT_EFFECT) {
+		throw new Error('Ti.UI.ATTRIBUTE_TEXT_EFFECT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_TEXT_EFFECT = undefined;
+	} else {
+		this.ATTRIBUTE_TEXT_EFFECT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINK) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINK is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINK = undefined;
+	} else {
+		this.ATTRIBUTE_LINK = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_BASELINE_OFFSET) {
+		throw new Error('Ti.UI.ATTRIBUTE_BASELINE_OFFSET is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_BASELINE_OFFSET = undefined;
+	} else {
+		this.ATTRIBUTE_BASELINE_OFFSET = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_COLOR) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_COLOR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_COLOR = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_COLOR = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STRIKETHROUGH_COLOR) {
+		throw new Error('Ti.UI.ATTRIBUTE_STRIKETHROUGH_COLOR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_STRIKETHROUGH_COLOR = undefined;
+	} else {
+		this.ATTRIBUTE_STRIKETHROUGH_COLOR = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_OBLIQUENESS) {
+		throw new Error('Ti.UI.ATTRIBUTE_OBLIQUENESS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_OBLIQUENESS = undefined;
+	} else {
+		this.ATTRIBUTE_OBLIQUENESS = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_EXPANSION) {
+		throw new Error('Ti.UI.ATTRIBUTE_EXPANSION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_EXPANSION = undefined;
+	} else {
+		this.ATTRIBUTE_EXPANSION = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINE_BREAK) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINE_BREAK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINE_BREAK = undefined;
+	} else {
+		this.ATTRIBUTE_LINE_BREAK = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_NONE) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_STYLE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_STYLE_NONE = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_STYLE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_SINGLE) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_STYLE_SINGLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_STYLE_SINGLE = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_STYLE_SINGLE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_THICK) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_STYLE_THICK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_STYLE_THICK = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_STYLE_THICK = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_DOUBLE) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_STYLE_DOUBLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_STYLE_DOUBLE = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_STYLE_DOUBLE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_SOLID) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_PATTERN_SOLID is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_SOLID = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_SOLID = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DOT) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_PATTERN_DOT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DOT = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DOT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DASH) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_PATTERN_DASH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DASH = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DASH = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_BY_WORD) {
+		throw new Error('Ti.UI.ATTRIBUTE_UNDERLINE_BY_WORD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_UNDERLINE_BY_WORD = undefined;
+	} else {
+		this.ATTRIBUTE_UNDERLINE_BY_WORD = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_EMBEDDING) {
+		throw new Error('Ti.UI.ATTRIBUTE_WRITING_DIRECTION_EMBEDDING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_WRITING_DIRECTION_EMBEDDING = undefined;
+	} else {
+		this.ATTRIBUTE_WRITING_DIRECTION_EMBEDDING = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_OVERRIDE) {
+		throw new Error('Ti.UI.ATTRIBUTE_WRITING_DIRECTION_OVERRIDE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_WRITING_DIRECTION_OVERRIDE = undefined;
+	} else {
+		this.ATTRIBUTE_WRITING_DIRECTION_OVERRIDE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_NATURAL) {
+		throw new Error('Ti.UI.ATTRIBUTE_WRITING_DIRECTION_NATURAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_WRITING_DIRECTION_NATURAL = undefined;
+	} else {
+		this.ATTRIBUTE_WRITING_DIRECTION_NATURAL = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT) {
+		throw new Error('Ti.UI.ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT = undefined;
+	} else {
+		this.ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT) {
+		throw new Error('Ti.UI.ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT = undefined;
+	} else {
+		this.ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINE_BREAK_BY_WORD_WRAPPING) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINE_BREAK_BY_WORD_WRAPPING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINE_BREAK_BY_WORD_WRAPPING = undefined;
+	} else {
+		this.ATTRIBUTE_LINE_BREAK_BY_WORD_WRAPPING = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINE_BREAK_BY_CHAR_WRAPPING) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINE_BREAK_BY_CHAR_WRAPPING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINE_BREAK_BY_CHAR_WRAPPING = undefined;
+	} else {
+		this.ATTRIBUTE_LINE_BREAK_BY_CHAR_WRAPPING = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINE_BREAK_BY_CLIPPING) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINE_BREAK_BY_CLIPPING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINE_BREAK_BY_CLIPPING = undefined;
+	} else {
+		this.ATTRIBUTE_LINE_BREAK_BY_CLIPPING = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_HEAD) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_HEAD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_HEAD = undefined;
+	} else {
+		this.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_HEAD = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE = undefined;
+	} else {
+		this.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_TAIL) {
+		throw new Error('Ti.UI.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_TAIL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_TAIL = undefined;
+	} else {
+		this.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_TAIL = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_ADDRESS) {
+		throw new Error('Ti.UI.AUTODETECT_ADDRESS was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_ALL) {
+		throw new Error('Ti.UI.AUTODETECT_ALL was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_CALENDAR) {
+		throw new Error('Ti.UI.AUTODETECT_CALENDAR was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_LINK) {
+		throw new Error('Ti.UI.AUTODETECT_LINK was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_NONE) {
+		throw new Error('Ti.UI.AUTODETECT_NONE was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_PHONE) {
+		throw new Error('Ti.UI.AUTODETECT_PHONE was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.AUTOLINK_MAP_ADDRESSES) {
+		throw new Error('Ti.UI.AUTOLINK_MAP_ADDRESSES is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTOLINK_MAP_ADDRESSES = undefined;
+	} else {
+		this.AUTOLINK_MAP_ADDRESSES = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTOLINK_ALL) {
+		throw new Error('Ti.UI.AUTOLINK_ALL is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTOLINK_ALL = undefined;
+	} else {
+		this.AUTOLINK_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTOLINK_CALENDAR) {
+		throw new Error('Ti.UI.AUTOLINK_CALENDAR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTOLINK_CALENDAR = undefined;
+	} else {
+		this.AUTOLINK_CALENDAR = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTOLINK_URLS) {
+		throw new Error('Ti.UI.AUTOLINK_URLS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTOLINK_URLS = undefined;
+	} else {
+		this.AUTOLINK_URLS = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTOLINK_NONE) {
+		throw new Error('Ti.UI.AUTOLINK_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTOLINK_NONE = undefined;
+	} else {
+		this.AUTOLINK_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTOLINK_PHONE_NUMBERS) {
+		throw new Error('Ti.UI.AUTOLINK_PHONE_NUMBERS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTOLINK_PHONE_NUMBERS = undefined;
+	} else {
+		this.AUTOLINK_PHONE_NUMBERS = 0;
+	}
+	if (__SLAG_PROPERTIES.AUTOLINK_EMAIL_ADDRESSES) {
+		throw new Error('Ti.UI.AUTOLINK_EMAIL_ADDRESSES is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AUTOLINK_EMAIL_ADDRESSES = undefined;
+	} else {
+		this.AUTOLINK_EMAIL_ADDRESSES = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_CLEAR) {
+		throw new Error('Ti.UI.BLEND_MODE_CLEAR was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COLOR) {
+		throw new Error('Ti.UI.BLEND_MODE_COLOR was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COLOR_BURN) {
+		throw new Error('Ti.UI.BLEND_MODE_COLOR_BURN was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COLOR_DODGE) {
+		throw new Error('Ti.UI.BLEND_MODE_COLOR_DODGE was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COPY) {
+		throw new Error('Ti.UI.BLEND_MODE_COPY was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DARKEN) {
+		throw new Error('Ti.UI.BLEND_MODE_DARKEN was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_ATOP) {
+		throw new Error('Ti.UI.BLEND_MODE_DESTINATION_ATOP was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_IN) {
+		throw new Error('Ti.UI.BLEND_MODE_DESTINATION_IN was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_OUT) {
+		throw new Error('Ti.UI.BLEND_MODE_DESTINATION_OUT was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_OVER) {
+		throw new Error('Ti.UI.BLEND_MODE_DESTINATION_OVER was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DIFFERENCE) {
+		throw new Error('Ti.UI.BLEND_MODE_DIFFERENCE was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_EXCLUSION) {
+		throw new Error('Ti.UI.BLEND_MODE_EXCLUSION was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_HARD_LIGHT) {
+		throw new Error('Ti.UI.BLEND_MODE_HARD_LIGHT was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_HUE) {
+		throw new Error('Ti.UI.BLEND_MODE_HUE was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_LIGHTEN) {
+		throw new Error('Ti.UI.BLEND_MODE_LIGHTEN was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_LUMINOSITY) {
+		throw new Error('Ti.UI.BLEND_MODE_LUMINOSITY was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_MULTIPLY) {
+		throw new Error('Ti.UI.BLEND_MODE_MULTIPLY was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_NORMAL) {
+		throw new Error('Ti.UI.BLEND_MODE_NORMAL was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_OVERLAY) {
+		throw new Error('Ti.UI.BLEND_MODE_OVERLAY was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_PLUS_DARKER) {
+		throw new Error('Ti.UI.BLEND_MODE_PLUS_DARKER was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_PLUS_LIGHTER) {
+		throw new Error('Ti.UI.BLEND_MODE_PLUS_LIGHTER was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SATURATION) {
+		throw new Error('Ti.UI.BLEND_MODE_SATURATION was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SCREEN) {
+		throw new Error('Ti.UI.BLEND_MODE_SCREEN was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOFT_LIGHT) {
+		throw new Error('Ti.UI.BLEND_MODE_SOFT_LIGHT was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOURCE_ATOP) {
+		throw new Error('Ti.UI.BLEND_MODE_SOURCE_ATOP was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOURCE_IN) {
+		throw new Error('Ti.UI.BLEND_MODE_SOURCE_IN was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOURCE_OUT) {
+		throw new Error('Ti.UI.BLEND_MODE_SOURCE_OUT was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_XOR) {
+		throw new Error('Ti.UI.BLEND_MODE_XOR was deprecated, since 1.8.0');
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_WORD_WRAP) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_WORD_WRAP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_WORD_WRAP = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_WORD_WRAP = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_CHAR_WRAP) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_CHAR_WRAP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_CHAR_WRAP = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_CHAR_WRAP = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_CLIP) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_CLIP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_CLIP = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_CLIP = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_START) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_START is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_START = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_START = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_MIDDLE) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_MIDDLE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_MIDDLE = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_MIDDLE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_END) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_END is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_END = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_END = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_MARQUEE) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_MARQUEE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_MARQUEE = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_MARQUEE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ELLIPSIZE_TRUNCATE_NONE) {
+		throw new Error('Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_NONE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ELLIPSIZE_TRUNCATE_NONE = undefined;
+	} else {
+		this.TEXT_ELLIPSIZE_TRUNCATE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.EXTEND_EDGE_TOP) {
+		throw new Error('Ti.UI.EXTEND_EDGE_TOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTEND_EDGE_TOP = undefined;
+	} else {
+		this.EXTEND_EDGE_TOP = 0;
+	}
+	if (__SLAG_PROPERTIES.EXTEND_EDGE_BOTTOM) {
+		throw new Error('Ti.UI.EXTEND_EDGE_BOTTOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTEND_EDGE_BOTTOM = undefined;
+	} else {
+		this.EXTEND_EDGE_BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.EXTEND_EDGE_LEFT) {
+		throw new Error('Ti.UI.EXTEND_EDGE_LEFT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTEND_EDGE_LEFT = undefined;
+	} else {
+		this.EXTEND_EDGE_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.EXTEND_EDGE_RIGHT) {
+		throw new Error('Ti.UI.EXTEND_EDGE_RIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTEND_EDGE_RIGHT = undefined;
+	} else {
+		this.EXTEND_EDGE_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.EXTEND_EDGE_NONE) {
+		throw new Error('Ti.UI.EXTEND_EDGE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTEND_EDGE_NONE = undefined;
+	} else {
+		this.EXTEND_EDGE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.EXTEND_EDGE_ALL) {
+		throw new Error('Ti.UI.EXTEND_EDGE_ALL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EXTEND_EDGE_ALL = undefined;
+	} else {
+		this.EXTEND_EDGE_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.FACE_DOWN) {
+		throw new Error('Ti.UI.FACE_DOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FACE_DOWN = undefined;
+	} else {
+		this.FACE_DOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.FACE_UP) {
+		throw new Error('Ti.UI.FACE_UP is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FACE_UP = undefined;
+	} else {
+		this.FACE_UP = 0;
+	}
+	if (__SLAG_PROPERTIES.FILL) {
+		throw new Error('Ti.UI.FILL is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FILL = undefined;
+	} else {
+		this.FILL = '';
+	}
+	if (__SLAG_PROPERTIES.INHERIT) {
+		throw new Error('Ti.UI.INHERIT is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INHERIT = undefined;
+	} else {
+		this.INHERIT = '';
+	}
+	if (__SLAG_PROPERTIES.INPUT_BORDERSTYLE_BEZEL) {
+		throw new Error('Ti.UI.INPUT_BORDERSTYLE_BEZEL is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BORDERSTYLE_BEZEL = undefined;
+	} else {
+		this.INPUT_BORDERSTYLE_BEZEL = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_BORDERSTYLE_LINE) {
+		throw new Error('Ti.UI.INPUT_BORDERSTYLE_LINE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BORDERSTYLE_LINE = undefined;
+	} else {
+		this.INPUT_BORDERSTYLE_LINE = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_BORDERSTYLE_NONE) {
+		throw new Error('Ti.UI.INPUT_BORDERSTYLE_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BORDERSTYLE_NONE = undefined;
+	} else {
+		this.INPUT_BORDERSTYLE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_BORDERSTYLE_ROUNDED) {
+		throw new Error('Ti.UI.INPUT_BORDERSTYLE_ROUNDED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BORDERSTYLE_ROUNDED = undefined;
+	} else {
+		this.INPUT_BORDERSTYLE_ROUNDED = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_BUTTONMODE_ALWAYS) {
+		throw new Error('Ti.UI.INPUT_BUTTONMODE_ALWAYS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BUTTONMODE_ALWAYS = undefined;
+	} else {
+		this.INPUT_BUTTONMODE_ALWAYS = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_BUTTONMODE_NEVER) {
+		throw new Error('Ti.UI.INPUT_BUTTONMODE_NEVER is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BUTTONMODE_NEVER = undefined;
+	} else {
+		this.INPUT_BUTTONMODE_NEVER = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_BUTTONMODE_ONBLUR) {
+		throw new Error('Ti.UI.INPUT_BUTTONMODE_ONBLUR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BUTTONMODE_ONBLUR = undefined;
+	} else {
+		this.INPUT_BUTTONMODE_ONBLUR = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_BUTTONMODE_ONFOCUS) {
+		throw new Error('Ti.UI.INPUT_BUTTONMODE_ONFOCUS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_BUTTONMODE_ONFOCUS = undefined;
+	} else {
+		this.INPUT_BUTTONMODE_ONFOCUS = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_TYPE_CLASS_NUMBER) {
+		throw new Error('Ti.UI.INPUT_TYPE_CLASS_NUMBER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_TYPE_CLASS_NUMBER = undefined;
+	} else {
+		this.INPUT_TYPE_CLASS_NUMBER = 0;
+	}
+	if (__SLAG_PROPERTIES.INPUT_TYPE_CLASS_TEXT) {
+		throw new Error('Ti.UI.INPUT_TYPE_CLASS_TEXT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INPUT_TYPE_CLASS_TEXT = undefined;
+	} else {
+		this.INPUT_TYPE_CLASS_TEXT = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_APPEARANCE_ALERT) {
+		throw new Error('Ti.UI.KEYBOARD_APPEARANCE_ALERT was deprecated, since 5.4.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_APPEARANCE_DEFAULT) {
+		throw new Error('Ti.UI.KEYBOARD_APPEARANCE_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_APPEARANCE_DEFAULT = undefined;
+	} else {
+		this.KEYBOARD_APPEARANCE_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_APPEARANCE_DARK) {
+		throw new Error('Ti.UI.KEYBOARD_APPEARANCE_DARK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_APPEARANCE_DARK = undefined;
+	} else {
+		this.KEYBOARD_APPEARANCE_DARK = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_APPEARANCE_LIGHT) {
+		throw new Error('Ti.UI.KEYBOARD_APPEARANCE_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_APPEARANCE_LIGHT = undefined;
+	} else {
+		this.KEYBOARD_APPEARANCE_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_ASCII) {
+		throw new Error('Ti.UI.KEYBOARD_ASCII was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_DECIMAL_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_DECIMAL_PAD was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_DEFAULT) {
+		throw new Error('Ti.UI.KEYBOARD_DEFAULT was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_EMAIL) {
+		throw new Error('Ti.UI.KEYBOARD_EMAIL was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_NAMEPHONE_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_NAMEPHONE_PAD was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_NUMBERS_PUNCTUATION) {
+		throw new Error('Ti.UI.KEYBOARD_NUMBERS_PUNCTUATION was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_NUMBER_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_NUMBER_PAD was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_PHONE_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_PHONE_PAD was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_URL) {
+		throw new Error('Ti.UI.KEYBOARD_URL was deprecated, since 5.2.0');
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_DECIMAL_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_DECIMAL_PAD is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_DECIMAL_PAD = undefined;
+	} else {
+		this.KEYBOARD_TYPE_DECIMAL_PAD = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_ASCII) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_ASCII is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_ASCII = undefined;
+	} else {
+		this.KEYBOARD_TYPE_ASCII = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_DEFAULT) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_DEFAULT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_DEFAULT = undefined;
+	} else {
+		this.KEYBOARD_TYPE_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_EMAIL) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_EMAIL is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_EMAIL = undefined;
+	} else {
+		this.KEYBOARD_TYPE_EMAIL = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_NAMEPHONE_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_NAMEPHONE_PAD is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_NAMEPHONE_PAD = undefined;
+	} else {
+		this.KEYBOARD_TYPE_NAMEPHONE_PAD = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_NUMBERS_PUNCTUATION) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_NUMBERS_PUNCTUATION is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_NUMBERS_PUNCTUATION = undefined;
+	} else {
+		this.KEYBOARD_TYPE_NUMBERS_PUNCTUATION = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_NUMBER_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_NUMBER_PAD is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_NUMBER_PAD = undefined;
+	} else {
+		this.KEYBOARD_TYPE_NUMBER_PAD = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_PHONE_PAD) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_PHONE_PAD is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_PHONE_PAD = undefined;
+	} else {
+		this.KEYBOARD_TYPE_PHONE_PAD = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_WEBSEARCH) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_WEBSEARCH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_WEBSEARCH = undefined;
+	} else {
+		this.KEYBOARD_TYPE_WEBSEARCH = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_TWITTER) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_TWITTER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_TWITTER = undefined;
+	} else {
+		this.KEYBOARD_TYPE_TWITTER = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_TYPE_URL) {
+		throw new Error('Ti.UI.KEYBOARD_TYPE_URL is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_TYPE_URL = undefined;
+	} else {
+		this.KEYBOARD_TYPE_URL = 0;
+	}
+	if (__SLAG_PROPERTIES.LANDSCAPE_LEFT) {
+		throw new Error('Ti.UI.LANDSCAPE_LEFT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LANDSCAPE_LEFT = undefined;
+	} else {
+		this.LANDSCAPE_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.LANDSCAPE_RIGHT) {
+		throw new Error('Ti.UI.LANDSCAPE_RIGHT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LANDSCAPE_RIGHT = undefined;
+	} else {
+		this.LANDSCAPE_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ACCESSORY_TYPE_NONE) {
+		throw new Error('Ti.UI.LIST_ACCESSORY_TYPE_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ACCESSORY_TYPE_NONE = undefined;
+	} else {
+		this.LIST_ACCESSORY_TYPE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ACCESSORY_TYPE_CHECKMARK) {
+		throw new Error('Ti.UI.LIST_ACCESSORY_TYPE_CHECKMARK is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ACCESSORY_TYPE_CHECKMARK = undefined;
+	} else {
+		this.LIST_ACCESSORY_TYPE_CHECKMARK = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ACCESSORY_TYPE_DETAIL) {
+		throw new Error('Ti.UI.LIST_ACCESSORY_TYPE_DETAIL is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ACCESSORY_TYPE_DETAIL = undefined;
+	} else {
+		this.LIST_ACCESSORY_TYPE_DETAIL = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ACCESSORY_TYPE_DISCLOSURE) {
+		throw new Error('Ti.UI.LIST_ACCESSORY_TYPE_DISCLOSURE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ACCESSORY_TYPE_DISCLOSURE = undefined;
+	} else {
+		this.LIST_ACCESSORY_TYPE_DISCLOSURE = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ITEM_TEMPLATE_DEFAULT) {
+		throw new Error('Ti.UI.LIST_ITEM_TEMPLATE_DEFAULT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ITEM_TEMPLATE_DEFAULT = undefined;
+	} else {
+		this.LIST_ITEM_TEMPLATE_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ITEM_TEMPLATE_SETTINGS) {
+		throw new Error('Ti.UI.LIST_ITEM_TEMPLATE_SETTINGS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ITEM_TEMPLATE_SETTINGS = undefined;
+	} else {
+		this.LIST_ITEM_TEMPLATE_SETTINGS = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ITEM_TEMPLATE_CONTACTS) {
+		throw new Error('Ti.UI.LIST_ITEM_TEMPLATE_CONTACTS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ITEM_TEMPLATE_CONTACTS = undefined;
+	} else {
+		this.LIST_ITEM_TEMPLATE_CONTACTS = 0;
+	}
+	if (__SLAG_PROPERTIES.LIST_ITEM_TEMPLATE_SUBTITLE) {
+		throw new Error('Ti.UI.LIST_ITEM_TEMPLATE_SUBTITLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIST_ITEM_TEMPLATE_SUBTITLE = undefined;
+	} else {
+		this.LIST_ITEM_TEMPLATE_SUBTITLE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTIFICATION_DURATION_LONG) {
+		throw new Error('Ti.UI.NOTIFICATION_DURATION_LONG is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTIFICATION_DURATION_LONG = undefined;
+	} else {
+		this.NOTIFICATION_DURATION_LONG = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTIFICATION_DURATION_SHORT) {
+		throw new Error('Ti.UI.NOTIFICATION_DURATION_SHORT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTIFICATION_DURATION_SHORT = undefined;
+	} else {
+		this.NOTIFICATION_DURATION_SHORT = 0;
+	}
+	if (__SLAG_PROPERTIES.CLIPBOARD_OPTION_LOCAL_ONLY) {
+		throw new Error('Ti.UI.CLIPBOARD_OPTION_LOCAL_ONLY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CLIPBOARD_OPTION_LOCAL_ONLY = undefined;
+	} else {
+		this.CLIPBOARD_OPTION_LOCAL_ONLY = '';
+	}
+	if (__SLAG_PROPERTIES.CLIPBOARD_OPTION_EXPIRATION_DATE) {
+		throw new Error('Ti.UI.CLIPBOARD_OPTION_EXPIRATION_DATE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CLIPBOARD_OPTION_EXPIRATION_DATE = undefined;
+	} else {
+		this.CLIPBOARD_OPTION_EXPIRATION_DATE = '';
+	}
+	if (__SLAG_PROPERTIES.PICKER_TYPE_COUNT_DOWN_TIMER) {
+		throw new Error('Ti.UI.PICKER_TYPE_COUNT_DOWN_TIMER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PICKER_TYPE_COUNT_DOWN_TIMER = undefined;
+	} else {
+		this.PICKER_TYPE_COUNT_DOWN_TIMER = 0;
+	}
+	if (__SLAG_PROPERTIES.PICKER_TYPE_DATE) {
+		throw new Error('Ti.UI.PICKER_TYPE_DATE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PICKER_TYPE_DATE = undefined;
+	} else {
+		this.PICKER_TYPE_DATE = 0;
+	}
+	if (__SLAG_PROPERTIES.PICKER_TYPE_DATE_AND_TIME) {
+		throw new Error('Ti.UI.PICKER_TYPE_DATE_AND_TIME is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PICKER_TYPE_DATE_AND_TIME = undefined;
+	} else {
+		this.PICKER_TYPE_DATE_AND_TIME = 0;
+	}
+	if (__SLAG_PROPERTIES.PICKER_TYPE_PLAIN) {
+		throw new Error('Ti.UI.PICKER_TYPE_PLAIN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PICKER_TYPE_PLAIN = undefined;
+	} else {
+		this.PICKER_TYPE_PLAIN = 0;
+	}
+	if (__SLAG_PROPERTIES.PICKER_TYPE_TIME) {
+		throw new Error('Ti.UI.PICKER_TYPE_TIME is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PICKER_TYPE_TIME = undefined;
+	} else {
+		this.PICKER_TYPE_TIME = 0;
+	}
+	if (__SLAG_PROPERTIES.PORTRAIT) {
+		throw new Error('Ti.UI.PORTRAIT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PORTRAIT = undefined;
+	} else {
+		this.PORTRAIT = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_CONTINUE) {
+		throw new Error('Ti.UI.RETURNKEY_CONTINUE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_CONTINUE = undefined;
+	} else {
+		this.RETURNKEY_CONTINUE = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_DEFAULT) {
+		throw new Error('Ti.UI.RETURNKEY_DEFAULT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_DEFAULT = undefined;
+	} else {
+		this.RETURNKEY_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_DONE) {
+		throw new Error('Ti.UI.RETURNKEY_DONE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_DONE = undefined;
+	} else {
+		this.RETURNKEY_DONE = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_EMERGENCY_CALL) {
+		throw new Error('Ti.UI.RETURNKEY_EMERGENCY_CALL is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_EMERGENCY_CALL = undefined;
+	} else {
+		this.RETURNKEY_EMERGENCY_CALL = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_GO) {
+		throw new Error('Ti.UI.RETURNKEY_GO is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_GO = undefined;
+	} else {
+		this.RETURNKEY_GO = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_GOOGLE) {
+		throw new Error('Ti.UI.RETURNKEY_GOOGLE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_GOOGLE = undefined;
+	} else {
+		this.RETURNKEY_GOOGLE = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_JOIN) {
+		throw new Error('Ti.UI.RETURNKEY_JOIN is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_JOIN = undefined;
+	} else {
+		this.RETURNKEY_JOIN = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_NEXT) {
+		throw new Error('Ti.UI.RETURNKEY_NEXT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_NEXT = undefined;
+	} else {
+		this.RETURNKEY_NEXT = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_ROUTE) {
+		throw new Error('Ti.UI.RETURNKEY_ROUTE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_ROUTE = undefined;
+	} else {
+		this.RETURNKEY_ROUTE = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_SEARCH) {
+		throw new Error('Ti.UI.RETURNKEY_SEARCH is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_SEARCH = undefined;
+	} else {
+		this.RETURNKEY_SEARCH = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_SEND) {
+		throw new Error('Ti.UI.RETURNKEY_SEND is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_SEND = undefined;
+	} else {
+		this.RETURNKEY_SEND = 0;
+	}
+	if (__SLAG_PROPERTIES.RETURNKEY_YAHOO) {
+		throw new Error('Ti.UI.RETURNKEY_YAHOO is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RETURNKEY_YAHOO = undefined;
+	} else {
+		this.RETURNKEY_YAHOO = 0;
+	}
+	if (__SLAG_PROPERTIES.SIZE) {
+		throw new Error('Ti.UI.SIZE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SIZE = undefined;
+	} else {
+		this.SIZE = '';
+	}
+	if (__SLAG_PROPERTIES.TABLE_VIEW_SEPARATOR_STYLE_NONE) {
+		throw new Error('Ti.UI.TABLE_VIEW_SEPARATOR_STYLE_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TABLE_VIEW_SEPARATOR_STYLE_NONE = undefined;
+	} else {
+		this.TABLE_VIEW_SEPARATOR_STYLE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE) {
+		throw new Error('Ti.UI.TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE = undefined;
+	} else {
+		this.TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ALIGNMENT_CENTER) {
+		throw new Error('Ti.UI.TEXT_ALIGNMENT_CENTER is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ALIGNMENT_CENTER = undefined;
+	} else {
+		this.TEXT_ALIGNMENT_CENTER = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ALIGNMENT_LEFT) {
+		throw new Error('Ti.UI.TEXT_ALIGNMENT_LEFT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ALIGNMENT_LEFT = undefined;
+	} else {
+		this.TEXT_ALIGNMENT_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_ALIGNMENT_RIGHT) {
+		throw new Error('Ti.UI.TEXT_ALIGNMENT_RIGHT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_ALIGNMENT_RIGHT = undefined;
+	} else {
+		this.TEXT_ALIGNMENT_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_AUTOCAPITALIZATION_ALL) {
+		throw new Error('Ti.UI.TEXT_AUTOCAPITALIZATION_ALL is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_AUTOCAPITALIZATION_ALL = undefined;
+	} else {
+		this.TEXT_AUTOCAPITALIZATION_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_AUTOCAPITALIZATION_NONE) {
+		throw new Error('Ti.UI.TEXT_AUTOCAPITALIZATION_NONE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_AUTOCAPITALIZATION_NONE = undefined;
+	} else {
+		this.TEXT_AUTOCAPITALIZATION_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_AUTOCAPITALIZATION_SENTENCES) {
+		throw new Error('Ti.UI.TEXT_AUTOCAPITALIZATION_SENTENCES is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_AUTOCAPITALIZATION_SENTENCES = undefined;
+	} else {
+		this.TEXT_AUTOCAPITALIZATION_SENTENCES = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_AUTOCAPITALIZATION_WORDS) {
+		throw new Error('Ti.UI.TEXT_AUTOCAPITALIZATION_WORDS is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_AUTOCAPITALIZATION_WORDS = undefined;
+	} else {
+		this.TEXT_AUTOCAPITALIZATION_WORDS = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_HEADLINE) {
+		throw new Error('Ti.UI.TEXT_STYLE_HEADLINE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_HEADLINE = undefined;
+	} else {
+		this.TEXT_STYLE_HEADLINE = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_SUBHEADLINE) {
+		throw new Error('Ti.UI.TEXT_STYLE_SUBHEADLINE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_SUBHEADLINE = undefined;
+	} else {
+		this.TEXT_STYLE_SUBHEADLINE = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_BODY) {
+		throw new Error('Ti.UI.TEXT_STYLE_BODY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_BODY = undefined;
+	} else {
+		this.TEXT_STYLE_BODY = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_FOOTNOTE) {
+		throw new Error('Ti.UI.TEXT_STYLE_FOOTNOTE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_FOOTNOTE = undefined;
+	} else {
+		this.TEXT_STYLE_FOOTNOTE = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_CAPTION1) {
+		throw new Error('Ti.UI.TEXT_STYLE_CAPTION1 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_CAPTION1 = undefined;
+	} else {
+		this.TEXT_STYLE_CAPTION1 = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_CAPTION2) {
+		throw new Error('Ti.UI.TEXT_STYLE_CAPTION2 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_CAPTION2 = undefined;
+	} else {
+		this.TEXT_STYLE_CAPTION2 = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_CALLOUT) {
+		throw new Error('Ti.UI.TEXT_STYLE_CALLOUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_CALLOUT = undefined;
+	} else {
+		this.TEXT_STYLE_CALLOUT = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_TITLE1) {
+		throw new Error('Ti.UI.TEXT_STYLE_TITLE1 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_TITLE1 = undefined;
+	} else {
+		this.TEXT_STYLE_TITLE1 = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_TITLE2) {
+		throw new Error('Ti.UI.TEXT_STYLE_TITLE2 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_TITLE2 = undefined;
+	} else {
+		this.TEXT_STYLE_TITLE2 = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_STYLE_TITLE3) {
+		throw new Error('Ti.UI.TEXT_STYLE_TITLE3 is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_STYLE_TITLE3 = undefined;
+	} else {
+		this.TEXT_STYLE_TITLE3 = '';
+	}
+	if (__SLAG_PROPERTIES.TEXT_VERTICAL_ALIGNMENT_BOTTOM) {
+		throw new Error('Ti.UI.TEXT_VERTICAL_ALIGNMENT_BOTTOM is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_VERTICAL_ALIGNMENT_BOTTOM = undefined;
+	} else {
+		this.TEXT_VERTICAL_ALIGNMENT_BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_VERTICAL_ALIGNMENT_CENTER) {
+		throw new Error('Ti.UI.TEXT_VERTICAL_ALIGNMENT_CENTER is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_VERTICAL_ALIGNMENT_CENTER = undefined;
+	} else {
+		this.TEXT_VERTICAL_ALIGNMENT_CENTER = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_VERTICAL_ALIGNMENT_TOP) {
+		throw new Error('Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_VERTICAL_ALIGNMENT_TOP = undefined;
+	} else {
+		this.TEXT_VERTICAL_ALIGNMENT_TOP = 0;
+	}
+	if (__SLAG_PROPERTIES.UNIT_CM) {
+		throw new Error('Ti.UI.UNIT_CM is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNIT_CM = undefined;
+	} else {
+		this.UNIT_CM = '';
+	}
+	if (__SLAG_PROPERTIES.UNIT_DIP) {
+		throw new Error('Ti.UI.UNIT_DIP is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNIT_DIP = undefined;
+	} else {
+		this.UNIT_DIP = '';
+	}
+	if (__SLAG_PROPERTIES.UNIT_IN) {
+		throw new Error('Ti.UI.UNIT_IN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNIT_IN = undefined;
+	} else {
+		this.UNIT_IN = '';
+	}
+	if (__SLAG_PROPERTIES.UNIT_MM) {
+		throw new Error('Ti.UI.UNIT_MM is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNIT_MM = undefined;
+	} else {
+		this.UNIT_MM = '';
+	}
+	if (__SLAG_PROPERTIES.UNIT_PX) {
+		throw new Error('Ti.UI.UNIT_PX is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNIT_PX = undefined;
+	} else {
+		this.UNIT_PX = '';
+	}
+	if (__SLAG_PROPERTIES.UNKNOWN) {
+		throw new Error('Ti.UI.UNKNOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UNKNOWN = undefined;
+	} else {
+		this.UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.UPSIDE_PORTRAIT) {
+		throw new Error('Ti.UI.UPSIDE_PORTRAIT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.UPSIDE_PORTRAIT = undefined;
+	} else {
+		this.UPSIDE_PORTRAIT = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_AUTHENTICATION) {
+		throw new Error('Ti.UI.URL_ERROR_AUTHENTICATION is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_AUTHENTICATION = undefined;
+	} else {
+		this.URL_ERROR_AUTHENTICATION = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_BAD_URL) {
+		throw new Error('Ti.UI.URL_ERROR_BAD_URL is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_BAD_URL = undefined;
+	} else {
+		this.URL_ERROR_BAD_URL = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_CONNECT) {
+		throw new Error('Ti.UI.URL_ERROR_CONNECT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_CONNECT = undefined;
+	} else {
+		this.URL_ERROR_CONNECT = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_SSL_FAILED) {
+		throw new Error('Ti.UI.URL_ERROR_SSL_FAILED is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_SSL_FAILED = undefined;
+	} else {
+		this.URL_ERROR_SSL_FAILED = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_FILE) {
+		throw new Error('Ti.UI.URL_ERROR_FILE is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_FILE = undefined;
+	} else {
+		this.URL_ERROR_FILE = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_FILE_NOT_FOUND) {
+		throw new Error('Ti.UI.URL_ERROR_FILE_NOT_FOUND is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_FILE_NOT_FOUND = undefined;
+	} else {
+		this.URL_ERROR_FILE_NOT_FOUND = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_HOST_LOOKUP) {
+		throw new Error('Ti.UI.URL_ERROR_HOST_LOOKUP is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_HOST_LOOKUP = undefined;
+	} else {
+		this.URL_ERROR_HOST_LOOKUP = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_REDIRECT_LOOP) {
+		throw new Error('Ti.UI.URL_ERROR_REDIRECT_LOOP is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_REDIRECT_LOOP = undefined;
+	} else {
+		this.URL_ERROR_REDIRECT_LOOP = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_TIMEOUT) {
+		throw new Error('Ti.UI.URL_ERROR_TIMEOUT is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_TIMEOUT = undefined;
+	} else {
+		this.URL_ERROR_TIMEOUT = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_UNKNOWN) {
+		throw new Error('Ti.UI.URL_ERROR_UNKNOWN is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_UNKNOWN = undefined;
+	} else {
+		this.URL_ERROR_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.URL_ERROR_UNSUPPORTED_SCHEME) {
+		throw new Error('Ti.UI.URL_ERROR_UNSUPPORTED_SCHEME is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.URL_ERROR_UNSUPPORTED_SCHEME = undefined;
+	} else {
+		this.URL_ERROR_UNSUPPORTED_SCHEME = 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentTab = undefined;
+	} else {
+		this.currentTab = __SLAG_PROPERTIES.currentTab || {};
+	}
+	if (__SLAG_PROPERTIES.currentWindow) {
+		throw new Error('Ti.UI.currentWindow is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentWindow = undefined;
+	} else {
+		this.currentWindow = {};
+	}
+	if (__SLAG_PROPERTIES.orientation) {
+		throw new Error('Ti.UI.orientation was deprecated, since 1.7.2');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+UI.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UI.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UI.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+UI.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+UI.prototype.create2DMatrix = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TwoDMatrix = require('./UI/2DMatrix');
+	return TwoDMatrix(__SLAG_PROPERTY);
+};
+UI.prototype.convertUnits = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+UI.prototype.createView = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var View = require('./UI/View');
+	return View(__SLAG_PROPERTY);
+};
+UI.prototype.create3DMatrix = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ThreeDMatrix = require('./UI/3DMatrix');
+	return ThreeDMatrix(__SLAG_PROPERTY);
+};
+UI.prototype.createActivityIndicator = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ActivityIndicator = require('./UI/ActivityIndicator');
+	return ActivityIndicator(__SLAG_PROPERTY);
+};
+UI.prototype.createAlertDialog = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var AlertDialog = require('./UI/AlertDialog');
+	return AlertDialog(__SLAG_PROPERTY);
+};
+UI.prototype.createAnimation = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Animation = require('./UI/Animation');
+	return Animation(__SLAG_PROPERTY);
+};
+UI.prototype.createAttributedString = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var AttributedString = require('./UI/AttributedString');
+	return AttributedString(__SLAG_PROPERTY);
+};
+UI.prototype.createButton = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Button = require('./UI/Button');
+	return Button(__SLAG_PROPERTY);
+};
+UI.prototype.createButtonBar = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ButtonBar = require('./UI/ButtonBar');
+	return ButtonBar(__SLAG_PROPERTY);
+};
+UI.prototype.createCoverFlowView = function () {
+	throw new Error('Ti.UI.createCoverFlowView was deprecated, since 1.8.0');
+};
+UI.prototype.createDashboardItem = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var DashboardItem = require('./UI/DashboardItem');
+	return DashboardItem(__SLAG_PROPERTY);
+};
+UI.prototype.createDashboardView = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var DashboardView = require('./UI/DashboardView');
+	return DashboardView(__SLAG_PROPERTY);
+};
+UI.prototype.createEmailDialog = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var EmailDialog = require('./UI/EmailDialog');
+	return EmailDialog(__SLAG_PROPERTY);
+};
+UI.prototype.createImageView = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ImageView = require('./UI/ImageView');
+	return ImageView(__SLAG_PROPERTY);
+};
+UI.prototype.createLabel = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Label = require('./UI/Label');
+	return Label(__SLAG_PROPERTY);
+};
+UI.prototype.createListSection = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ListSection = require('./UI/ListSection');
+	return ListSection(__SLAG_PROPERTY);
+};
+UI.prototype.createListView = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ListView = require('./UI/ListView');
+	return ListView(__SLAG_PROPERTY);
+};
+UI.prototype.createMaskedImage = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var MaskedImage = require('./UI/MaskedImage');
+	return MaskedImage(__SLAG_PROPERTY);
+};
+UI.prototype.createNotification = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Notification = require('./UI/Notification');
+	return Notification(__SLAG_PROPERTY);
+};
+UI.prototype.createOptionDialog = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var OptionDialog = require('./UI/OptionDialog');
+	return OptionDialog(__SLAG_PROPERTY);
+};
+UI.prototype.createPicker = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Picker = require('./UI/Picker');
+	return Picker(__SLAG_PROPERTY);
+};
+UI.prototype.createPickerColumn = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var PickerColumn = require('./UI/PickerColumn');
+	return PickerColumn(__SLAG_PROPERTY);
+};
+UI.prototype.createPickerRow = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var PickerRow = require('./UI/PickerRow');
+	return PickerRow(__SLAG_PROPERTY);
+};
+UI.prototype.createProgressBar = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ProgressBar = require('./UI/ProgressBar');
+	return ProgressBar(__SLAG_PROPERTY);
+};
+UI.prototype.createRefreshControl = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var RefreshControl = require('./UI/RefreshControl');
+	return RefreshControl(__SLAG_PROPERTY);
+};
+UI.prototype.createScrollView = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ScrollView = require('./UI/ScrollView');
+	return ScrollView(__SLAG_PROPERTY);
+};
+UI.prototype.createScrollableView = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ScrollableView = require('./UI/ScrollableView');
+	return ScrollableView(__SLAG_PROPERTY);
+};
+UI.prototype.createSearchBar = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SearchBar = require('./UI/SearchBar');
+	return SearchBar(__SLAG_PROPERTY);
+};
+UI.prototype.createSlider = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Slider = require('./UI/Slider');
+	return Slider(__SLAG_PROPERTY);
+};
+UI.prototype.createSwitch = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Switch = require('./UI/Switch');
+	return Switch(__SLAG_PROPERTY);
+};
+UI.prototype.createTab = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Tab = require('./UI/Tab');
+	return Tab(__SLAG_PROPERTY);
+};
+UI.prototype.createTabGroup = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TabGroup = require('./UI/TabGroup');
+	return TabGroup(__SLAG_PROPERTY);
+};
+UI.prototype.createTabbedBar = function () {
+	throw new Error('Ti.UI.createTabbedBar was deprecated, since 1.8.0');
+};
+UI.prototype.createTableView = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TableView = require('./UI/TableView');
+	return TableView(__SLAG_PROPERTY);
+};
+UI.prototype.createTableViewRow = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TableViewRow = require('./UI/TableViewRow');
+	return TableViewRow(__SLAG_PROPERTY);
+};
+UI.prototype.createTableViewSection = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TableViewSection = require('./UI/TableViewSection');
+	return TableViewSection(__SLAG_PROPERTY);
+};
+UI.prototype.createTextArea = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TextArea = require('./UI/TextArea');
+	return TextArea(__SLAG_PROPERTY);
+};
+UI.prototype.createTextField = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TextField = require('./UI/TextField');
+	return TextField(__SLAG_PROPERTY);
+};
+UI.prototype.createToolbar = function () {
+	throw new Error('Ti.UI.createToolbar was deprecated, since 1.8.0');
+};
+UI.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+UI.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+UI.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+UI.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+UI.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+UI.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+UI.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+UI.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+UI.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+UI.prototype.getCurrentTab = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentTab;
+};
+UI.prototype.setCurrentTab = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.currentTab = __SLAG__PROPERTY;
+};
+UI.prototype.getCurrentWindow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentWindow;
+};
+UI.prototype.getOrientation = function () {
+	throw new Error('Ti.UI.getOrientation was deprecated, since 1.7.2');
+};
+UI.prototype.setOrientation = function () {
+	throw new Error('Ti.UI.setOrientation was deprecated, since 1.7.2');
+};
+UI.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+UI.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+UI.prototype.createWebView = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var WebView = require('./UI/WebView');
+	return WebView(__SLAG_PROPERTY);
+};
+UI.prototype.createWindow = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Window = require('./UI/Window');
+	return Window(__SLAG_PROPERTY);
+};
+module.exports = function (properties) {
+	return new UI(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/2DMatrix.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/2DMatrix.js
@@ -1,0 +1,330 @@
+var crypto = require('crypto');
+function TwoDMatrix(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'a',
+			'b',
+			'c',
+			'd',
+			'tx',
+			'ty',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.2DMatrix.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.2DMatrix';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.a = undefined;
+	} else {
+		this.a = __SLAG_PROPERTIES.a || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.b = undefined;
+	} else {
+		this.b = __SLAG_PROPERTIES.b || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.c = undefined;
+	} else {
+		this.c = __SLAG_PROPERTIES.c || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.d = undefined;
+	} else {
+		this.d = __SLAG_PROPERTIES.d || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tx = undefined;
+	} else {
+		this.tx = __SLAG_PROPERTIES.tx || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ty = undefined;
+	} else {
+		this.ty = __SLAG_PROPERTIES.ty || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TwoDMatrix.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TwoDMatrix.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TwoDMatrix.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TwoDMatrix.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TwoDMatrix.prototype.invert = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TwoDMatrix.prototype.multiply = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TwoDMatrix.prototype.rotate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TwoDMatrix.prototype.scale = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TwoDMatrix.prototype.translate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TwoDMatrix.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TwoDMatrix.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TwoDMatrix.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TwoDMatrix.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TwoDMatrix.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TwoDMatrix.prototype.getA = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.a;
+};
+TwoDMatrix.prototype.setA = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.a = __SLAG__PROPERTY;
+};
+TwoDMatrix.prototype.getB = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.b;
+};
+TwoDMatrix.prototype.setB = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.b = __SLAG__PROPERTY;
+};
+TwoDMatrix.prototype.getC = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.c;
+};
+TwoDMatrix.prototype.setC = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.c = __SLAG__PROPERTY;
+};
+TwoDMatrix.prototype.getD = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.d;
+};
+TwoDMatrix.prototype.setD = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.d = __SLAG__PROPERTY;
+};
+TwoDMatrix.prototype.getTx = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tx;
+};
+TwoDMatrix.prototype.setTx = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tx = __SLAG__PROPERTY;
+};
+TwoDMatrix.prototype.getTy = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ty;
+};
+TwoDMatrix.prototype.setTy = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ty = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TwoDMatrix(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/3DMatrix.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/3DMatrix.js
@@ -1,0 +1,393 @@
+var crypto = require('crypto');
+function ThreeDMatrix(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'm11',
+			'm12',
+			'm13',
+			'm14',
+			'm21',
+			'm22',
+			'm23',
+			'm24',
+			'm31',
+			'm32',
+			'm33',
+			'm34',
+			'm41',
+			'm42',
+			'm43',
+			'm44',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.3DMatrix.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.3DMatrix';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m11 = undefined;
+	} else {
+		this.m11 = __SLAG_PROPERTIES.m11 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m12 = undefined;
+	} else {
+		this.m12 = __SLAG_PROPERTIES.m12 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m13 = undefined;
+	} else {
+		this.m13 = __SLAG_PROPERTIES.m13 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m14 = undefined;
+	} else {
+		this.m14 = __SLAG_PROPERTIES.m14 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m21 = undefined;
+	} else {
+		this.m21 = __SLAG_PROPERTIES.m21 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m22 = undefined;
+	} else {
+		this.m22 = __SLAG_PROPERTIES.m22 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m23 = undefined;
+	} else {
+		this.m23 = __SLAG_PROPERTIES.m23 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m24 = undefined;
+	} else {
+		this.m24 = __SLAG_PROPERTIES.m24 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m31 = undefined;
+	} else {
+		this.m31 = __SLAG_PROPERTIES.m31 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m32 = undefined;
+	} else {
+		this.m32 = __SLAG_PROPERTIES.m32 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m33 = undefined;
+	} else {
+		this.m33 = __SLAG_PROPERTIES.m33 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m34 = undefined;
+	} else {
+		this.m34 = __SLAG_PROPERTIES.m34 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m41 = undefined;
+	} else {
+		this.m41 = __SLAG_PROPERTIES.m41 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m42 = undefined;
+	} else {
+		this.m42 = __SLAG_PROPERTIES.m42 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m43 = undefined;
+	} else {
+		this.m43 = __SLAG_PROPERTIES.m43 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m44 = undefined;
+	} else {
+		this.m44 = __SLAG_PROPERTIES.m44 || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ThreeDMatrix.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ThreeDMatrix.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ThreeDMatrix.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ThreeDMatrix.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ThreeDMatrix.prototype.invert = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.multiply = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.rotate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.scale = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.translate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ThreeDMatrix.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ThreeDMatrix.prototype.getM11 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m11;
+};
+ThreeDMatrix.prototype.setM11 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m11 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM12 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m12;
+};
+ThreeDMatrix.prototype.setM12 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m12 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM13 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m13;
+};
+ThreeDMatrix.prototype.setM13 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m13 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM14 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m14;
+};
+ThreeDMatrix.prototype.setM14 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m14 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM21 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m21;
+};
+ThreeDMatrix.prototype.setM21 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m21 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM22 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m22;
+};
+ThreeDMatrix.prototype.setM22 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m22 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM23 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m23;
+};
+ThreeDMatrix.prototype.setM23 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m23 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM24 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m24;
+};
+ThreeDMatrix.prototype.setM24 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m24 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM31 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m31;
+};
+ThreeDMatrix.prototype.setM31 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m31 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM32 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m32;
+};
+ThreeDMatrix.prototype.setM32 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m32 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM33 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m33;
+};
+ThreeDMatrix.prototype.setM33 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m33 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM34 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m34;
+};
+ThreeDMatrix.prototype.setM34 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m34 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM41 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m41;
+};
+ThreeDMatrix.prototype.setM41 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m41 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM42 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m42;
+};
+ThreeDMatrix.prototype.setM42 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m42 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM43 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m43;
+};
+ThreeDMatrix.prototype.setM43 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m43 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM44 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m44;
+};
+ThreeDMatrix.prototype.setM44 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m44 = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ThreeDMatrix(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ActivityIndicator.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ActivityIndicator.js
@@ -1,0 +1,750 @@
+var crypto = require('crypto');
+function ActivityIndicator(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'bottom',
+			'elevation',
+			'height',
+			'left',
+			'previewContext',
+			'right',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'top',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'width',
+			'color',
+			'font',
+			'message',
+			'messageid',
+			'style',
+			'indicatorColor',
+			'indicatorDiameter',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ActivityIndicator.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ActivityIndicator';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.messageid = undefined;
+	} else {
+		this.messageid = __SLAG_PROPERTIES.messageid || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.indicatorColor = undefined;
+	} else {
+		this.indicatorColor = __SLAG_PROPERTIES.indicatorColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.indicatorDiameter = undefined;
+	} else {
+		this.indicatorDiameter = __SLAG_PROPERTIES.indicatorDiameter || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ActivityIndicator.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ActivityIndicator.prototype.add = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.ActivityIndicator.finishLayout was deprecated, since 3.0.0');
+};
+ActivityIndicator.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.remove = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicator.prototype.startLayout = function () {
+	throw new Error('Ti.UI.ActivityIndicator.startLayout was deprecated, since 3.0.0');
+};
+ActivityIndicator.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.ActivityIndicator.updateLayout was deprecated, since 3.0.0');
+};
+ActivityIndicator.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ActivityIndicator.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ActivityIndicator.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ActivityIndicator.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+ActivityIndicator.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+ActivityIndicator.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+ActivityIndicator.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+ActivityIndicator.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+ActivityIndicator.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+ActivityIndicator.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+ActivityIndicator.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+ActivityIndicator.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+ActivityIndicator.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+ActivityIndicator.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+ActivityIndicator.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+ActivityIndicator.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+ActivityIndicator.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+ActivityIndicator.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+ActivityIndicator.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+ActivityIndicator.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+ActivityIndicator.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+ActivityIndicator.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getFont = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+ActivityIndicator.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getMessage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.message;
+};
+ActivityIndicator.prototype.setMessage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.message = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getMessageid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.messageid;
+};
+ActivityIndicator.prototype.setMessageid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.messageid = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getStyle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+ActivityIndicator.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getIndicatorColor = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.indicatorColor;
+};
+ActivityIndicator.prototype.setIndicatorColor = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.indicatorColor = __SLAG__PROPERTY;
+};
+ActivityIndicator.prototype.getIndicatorDiameter = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.indicatorDiameter;
+};
+ActivityIndicator.prototype.setIndicatorDiameter = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.indicatorDiameter = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ActivityIndicator(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ActivityIndicatorStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ActivityIndicatorStyle.js
@@ -1,0 +1,169 @@
+var crypto = require('crypto');
+function ActivityIndicatorStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'BIG',
+			'DARK',
+			'BIG_DARK',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ActivityIndicatorStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ActivityIndicatorStyle';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.BIG) {
+		throw new Error('Ti.UI.ActivityIndicatorStyle.BIG is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BIG = undefined;
+	} else {
+		this.BIG = 0;
+	}
+	if (__SLAG_PROPERTIES.DARK) {
+		throw new Error('Ti.UI.ActivityIndicatorStyle.DARK is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DARK = undefined;
+	} else {
+		this.DARK = 0;
+	}
+	if (__SLAG_PROPERTIES.BIG_DARK) {
+		throw new Error('Ti.UI.ActivityIndicatorStyle.BIG_DARK is read only property');
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BIG_DARK = undefined;
+	} else {
+		this.BIG_DARK = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.ActivityIndicatorStyle.PLAIN is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ActivityIndicatorStyle.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicatorStyle.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicatorStyle.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicatorStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ActivityIndicatorStyle.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ActivityIndicatorStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ActivityIndicatorStyle.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ActivityIndicatorStyle.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ActivityIndicatorStyle.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ActivityIndicatorStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/AlertDialog.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/AlertDialog.js
@@ -1,0 +1,959 @@
+var crypto = require('crypto');
+function AlertDialog(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'elevation',
+			'previewContext',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'androidView',
+			'buttonNames',
+			'cancel',
+			'canceledOnTouchOutside',
+			'destructive',
+			'preferred',
+			'keyboardType',
+			'keyboardAppearance',
+			'loginPlaceholder',
+			'loginHintText',
+			'loginReturnKeyType',
+			'loginKeyboardType',
+			'message',
+			'messageid',
+			'ok',
+			'okid',
+			'passwordPlaceholder',
+			'passwordHintText',
+			'passwordReturnKeyType',
+			'passwordKeyboardType',
+			'placeholder',
+			'hintText',
+			'persistent',
+			'returnKeyType',
+			'style',
+			'title',
+			'titleid',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.AlertDialog.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.AlertDialog';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.androidView = undefined;
+	} else {
+		this.androidView = __SLAG_PROPERTIES.androidView || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.buttonNames = undefined;
+	} else {
+		this.buttonNames = __SLAG_PROPERTIES.buttonNames || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancel = undefined;
+	} else {
+		this.cancel = __SLAG_PROPERTIES.cancel || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canceledOnTouchOutside = undefined;
+	} else {
+		this.canceledOnTouchOutside = __SLAG_PROPERTIES.canceledOnTouchOutside || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.destructive = undefined;
+	} else {
+		this.destructive = __SLAG_PROPERTIES.destructive || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.preferred = undefined;
+	} else {
+		this.preferred = __SLAG_PROPERTIES.preferred || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardType = undefined;
+	} else {
+		this.keyboardType = __SLAG_PROPERTIES.keyboardType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardAppearance = undefined;
+	} else {
+		this.keyboardAppearance = __SLAG_PROPERTIES.keyboardAppearance || 0;
+	}
+	if (__SLAG_PROPERTIES.loginPlaceholder) {
+		throw new Error('Ti.UI.AlertDialog.loginPlaceholder was deprecated, since 5.4.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.loginHintText = undefined;
+	} else {
+		this.loginHintText = __SLAG_PROPERTIES.loginHintText || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.loginReturnKeyType = undefined;
+	} else {
+		this.loginReturnKeyType = __SLAG_PROPERTIES.loginReturnKeyType || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.loginKeyboardType = undefined;
+	} else {
+		this.loginKeyboardType = __SLAG_PROPERTIES.loginKeyboardType || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.messageid = undefined;
+	} else {
+		this.messageid = __SLAG_PROPERTIES.messageid || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ok = undefined;
+	} else {
+		this.ok = __SLAG_PROPERTIES.ok || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.okid = undefined;
+	} else {
+		this.okid = __SLAG_PROPERTIES.okid || '';
+	}
+	if (__SLAG_PROPERTIES.passwordPlaceholder) {
+		throw new Error('Ti.UI.AlertDialog.passwordPlaceholder was deprecated, since 5.4.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.passwordHintText = undefined;
+	} else {
+		this.passwordHintText = __SLAG_PROPERTIES.passwordHintText || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.passwordReturnKeyType = undefined;
+	} else {
+		this.passwordReturnKeyType = __SLAG_PROPERTIES.passwordReturnKeyType || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.passwordKeyboardType = undefined;
+	} else {
+		this.passwordKeyboardType = __SLAG_PROPERTIES.passwordKeyboardType || 0;
+	}
+	if (__SLAG_PROPERTIES.placeholder) {
+		throw new Error('Ti.UI.AlertDialog.placeholder was deprecated, since 5.4.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hintText = undefined;
+	} else {
+		this.hintText = __SLAG_PROPERTIES.hintText || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.persistent = undefined;
+	} else {
+		this.persistent = __SLAG_PROPERTIES.persistent || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.returnKeyType = undefined;
+	} else {
+		this.returnKeyType = __SLAG_PROPERTIES.returnKeyType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AlertDialog.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialog.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialog.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialog.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AlertDialog.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.AlertDialog.finishLayout was deprecated, since 3.0.0');
+};
+AlertDialog.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialog.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialog.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialog.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialog.prototype.startLayout = function () {
+	throw new Error('Ti.UI.AlertDialog.startLayout was deprecated, since 3.0.0');
+};
+AlertDialog.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.AlertDialog.updateLayout was deprecated, since 3.0.0');
+};
+AlertDialog.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AlertDialog.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+AlertDialog.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+AlertDialog.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+AlertDialog.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+AlertDialog.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+AlertDialog.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+AlertDialog.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+AlertDialog.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+AlertDialog.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+AlertDialog.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+AlertDialog.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+AlertDialog.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+AlertDialog.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+AlertDialog.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getButtonNames = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.buttonNames;
+};
+AlertDialog.prototype.setButtonNames = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.buttonNames = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getCancel = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cancel;
+};
+AlertDialog.prototype.setCancel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cancel = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getCanceledOnTouchOutside = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.canceledOnTouchOutside;
+};
+AlertDialog.prototype.setCanceledOnTouchOutside = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.canceledOnTouchOutside = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getDestructive = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.destructive;
+};
+AlertDialog.prototype.setDestructive = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.destructive = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getPreferred = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.preferred;
+};
+AlertDialog.prototype.setPreferred = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.preferred = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getKeyboardType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardType;
+};
+AlertDialog.prototype.setKeyboardType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardType = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getKeyboardAppearance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardAppearance;
+};
+AlertDialog.prototype.setKeyboardAppearance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardAppearance = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getLoginPlaceholder = function () {
+	throw new Error('Ti.UI.AlertDialog.getLoginPlaceholder was deprecated, since 5.4.0');
+};
+AlertDialog.prototype.setLoginPlaceholder = function () {
+	throw new Error('Ti.UI.AlertDialog.setLoginPlaceholder was deprecated, since 5.4.0');
+};
+AlertDialog.prototype.getLoginHintText = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.loginHintText;
+};
+AlertDialog.prototype.setLoginHintText = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.loginHintText = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getLoginReturnKeyType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.loginReturnKeyType;
+};
+AlertDialog.prototype.setLoginReturnKeyType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.loginReturnKeyType = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getLoginKeyboardType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.loginKeyboardType;
+};
+AlertDialog.prototype.setLoginKeyboardType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.loginKeyboardType = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getMessage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.message;
+};
+AlertDialog.prototype.setMessage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.message = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getMessageid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.messageid;
+};
+AlertDialog.prototype.setMessageid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.messageid = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getOk = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ok;
+};
+AlertDialog.prototype.setOk = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ok = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getOkid = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.okid;
+};
+AlertDialog.prototype.setOkid = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.okid = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getPasswordPlaceholder = function () {
+	throw new Error('Ti.UI.AlertDialog.getPasswordPlaceholder was deprecated, since 5.4.0');
+};
+AlertDialog.prototype.setPasswordPlaceholder = function () {
+	throw new Error('Ti.UI.AlertDialog.setPasswordPlaceholder was deprecated, since 5.4.0');
+};
+AlertDialog.prototype.getPasswordHintText = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.passwordHintText;
+};
+AlertDialog.prototype.setPasswordHintText = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.passwordHintText = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getPasswordReturnKeyType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.passwordReturnKeyType;
+};
+AlertDialog.prototype.setPasswordReturnKeyType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.passwordReturnKeyType = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getPasswordKeyboardType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.passwordKeyboardType;
+};
+AlertDialog.prototype.setPasswordKeyboardType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.passwordKeyboardType = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getPlaceholder = function () {
+	throw new Error('Ti.UI.AlertDialog.getPlaceholder was deprecated, since 5.4.0');
+};
+AlertDialog.prototype.setPlaceholder = function () {
+	throw new Error('Ti.UI.AlertDialog.setPlaceholder was deprecated, since 5.4.0');
+};
+AlertDialog.prototype.getHintText = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hintText;
+};
+AlertDialog.prototype.setHintText = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hintText = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getPersistent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.persistent;
+};
+AlertDialog.prototype.setPersistent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.persistent = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getReturnKeyType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.returnKeyType;
+};
+AlertDialog.prototype.setReturnKeyType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.returnKeyType = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+AlertDialog.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+AlertDialog.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+AlertDialog.prototype.getTitleid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+AlertDialog.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new AlertDialog(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Android.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Android.js
@@ -1,0 +1,873 @@
+var crypto = require('crypto');
+function Android(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'GRAVITY_AXIS_CLIP',
+			'GRAVITY_AXIS_PULL_AFTER',
+			'GRAVITY_AXIS_PULL_BEFORE',
+			'GRAVITY_AXIS_SPECIFIED',
+			'GRAVITY_AXIS_X_SHIFT',
+			'GRAVITY_AXIS_Y_SHIFT',
+			'GRAVITY_BOTTOM',
+			'GRAVITY_CENTER',
+			'GRAVITY_CENTER_HORIZONTAL',
+			'GRAVITY_CENTER_VERTICAL',
+			'GRAVITY_CLIP_HORIZONTAL',
+			'GRAVITY_CLIP_VERTICAL',
+			'GRAVITY_DISPLAY_CLIP_HORIZONTAL',
+			'GRAVITY_DISPLAY_CLIP_VERTICAL',
+			'GRAVITY_END',
+			'GRAVITY_FILL',
+			'GRAVITY_FILL_HORIZONTAL',
+			'GRAVITY_FILL_VERTICAL',
+			'GRAVITY_HORIZONTAL_GRAVITY_MASK',
+			'GRAVITY_LEFT',
+			'GRAVITY_NO_GRAVITY',
+			'GRAVITY_RELATIVE_HORIZONTAL_GRAVITY_MASK',
+			'GRAVITY_RELATIVE_LAYOUT_DIRECTION',
+			'GRAVITY_RIGHT',
+			'GRAVITY_START',
+			'GRAVITY_TOP',
+			'GRAVITY_VERTICAL_GRAVITY_MASK',
+			'LINKIFY_ALL',
+			'LINKIFY_EMAIL_ADDRESSES',
+			'LINKIFY_MAP_ADDRESSES',
+			'LINKIFY_PHONE_NUMBERS',
+			'LINKIFY_WEB_URLS',
+			'OVER_SCROLL_ALWAYS',
+			'OVER_SCROLL_IF_CONTENT_SCROLLS',
+			'OVER_SCROLL_NEVER',
+			'PIXEL_FORMAT_A_8',
+			'PIXEL_FORMAT_LA_88',
+			'PIXEL_FORMAT_L_8',
+			'PIXEL_FORMAT_OPAQUE',
+			'PIXEL_FORMAT_RGBA_4444',
+			'PIXEL_FORMAT_RGBA_5551',
+			'PIXEL_FORMAT_RGBA_8888',
+			'PIXEL_FORMAT_RGBX_8888',
+			'PIXEL_FORMAT_RGB_332',
+			'PIXEL_FORMAT_RGB_565',
+			'PIXEL_FORMAT_RGB_888',
+			'PIXEL_FORMAT_TRANSLUCENT',
+			'PIXEL_FORMAT_TRANSPARENT',
+			'PIXEL_FORMAT_UNKNOWN',
+			'PROGRESS_INDICATOR_DIALOG',
+			'PROGRESS_INDICATOR_STATUS_BAR',
+			'PROGRESS_INDICATOR_INDETERMINANT',
+			'PROGRESS_INDICATOR_DETERMINANT',
+			'SOFT_INPUT_ADJUST_PAN',
+			'SOFT_INPUT_ADJUST_RESIZE',
+			'SOFT_INPUT_ADJUST_UNSPECIFIED',
+			'SOFT_INPUT_STATE_ALWAYS_HIDDEN',
+			'SOFT_INPUT_STATE_ALWAYS_VISIBLE',
+			'SOFT_INPUT_STATE_HIDDEN',
+			'SOFT_INPUT_STATE_UNSPECIFIED',
+			'SOFT_INPUT_STATE_VISIBLE',
+			'SOFT_KEYBOARD_DEFAULT_ON_FOCUS',
+			'SOFT_KEYBOARD_HIDE_ON_FOCUS',
+			'SOFT_KEYBOARD_SHOW_ON_FOCUS',
+			'SWITCH_STYLE_CHECKBOX',
+			'SWITCH_STYLE_TOGGLEBUTTON',
+			'SWITCH_STYLE_SWITCH',
+			'WEBVIEW_PLUGINS_OFF',
+			'WEBVIEW_PLUGINS_ON',
+			'WEBVIEW_PLUGINS_ON_DEMAND',
+			'WEBVIEW_LOAD_DEFAULT',
+			'WEBVIEW_LOAD_NO_CACHE',
+			'WEBVIEW_LOAD_CACHE_ONLY',
+			'WEBVIEW_LOAD_CACHE_ELSE_NETWORK',
+			'TRANSITION_EXPLODE',
+			'TRANSITION_FADE_IN',
+			'TRANSITION_FADE_OUT',
+			'TRANSITION_SLIDE_TOP',
+			'TRANSITION_SLIDE_RIGHT',
+			'TRANSITION_SLIDE_BOTTOM',
+			'TRANSITION_SLIDE_LEFT',
+			'TRANSITION_CHANGE_BOUNDS',
+			'TRANSITION_CHANGE_CLIP_BOUNDS',
+			'TRANSITION_CHANGE_TRANSFORM',
+			'TRANSITION_CHANGE_IMAGE_TRANSFORM',
+			'TRANSITION_NONE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Android.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Android';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_AXIS_CLIP) {
+		throw new Error('Ti.UI.Android.GRAVITY_AXIS_CLIP is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_AXIS_CLIP = undefined;
+	} else {
+		this.GRAVITY_AXIS_CLIP = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_AXIS_PULL_AFTER) {
+		throw new Error('Ti.UI.Android.GRAVITY_AXIS_PULL_AFTER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_AXIS_PULL_AFTER = undefined;
+	} else {
+		this.GRAVITY_AXIS_PULL_AFTER = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_AXIS_PULL_BEFORE) {
+		throw new Error('Ti.UI.Android.GRAVITY_AXIS_PULL_BEFORE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_AXIS_PULL_BEFORE = undefined;
+	} else {
+		this.GRAVITY_AXIS_PULL_BEFORE = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_AXIS_SPECIFIED) {
+		throw new Error('Ti.UI.Android.GRAVITY_AXIS_SPECIFIED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_AXIS_SPECIFIED = undefined;
+	} else {
+		this.GRAVITY_AXIS_SPECIFIED = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_AXIS_X_SHIFT) {
+		throw new Error('Ti.UI.Android.GRAVITY_AXIS_X_SHIFT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_AXIS_X_SHIFT = undefined;
+	} else {
+		this.GRAVITY_AXIS_X_SHIFT = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_AXIS_Y_SHIFT) {
+		throw new Error('Ti.UI.Android.GRAVITY_AXIS_Y_SHIFT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_AXIS_Y_SHIFT = undefined;
+	} else {
+		this.GRAVITY_AXIS_Y_SHIFT = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_BOTTOM) {
+		throw new Error('Ti.UI.Android.GRAVITY_BOTTOM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_BOTTOM = undefined;
+	} else {
+		this.GRAVITY_BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_CENTER) {
+		throw new Error('Ti.UI.Android.GRAVITY_CENTER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_CENTER = undefined;
+	} else {
+		this.GRAVITY_CENTER = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_CENTER_HORIZONTAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_CENTER_HORIZONTAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_CENTER_HORIZONTAL = undefined;
+	} else {
+		this.GRAVITY_CENTER_HORIZONTAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_CENTER_VERTICAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_CENTER_VERTICAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_CENTER_VERTICAL = undefined;
+	} else {
+		this.GRAVITY_CENTER_VERTICAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_CLIP_HORIZONTAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_CLIP_HORIZONTAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_CLIP_HORIZONTAL = undefined;
+	} else {
+		this.GRAVITY_CLIP_HORIZONTAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_CLIP_VERTICAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_CLIP_VERTICAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_CLIP_VERTICAL = undefined;
+	} else {
+		this.GRAVITY_CLIP_VERTICAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_DISPLAY_CLIP_HORIZONTAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_DISPLAY_CLIP_HORIZONTAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_DISPLAY_CLIP_HORIZONTAL = undefined;
+	} else {
+		this.GRAVITY_DISPLAY_CLIP_HORIZONTAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_DISPLAY_CLIP_VERTICAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_DISPLAY_CLIP_VERTICAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_DISPLAY_CLIP_VERTICAL = undefined;
+	} else {
+		this.GRAVITY_DISPLAY_CLIP_VERTICAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_END) {
+		throw new Error('Ti.UI.Android.GRAVITY_END is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_END = undefined;
+	} else {
+		this.GRAVITY_END = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_FILL) {
+		throw new Error('Ti.UI.Android.GRAVITY_FILL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_FILL = undefined;
+	} else {
+		this.GRAVITY_FILL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_FILL_HORIZONTAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_FILL_HORIZONTAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_FILL_HORIZONTAL = undefined;
+	} else {
+		this.GRAVITY_FILL_HORIZONTAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_FILL_VERTICAL) {
+		throw new Error('Ti.UI.Android.GRAVITY_FILL_VERTICAL is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_FILL_VERTICAL = undefined;
+	} else {
+		this.GRAVITY_FILL_VERTICAL = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_HORIZONTAL_GRAVITY_MASK) {
+		throw new Error('Ti.UI.Android.GRAVITY_HORIZONTAL_GRAVITY_MASK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_HORIZONTAL_GRAVITY_MASK = undefined;
+	} else {
+		this.GRAVITY_HORIZONTAL_GRAVITY_MASK = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_LEFT) {
+		throw new Error('Ti.UI.Android.GRAVITY_LEFT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_LEFT = undefined;
+	} else {
+		this.GRAVITY_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_NO_GRAVITY) {
+		throw new Error('Ti.UI.Android.GRAVITY_NO_GRAVITY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_NO_GRAVITY = undefined;
+	} else {
+		this.GRAVITY_NO_GRAVITY = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_RELATIVE_HORIZONTAL_GRAVITY_MASK) {
+		throw new Error('Ti.UI.Android.GRAVITY_RELATIVE_HORIZONTAL_GRAVITY_MASK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_RELATIVE_HORIZONTAL_GRAVITY_MASK = undefined;
+	} else {
+		this.GRAVITY_RELATIVE_HORIZONTAL_GRAVITY_MASK = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_RELATIVE_LAYOUT_DIRECTION) {
+		throw new Error('Ti.UI.Android.GRAVITY_RELATIVE_LAYOUT_DIRECTION is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_RELATIVE_LAYOUT_DIRECTION = undefined;
+	} else {
+		this.GRAVITY_RELATIVE_LAYOUT_DIRECTION = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_RIGHT) {
+		throw new Error('Ti.UI.Android.GRAVITY_RIGHT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_RIGHT = undefined;
+	} else {
+		this.GRAVITY_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_START) {
+		throw new Error('Ti.UI.Android.GRAVITY_START is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_START = undefined;
+	} else {
+		this.GRAVITY_START = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_TOP) {
+		throw new Error('Ti.UI.Android.GRAVITY_TOP is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_TOP = undefined;
+	} else {
+		this.GRAVITY_TOP = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAVITY_VERTICAL_GRAVITY_MASK) {
+		throw new Error('Ti.UI.Android.GRAVITY_VERTICAL_GRAVITY_MASK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAVITY_VERTICAL_GRAVITY_MASK = undefined;
+	} else {
+		this.GRAVITY_VERTICAL_GRAVITY_MASK = 0;
+	}
+	if (__SLAG_PROPERTIES.LINKIFY_ALL) {
+		throw new Error('Ti.UI.Android.LINKIFY_ALL was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.LINKIFY_EMAIL_ADDRESSES) {
+		throw new Error('Ti.UI.Android.LINKIFY_EMAIL_ADDRESSES was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.LINKIFY_MAP_ADDRESSES) {
+		throw new Error('Ti.UI.Android.LINKIFY_MAP_ADDRESSES was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.LINKIFY_PHONE_NUMBERS) {
+		throw new Error('Ti.UI.Android.LINKIFY_PHONE_NUMBERS was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.LINKIFY_WEB_URLS) {
+		throw new Error('Ti.UI.Android.LINKIFY_WEB_URLS was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.OVER_SCROLL_ALWAYS) {
+		throw new Error('Ti.UI.Android.OVER_SCROLL_ALWAYS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.OVER_SCROLL_ALWAYS = undefined;
+	} else {
+		this.OVER_SCROLL_ALWAYS = 0;
+	}
+	if (__SLAG_PROPERTIES.OVER_SCROLL_IF_CONTENT_SCROLLS) {
+		throw new Error('Ti.UI.Android.OVER_SCROLL_IF_CONTENT_SCROLLS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.OVER_SCROLL_IF_CONTENT_SCROLLS = undefined;
+	} else {
+		this.OVER_SCROLL_IF_CONTENT_SCROLLS = 0;
+	}
+	if (__SLAG_PROPERTIES.OVER_SCROLL_NEVER) {
+		throw new Error('Ti.UI.Android.OVER_SCROLL_NEVER is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.OVER_SCROLL_NEVER = undefined;
+	} else {
+		this.OVER_SCROLL_NEVER = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_A_8) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_A_8 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_A_8 = undefined;
+	} else {
+		this.PIXEL_FORMAT_A_8 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_LA_88) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_LA_88 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_LA_88 = undefined;
+	} else {
+		this.PIXEL_FORMAT_LA_88 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_L_8) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_L_8 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_L_8 = undefined;
+	} else {
+		this.PIXEL_FORMAT_L_8 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_OPAQUE) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_OPAQUE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_OPAQUE = undefined;
+	} else {
+		this.PIXEL_FORMAT_OPAQUE = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_RGBA_4444) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_RGBA_4444 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_RGBA_4444 = undefined;
+	} else {
+		this.PIXEL_FORMAT_RGBA_4444 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_RGBA_5551) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_RGBA_5551 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_RGBA_5551 = undefined;
+	} else {
+		this.PIXEL_FORMAT_RGBA_5551 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_RGBA_8888) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_RGBA_8888 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_RGBA_8888 = undefined;
+	} else {
+		this.PIXEL_FORMAT_RGBA_8888 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_RGBX_8888) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_RGBX_8888 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_RGBX_8888 = undefined;
+	} else {
+		this.PIXEL_FORMAT_RGBX_8888 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_RGB_332) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_RGB_332 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_RGB_332 = undefined;
+	} else {
+		this.PIXEL_FORMAT_RGB_332 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_RGB_565) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_RGB_565 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_RGB_565 = undefined;
+	} else {
+		this.PIXEL_FORMAT_RGB_565 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_RGB_888) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_RGB_888 is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_RGB_888 = undefined;
+	} else {
+		this.PIXEL_FORMAT_RGB_888 = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_TRANSLUCENT) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_TRANSLUCENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_TRANSLUCENT = undefined;
+	} else {
+		this.PIXEL_FORMAT_TRANSLUCENT = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_TRANSPARENT) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_TRANSPARENT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_TRANSPARENT = undefined;
+	} else {
+		this.PIXEL_FORMAT_TRANSPARENT = 0;
+	}
+	if (__SLAG_PROPERTIES.PIXEL_FORMAT_UNKNOWN) {
+		throw new Error('Ti.UI.Android.PIXEL_FORMAT_UNKNOWN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PIXEL_FORMAT_UNKNOWN = undefined;
+	} else {
+		this.PIXEL_FORMAT_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.PROGRESS_INDICATOR_DIALOG) {
+		throw new Error('Ti.UI.Android.PROGRESS_INDICATOR_DIALOG is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROGRESS_INDICATOR_DIALOG = undefined;
+	} else {
+		this.PROGRESS_INDICATOR_DIALOG = 0;
+	}
+	if (__SLAG_PROPERTIES.PROGRESS_INDICATOR_STATUS_BAR) {
+		throw new Error('Ti.UI.Android.PROGRESS_INDICATOR_STATUS_BAR is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROGRESS_INDICATOR_STATUS_BAR = undefined;
+	} else {
+		this.PROGRESS_INDICATOR_STATUS_BAR = 0;
+	}
+	if (__SLAG_PROPERTIES.PROGRESS_INDICATOR_INDETERMINANT) {
+		throw new Error('Ti.UI.Android.PROGRESS_INDICATOR_INDETERMINANT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROGRESS_INDICATOR_INDETERMINANT = undefined;
+	} else {
+		this.PROGRESS_INDICATOR_INDETERMINANT = 0;
+	}
+	if (__SLAG_PROPERTIES.PROGRESS_INDICATOR_DETERMINANT) {
+		throw new Error('Ti.UI.Android.PROGRESS_INDICATOR_DETERMINANT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROGRESS_INDICATOR_DETERMINANT = undefined;
+	} else {
+		this.PROGRESS_INDICATOR_DETERMINANT = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_ADJUST_PAN) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_ADJUST_PAN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_ADJUST_PAN = undefined;
+	} else {
+		this.SOFT_INPUT_ADJUST_PAN = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_ADJUST_RESIZE) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_ADJUST_RESIZE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_ADJUST_RESIZE = undefined;
+	} else {
+		this.SOFT_INPUT_ADJUST_RESIZE = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_ADJUST_UNSPECIFIED) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_ADJUST_UNSPECIFIED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_ADJUST_UNSPECIFIED = undefined;
+	} else {
+		this.SOFT_INPUT_ADJUST_UNSPECIFIED = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_STATE_ALWAYS_HIDDEN) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_STATE_ALWAYS_HIDDEN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_STATE_ALWAYS_HIDDEN = undefined;
+	} else {
+		this.SOFT_INPUT_STATE_ALWAYS_HIDDEN = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_STATE_ALWAYS_VISIBLE) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_STATE_ALWAYS_VISIBLE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_STATE_ALWAYS_VISIBLE = undefined;
+	} else {
+		this.SOFT_INPUT_STATE_ALWAYS_VISIBLE = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_STATE_HIDDEN) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_STATE_HIDDEN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_STATE_HIDDEN = undefined;
+	} else {
+		this.SOFT_INPUT_STATE_HIDDEN = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_STATE_UNSPECIFIED) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_STATE_UNSPECIFIED is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_STATE_UNSPECIFIED = undefined;
+	} else {
+		this.SOFT_INPUT_STATE_UNSPECIFIED = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_INPUT_STATE_VISIBLE) {
+		throw new Error('Ti.UI.Android.SOFT_INPUT_STATE_VISIBLE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_INPUT_STATE_VISIBLE = undefined;
+	} else {
+		this.SOFT_INPUT_STATE_VISIBLE = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_KEYBOARD_DEFAULT_ON_FOCUS) {
+		throw new Error('Ti.UI.Android.SOFT_KEYBOARD_DEFAULT_ON_FOCUS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_KEYBOARD_DEFAULT_ON_FOCUS = undefined;
+	} else {
+		this.SOFT_KEYBOARD_DEFAULT_ON_FOCUS = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_KEYBOARD_HIDE_ON_FOCUS) {
+		throw new Error('Ti.UI.Android.SOFT_KEYBOARD_HIDE_ON_FOCUS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_KEYBOARD_HIDE_ON_FOCUS = undefined;
+	} else {
+		this.SOFT_KEYBOARD_HIDE_ON_FOCUS = 0;
+	}
+	if (__SLAG_PROPERTIES.SOFT_KEYBOARD_SHOW_ON_FOCUS) {
+		throw new Error('Ti.UI.Android.SOFT_KEYBOARD_SHOW_ON_FOCUS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SOFT_KEYBOARD_SHOW_ON_FOCUS = undefined;
+	} else {
+		this.SOFT_KEYBOARD_SHOW_ON_FOCUS = 0;
+	}
+	if (__SLAG_PROPERTIES.SWITCH_STYLE_CHECKBOX) {
+		throw new Error('Ti.UI.Android.SWITCH_STYLE_CHECKBOX is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SWITCH_STYLE_CHECKBOX = undefined;
+	} else {
+		this.SWITCH_STYLE_CHECKBOX = 0;
+	}
+	if (__SLAG_PROPERTIES.SWITCH_STYLE_TOGGLEBUTTON) {
+		throw new Error('Ti.UI.Android.SWITCH_STYLE_TOGGLEBUTTON is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SWITCH_STYLE_TOGGLEBUTTON = undefined;
+	} else {
+		this.SWITCH_STYLE_TOGGLEBUTTON = 0;
+	}
+	if (__SLAG_PROPERTIES.SWITCH_STYLE_SWITCH) {
+		throw new Error('Ti.UI.Android.SWITCH_STYLE_SWITCH is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SWITCH_STYLE_SWITCH = undefined;
+	} else {
+		this.SWITCH_STYLE_SWITCH = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_PLUGINS_OFF) {
+		throw new Error('Ti.UI.Android.WEBVIEW_PLUGINS_OFF is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_PLUGINS_OFF = undefined;
+	} else {
+		this.WEBVIEW_PLUGINS_OFF = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_PLUGINS_ON) {
+		throw new Error('Ti.UI.Android.WEBVIEW_PLUGINS_ON is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_PLUGINS_ON = undefined;
+	} else {
+		this.WEBVIEW_PLUGINS_ON = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_PLUGINS_ON_DEMAND) {
+		throw new Error('Ti.UI.Android.WEBVIEW_PLUGINS_ON_DEMAND is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_PLUGINS_ON_DEMAND = undefined;
+	} else {
+		this.WEBVIEW_PLUGINS_ON_DEMAND = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_LOAD_DEFAULT) {
+		throw new Error('Ti.UI.Android.WEBVIEW_LOAD_DEFAULT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_LOAD_DEFAULT = undefined;
+	} else {
+		this.WEBVIEW_LOAD_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_LOAD_NO_CACHE) {
+		throw new Error('Ti.UI.Android.WEBVIEW_LOAD_NO_CACHE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_LOAD_NO_CACHE = undefined;
+	} else {
+		this.WEBVIEW_LOAD_NO_CACHE = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_LOAD_CACHE_ONLY) {
+		throw new Error('Ti.UI.Android.WEBVIEW_LOAD_CACHE_ONLY is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_LOAD_CACHE_ONLY = undefined;
+	} else {
+		this.WEBVIEW_LOAD_CACHE_ONLY = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_LOAD_CACHE_ELSE_NETWORK) {
+		throw new Error('Ti.UI.Android.WEBVIEW_LOAD_CACHE_ELSE_NETWORK is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_LOAD_CACHE_ELSE_NETWORK = undefined;
+	} else {
+		this.WEBVIEW_LOAD_CACHE_ELSE_NETWORK = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_EXPLODE) {
+		throw new Error('Ti.UI.Android.TRANSITION_EXPLODE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_EXPLODE = undefined;
+	} else {
+		this.TRANSITION_EXPLODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_FADE_IN) {
+		throw new Error('Ti.UI.Android.TRANSITION_FADE_IN is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_FADE_IN = undefined;
+	} else {
+		this.TRANSITION_FADE_IN = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_FADE_OUT) {
+		throw new Error('Ti.UI.Android.TRANSITION_FADE_OUT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_FADE_OUT = undefined;
+	} else {
+		this.TRANSITION_FADE_OUT = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_SLIDE_TOP) {
+		throw new Error('Ti.UI.Android.TRANSITION_SLIDE_TOP is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_SLIDE_TOP = undefined;
+	} else {
+		this.TRANSITION_SLIDE_TOP = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_SLIDE_RIGHT) {
+		throw new Error('Ti.UI.Android.TRANSITION_SLIDE_RIGHT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_SLIDE_RIGHT = undefined;
+	} else {
+		this.TRANSITION_SLIDE_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_SLIDE_BOTTOM) {
+		throw new Error('Ti.UI.Android.TRANSITION_SLIDE_BOTTOM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_SLIDE_BOTTOM = undefined;
+	} else {
+		this.TRANSITION_SLIDE_BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_SLIDE_LEFT) {
+		throw new Error('Ti.UI.Android.TRANSITION_SLIDE_LEFT is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_SLIDE_LEFT = undefined;
+	} else {
+		this.TRANSITION_SLIDE_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_CHANGE_BOUNDS) {
+		throw new Error('Ti.UI.Android.TRANSITION_CHANGE_BOUNDS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_CHANGE_BOUNDS = undefined;
+	} else {
+		this.TRANSITION_CHANGE_BOUNDS = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_CHANGE_CLIP_BOUNDS) {
+		throw new Error('Ti.UI.Android.TRANSITION_CHANGE_CLIP_BOUNDS is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_CHANGE_CLIP_BOUNDS = undefined;
+	} else {
+		this.TRANSITION_CHANGE_CLIP_BOUNDS = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_CHANGE_TRANSFORM) {
+		throw new Error('Ti.UI.Android.TRANSITION_CHANGE_TRANSFORM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_CHANGE_TRANSFORM = undefined;
+	} else {
+		this.TRANSITION_CHANGE_TRANSFORM = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_CHANGE_IMAGE_TRANSFORM) {
+		throw new Error('Ti.UI.Android.TRANSITION_CHANGE_IMAGE_TRANSFORM is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_CHANGE_IMAGE_TRANSFORM = undefined;
+	} else {
+		this.TRANSITION_CHANGE_IMAGE_TRANSFORM = 0;
+	}
+	if (__SLAG_PROPERTIES.TRANSITION_NONE) {
+		throw new Error('Ti.UI.Android.TRANSITION_NONE is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRANSITION_NONE = undefined;
+	} else {
+		this.TRANSITION_NONE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Android.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Android.prototype.hideSoftKeyboard = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.openPreferences = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Android.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Android.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Android.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Android.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Android.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Android.prototype.createCardView = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var CardView = require('./Android/CardView');
+	return CardView(__SLAG_PROPERTY);
+};
+Android.prototype.createProgressIndicator = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ProgressIndicator = require('./Android/ProgressIndicator');
+	return ProgressIndicator(__SLAG_PROPERTY);
+};
+Android.prototype.createSearchView = function (__SLAG_PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SearchView = require('./Android/SearchView');
+	return SearchView(__SLAG_PROPERTY);
+};
+module.exports = function (properties) {
+	return new Android(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Android/CardView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Android/CardView.js
@@ -1,0 +1,1285 @@
+var crypto = require('crypto');
+function CardView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'cardBackgroundColor',
+			'cardCornerRadius',
+			'cardElevation',
+			'cardMaxElevation',
+			'maxElevation',
+			'cardPreventCornerOverlap',
+			'preventCornerOverlap',
+			'cardUseCompatPadding',
+			'useCompatPadding',
+			'contentPadding',
+			'padding',
+			'contentPaddingBottom',
+			'paddingBottom',
+			'contentPaddingLeft',
+			'paddingLeft',
+			'contentPaddingRight',
+			'paddingRight',
+			'contentPaddingTop',
+			'paddingTop',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Android.CardView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Android.CardView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Android.CardView.children is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Android.CardView.rect is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Android.CardView.size is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (__SLAG_PROPERTIES.cardBackgroundColor) {
+		throw new Error('Ti.UI.Android.CardView.cardBackgroundColor was deprecated, since 5.1.2');
+	}
+	if (__SLAG_PROPERTIES.cardCornerRadius) {
+		throw new Error('Ti.UI.Android.CardView.cardCornerRadius was deprecated, since 5.1.2');
+	}
+	if (__SLAG_PROPERTIES.cardElevation) {
+		throw new Error('Ti.UI.Android.CardView.cardElevation was deprecated, since 5.1.2');
+	}
+	if (__SLAG_PROPERTIES.cardMaxElevation) {
+		throw new Error('Ti.UI.Android.CardView.cardMaxElevation was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxElevation = undefined;
+	} else {
+		this.maxElevation = __SLAG_PROPERTIES.maxElevation || 0;
+	}
+	if (__SLAG_PROPERTIES.cardPreventCornerOverlap) {
+		throw new Error('Ti.UI.Android.CardView.cardPreventCornerOverlap was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.preventCornerOverlap = undefined;
+	} else {
+		this.preventCornerOverlap = __SLAG_PROPERTIES.preventCornerOverlap || true;
+	}
+	if (__SLAG_PROPERTIES.cardUseCompatPadding) {
+		throw new Error('Ti.UI.Android.CardView.cardUseCompatPadding was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.useCompatPadding = undefined;
+	} else {
+		this.useCompatPadding = __SLAG_PROPERTIES.useCompatPadding || true;
+	}
+	if (__SLAG_PROPERTIES.contentPadding) {
+		throw new Error('Ti.UI.Android.CardView.contentPadding was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.padding = undefined;
+	} else {
+		this.padding = __SLAG_PROPERTIES.padding || 0;
+	}
+	if (__SLAG_PROPERTIES.contentPaddingBottom) {
+		throw new Error('Ti.UI.Android.CardView.contentPaddingBottom was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paddingBottom = undefined;
+	} else {
+		this.paddingBottom = __SLAG_PROPERTIES.paddingBottom || 0;
+	}
+	if (__SLAG_PROPERTIES.contentPaddingLeft) {
+		throw new Error('Ti.UI.Android.CardView.contentPaddingLeft was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paddingLeft = undefined;
+	} else {
+		this.paddingLeft = __SLAG_PROPERTIES.paddingLeft || 0;
+	}
+	if (__SLAG_PROPERTIES.contentPaddingRight) {
+		throw new Error('Ti.UI.Android.CardView.contentPaddingRight was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paddingRight = undefined;
+	} else {
+		this.paddingRight = __SLAG_PROPERTIES.paddingRight || 0;
+	}
+	if (__SLAG_PROPERTIES.contentPaddingTop) {
+		throw new Error('Ti.UI.Android.CardView.contentPaddingTop was deprecated, since 5.1.2');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paddingTop = undefined;
+	} else {
+		this.paddingTop = __SLAG_PROPERTIES.paddingTop || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+CardView.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+CardView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+CardView.prototype.animate = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Android.CardView.finishLayout was deprecated, since 3.0.0');
+};
+CardView.prototype.hide = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.insertAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+CardView.prototype.removeAllChildren = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.replaceAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.show = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CardView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Android.CardView.startLayout was deprecated, since 3.0.0');
+};
+CardView.prototype.toImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CardView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Android.CardView.updateLayout was deprecated, since 3.0.0');
+};
+CardView.prototype.convertPointToView = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+CardView.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+CardView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+CardView.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+CardView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+CardView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+CardView.prototype.getAccessibilityHidden = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+CardView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+CardView.prototype.getAccessibilityHint = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+CardView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+CardView.prototype.getAccessibilityLabel = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+CardView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+CardView.prototype.getAccessibilityValue = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+CardView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+CardView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+CardView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+CardView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+CardView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+CardView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundGradient = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+CardView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+CardView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundRepeat = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+CardView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundSelectedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+CardView.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+CardView.prototype.getBackgroundSelectedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+CardView.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+CardView.prototype.getBorderColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+CardView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+CardView.prototype.getBorderRadius = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+CardView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+CardView.prototype.getBorderWidth = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+CardView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+CardView.prototype.getBottom = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+CardView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+CardView.prototype.getCenter = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+CardView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+CardView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+CardView.prototype.getChildren = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+CardView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+CardView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+CardView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+CardView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+CardView.prototype.getHeight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+CardView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+CardView.prototype.getLeft = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+CardView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+CardView.prototype.getLayout = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+CardView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+CardView.prototype.getOpacity = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+CardView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+CardView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+CardView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+CardView.prototype.getRight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+CardView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+CardView.prototype.getRect = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+CardView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+CardView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+CardView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+CardView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+CardView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+CardView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+CardView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+CardView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+CardView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+CardView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+CardView.prototype.getSize = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+CardView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+CardView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+CardView.prototype.getTop = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+CardView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+CardView.prototype.getTouchEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+CardView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+CardView.prototype.getTransform = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+CardView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+CardView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+CardView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+CardView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+CardView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+CardView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+CardView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+CardView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+CardView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+CardView.prototype.getVisible = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+CardView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+CardView.prototype.getWidth = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+CardView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+CardView.prototype.getHorizontalWrap = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+CardView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+CardView.prototype.getZIndex = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+CardView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+CardView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+CardView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+CardView.prototype.getCardBackgroundColor = function () {
+	throw new Error('Ti.UI.Android.CardView.getCardBackgroundColor was deprecated, since 5.1.2');
+};
+CardView.prototype.setCardBackgroundColor = function () {
+	throw new Error('Ti.UI.Android.CardView.setCardBackgroundColor was deprecated, since 5.1.2');
+};
+CardView.prototype.getCardCornerRadius = function () {
+	throw new Error('Ti.UI.Android.CardView.getCardCornerRadius was deprecated, since 5.1.2');
+};
+CardView.prototype.setCardCornerRadius = function () {
+	throw new Error('Ti.UI.Android.CardView.setCardCornerRadius was deprecated, since 5.1.2');
+};
+CardView.prototype.getCardElevation = function () {
+	throw new Error('Ti.UI.Android.CardView.getCardElevation was deprecated, since 5.1.2');
+};
+CardView.prototype.setCardElevation = function () {
+	throw new Error('Ti.UI.Android.CardView.setCardElevation was deprecated, since 5.1.2');
+};
+CardView.prototype.getCardMaxElevation = function () {
+	throw new Error('Ti.UI.Android.CardView.getCardMaxElevation was deprecated, since 5.1.2');
+};
+CardView.prototype.setCardMaxElevation = function () {
+	throw new Error('Ti.UI.Android.CardView.setCardMaxElevation was deprecated, since 5.1.2');
+};
+CardView.prototype.getMaxElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxElevation;
+};
+CardView.prototype.setMaxElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxElevation = __SLAG__PROPERTY;
+};
+CardView.prototype.getCardPreventCornerOverlap = function () {
+	throw new Error('Ti.UI.Android.CardView.getCardPreventCornerOverlap was deprecated, since 5.1.2');
+};
+CardView.prototype.setCardPreventCornerOverlap = function () {
+	throw new Error('Ti.UI.Android.CardView.setCardPreventCornerOverlap was deprecated, since 5.1.2');
+};
+CardView.prototype.getPreventCornerOverlap = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.preventCornerOverlap;
+};
+CardView.prototype.setPreventCornerOverlap = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.preventCornerOverlap = __SLAG__PROPERTY;
+};
+CardView.prototype.getCardUseCompatPadding = function () {
+	throw new Error('Ti.UI.Android.CardView.getCardUseCompatPadding was deprecated, since 5.1.2');
+};
+CardView.prototype.setCardUseCompatPadding = function () {
+	throw new Error('Ti.UI.Android.CardView.setCardUseCompatPadding was deprecated, since 5.1.2');
+};
+CardView.prototype.getUseCompatPadding = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.useCompatPadding;
+};
+CardView.prototype.setUseCompatPadding = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.useCompatPadding = __SLAG__PROPERTY;
+};
+CardView.prototype.getContentPadding = function () {
+	throw new Error('Ti.UI.Android.CardView.getContentPadding was deprecated, since 5.1.2');
+};
+CardView.prototype.setContentPadding = function () {
+	throw new Error('Ti.UI.Android.CardView.setContentPadding was deprecated, since 5.1.2');
+};
+CardView.prototype.getPadding = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.padding;
+};
+CardView.prototype.setPadding = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.padding = __SLAG__PROPERTY;
+};
+CardView.prototype.getContentPaddingBottom = function () {
+	throw new Error('Ti.UI.Android.CardView.getContentPaddingBottom was deprecated, since 5.1.2');
+};
+CardView.prototype.setContentPaddingBottom = function () {
+	throw new Error('Ti.UI.Android.CardView.setContentPaddingBottom was deprecated, since 5.1.2');
+};
+CardView.prototype.getPaddingBottom = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paddingBottom;
+};
+CardView.prototype.setPaddingBottom = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.paddingBottom = __SLAG__PROPERTY;
+};
+CardView.prototype.getContentPaddingLeft = function () {
+	throw new Error('Ti.UI.Android.CardView.getContentPaddingLeft was deprecated, since 5.1.2');
+};
+CardView.prototype.setContentPaddingLeft = function () {
+	throw new Error('Ti.UI.Android.CardView.setContentPaddingLeft was deprecated, since 5.1.2');
+};
+CardView.prototype.getPaddingLeft = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paddingLeft;
+};
+CardView.prototype.setPaddingLeft = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.paddingLeft = __SLAG__PROPERTY;
+};
+CardView.prototype.getContentPaddingRight = function () {
+	throw new Error('Ti.UI.Android.CardView.getContentPaddingRight was deprecated, since 5.1.2');
+};
+CardView.prototype.setContentPaddingRight = function () {
+	throw new Error('Ti.UI.Android.CardView.setContentPaddingRight was deprecated, since 5.1.2');
+};
+CardView.prototype.getPaddingRight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paddingRight;
+};
+CardView.prototype.setPaddingRight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.paddingRight = __SLAG__PROPERTY;
+};
+CardView.prototype.getContentPaddingTop = function () {
+	throw new Error('Ti.UI.Android.CardView.getContentPaddingTop was deprecated, since 5.1.2');
+};
+CardView.prototype.setContentPaddingTop = function () {
+	throw new Error('Ti.UI.Android.CardView.setContentPaddingTop was deprecated, since 5.1.2');
+};
+CardView.prototype.getPaddingTop = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paddingTop;
+};
+CardView.prototype.setPaddingTop = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.paddingTop = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new CardView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Android/ProgressIndicator.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Android/ProgressIndicator.js
@@ -1,0 +1,446 @@
+var crypto = require('crypto');
+function ProgressIndicator(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'elevation',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'cancelable',
+			'canceledOnTouchOutside',
+			'message',
+			'messageid',
+			'min',
+			'max',
+			'location',
+			'type',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Android.ProgressIndicator.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Android.ProgressIndicator';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancelable = undefined;
+	} else {
+		this.cancelable = __SLAG_PROPERTIES.cancelable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canceledOnTouchOutside = undefined;
+	} else {
+		this.canceledOnTouchOutside = __SLAG_PROPERTIES.canceledOnTouchOutside || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.messageid = undefined;
+	} else {
+		this.messageid = __SLAG_PROPERTIES.messageid || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.min = undefined;
+	} else {
+		this.min = __SLAG_PROPERTIES.min || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.max = undefined;
+	} else {
+		this.max = __SLAG_PROPERTIES.max || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.location = undefined;
+	} else {
+		this.location = __SLAG_PROPERTIES.location || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ProgressIndicator.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressIndicator.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressIndicator.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressIndicator.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ProgressIndicator.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Android.ProgressIndicator.finishLayout was deprecated, since 3.0.0');
+};
+ProgressIndicator.prototype.hide = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressIndicator.prototype.insertAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressIndicator.prototype.replaceAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressIndicator.prototype.show = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressIndicator.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Android.ProgressIndicator.startLayout was deprecated, since 3.0.0');
+};
+ProgressIndicator.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Android.ProgressIndicator.updateLayout was deprecated, since 3.0.0');
+};
+ProgressIndicator.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ProgressIndicator.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ProgressIndicator.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ProgressIndicator.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+ProgressIndicator.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+ProgressIndicator.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+ProgressIndicator.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+ProgressIndicator.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+ProgressIndicator.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+ProgressIndicator.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+ProgressIndicator.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+ProgressIndicator.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+ProgressIndicator.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+ProgressIndicator.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getCancelable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cancelable;
+};
+ProgressIndicator.prototype.setCancelable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cancelable = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getCanceledOnTouchOutside = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.canceledOnTouchOutside;
+};
+ProgressIndicator.prototype.setCanceledOnTouchOutside = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.canceledOnTouchOutside = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getMessage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.message;
+};
+ProgressIndicator.prototype.setMessage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.message = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getMessageid = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.messageid;
+};
+ProgressIndicator.prototype.setMessageid = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.messageid = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getMin = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.min;
+};
+ProgressIndicator.prototype.setMin = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.min = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getMax = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.max;
+};
+ProgressIndicator.prototype.setMax = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.max = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getLocation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.location;
+};
+ProgressIndicator.prototype.setLocation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.location = __SLAG__PROPERTY;
+};
+ProgressIndicator.prototype.getType = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+ProgressIndicator.prototype.setType = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.type = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ProgressIndicator(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Android/SearchView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Android/SearchView.js
@@ -1,0 +1,1145 @@
+var crypto = require('crypto');
+function SearchView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'color',
+			'hintText',
+			'value',
+			'iconified',
+			'iconifiedByDefault',
+			'submitEnabled',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Android.SearchView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Android.SearchView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Android.SearchView.children is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Android.SearchView.rect is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Android.SearchView.size is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hintText = undefined;
+	} else {
+		this.hintText = __SLAG_PROPERTIES.hintText || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.iconified = undefined;
+	} else {
+		this.iconified = __SLAG_PROPERTIES.iconified || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.iconifiedByDefault = undefined;
+	} else {
+		this.iconifiedByDefault = __SLAG_PROPERTIES.iconifiedByDefault || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.submitEnabled = undefined;
+	} else {
+		this.submitEnabled = __SLAG_PROPERTIES.submitEnabled || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SearchView.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SearchView.prototype.animate = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Android.SearchView.finishLayout was deprecated, since 3.0.0');
+};
+SearchView.prototype.hide = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.insertAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+SearchView.prototype.removeAllChildren = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.replaceAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.show = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Android.SearchView.startLayout was deprecated, since 3.0.0');
+};
+SearchView.prototype.toImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+SearchView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Android.SearchView.updateLayout was deprecated, since 3.0.0');
+};
+SearchView.prototype.convertPointToView = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+SearchView.prototype.blur = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.focus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchView.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SearchView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SearchView.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SearchView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+SearchView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+SearchView.prototype.getAccessibilityHidden = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+SearchView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+SearchView.prototype.getAccessibilityHint = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+SearchView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+SearchView.prototype.getAccessibilityLabel = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+SearchView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+SearchView.prototype.getAccessibilityValue = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+SearchView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+SearchView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+SearchView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+SearchView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+SearchView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+SearchView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundGradient = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+SearchView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+SearchView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundRepeat = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+SearchView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundSelectedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+SearchView.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBackgroundSelectedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+SearchView.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBorderColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+SearchView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBorderRadius = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+SearchView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBorderWidth = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+SearchView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+SearchView.prototype.getBottom = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+SearchView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+SearchView.prototype.getCenter = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+SearchView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+SearchView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+SearchView.prototype.getChildren = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+SearchView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+SearchView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+SearchView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+SearchView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+SearchView.prototype.getHeight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+SearchView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+SearchView.prototype.getLeft = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+SearchView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+SearchView.prototype.getLayout = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+SearchView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+SearchView.prototype.getOpacity = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+SearchView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+SearchView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+SearchView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+SearchView.prototype.getRight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+SearchView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+SearchView.prototype.getRect = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+SearchView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+SearchView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+SearchView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+SearchView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+SearchView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+SearchView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+SearchView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+SearchView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+SearchView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+SearchView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+SearchView.prototype.getSize = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+SearchView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+SearchView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+SearchView.prototype.getTop = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+SearchView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+SearchView.prototype.getTouchEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+SearchView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+SearchView.prototype.getTransform = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+SearchView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+SearchView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+SearchView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+SearchView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+SearchView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+SearchView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+SearchView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+SearchView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+SearchView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+SearchView.prototype.getVisible = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+SearchView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+SearchView.prototype.getWidth = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+SearchView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+SearchView.prototype.getHorizontalWrap = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+SearchView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+SearchView.prototype.getZIndex = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+SearchView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+SearchView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+SearchView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+SearchView.prototype.getColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+SearchView.prototype.setColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+SearchView.prototype.getHintText = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hintText;
+};
+SearchView.prototype.setHintText = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hintText = __SLAG__PROPERTY;
+};
+SearchView.prototype.getValue = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+SearchView.prototype.setValue = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+SearchView.prototype.getIconified = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.iconified;
+};
+SearchView.prototype.setIconified = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.iconified = __SLAG__PROPERTY;
+};
+SearchView.prototype.getIconifiedByDefault = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.iconifiedByDefault;
+};
+SearchView.prototype.setIconifiedByDefault = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.iconifiedByDefault = __SLAG__PROPERTY;
+};
+SearchView.prototype.getSubmitEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.submitEnabled;
+};
+SearchView.prototype.setSubmitEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.submitEnabled = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SearchView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Animation.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Animation.js
@@ -1,0 +1,721 @@
+var crypto = require('crypto');
+function Animation(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'anchorPoint',
+			'autoreverse',
+			'backgroundColor',
+			'bottom',
+			'center',
+			'color',
+			'curve',
+			'delay',
+			'duration',
+			'height',
+			'left',
+			'opacity',
+			'opaque',
+			'repeat',
+			'right',
+			'top',
+			'transform',
+			'transition',
+			'view',
+			'visible',
+			'width',
+			'zIndex',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Animation.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Animation';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoreverse = undefined;
+	} else {
+		this.autoreverse = __SLAG_PROPERTIES.autoreverse || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.curve = undefined;
+	} else {
+		this.curve = __SLAG_PROPERTIES.curve || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.delay = undefined;
+	} else {
+		this.delay = __SLAG_PROPERTIES.delay || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opaque = undefined;
+	} else {
+		this.opaque = __SLAG_PROPERTIES.opaque || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.repeat = undefined;
+	} else {
+		this.repeat = __SLAG_PROPERTIES.repeat || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transition = undefined;
+	} else {
+		this.transition = __SLAG_PROPERTIES.transition || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.view = undefined;
+	} else {
+		this.view = __SLAG_PROPERTIES.view || {};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Animation.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animation.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animation.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animation.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Animation.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Animation.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Animation.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Animation.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Animation.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Animation.prototype.getAnchorPoint = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Animation.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Animation.prototype.getAutoreverse = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoreverse;
+};
+Animation.prototype.setAutoreverse = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoreverse = __SLAG__PROPERTY;
+};
+Animation.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Animation.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Animation.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Animation.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Animation.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Animation.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Animation.prototype.getColor = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+Animation.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+Animation.prototype.getCurve = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.curve;
+};
+Animation.prototype.setCurve = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.curve = __SLAG__PROPERTY;
+};
+Animation.prototype.getDelay = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.delay;
+};
+Animation.prototype.setDelay = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.delay = __SLAG__PROPERTY;
+};
+Animation.prototype.getDuration = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.duration;
+};
+Animation.prototype.setDuration = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.duration = __SLAG__PROPERTY;
+};
+Animation.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Animation.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Animation.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Animation.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Animation.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Animation.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Animation.prototype.getOpaque = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opaque;
+};
+Animation.prototype.setOpaque = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opaque = __SLAG__PROPERTY;
+};
+Animation.prototype.getRepeat = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.repeat;
+};
+Animation.prototype.setRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.repeat = __SLAG__PROPERTY;
+};
+Animation.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Animation.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Animation.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Animation.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Animation.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Animation.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Animation.prototype.getTransition = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transition;
+};
+Animation.prototype.setTransition = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transition = __SLAG__PROPERTY;
+};
+Animation.prototype.getView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.view;
+};
+Animation.prototype.setView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.view = __SLAG__PROPERTY;
+};
+Animation.prototype.getVisible = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Animation.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Animation.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Animation.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Animation.prototype.getZIndex = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Animation.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Animation(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/AttributedString.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/AttributedString.js
@@ -1,0 +1,176 @@
+var crypto = require('crypto');
+function AttributedString(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'text',
+			'attributes',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.AttributedString.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.AttributedString';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.text = undefined;
+	} else {
+		this.text = __SLAG_PROPERTIES.text || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = __SLAG_PROPERTIES.attributes || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AttributedString.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AttributedString.prototype.addAttribute = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AttributedString.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AttributedString.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+AttributedString.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+AttributedString.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+AttributedString.prototype.getText = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.text;
+};
+AttributedString.prototype.setText = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.text = __SLAG__PROPERTY;
+};
+AttributedString.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+AttributedString.prototype.setAttributes = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.attributes = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new AttributedString(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Button.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Button.js
@@ -1,0 +1,2051 @@
+var crypto = require('crypto');
+function Button(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'color',
+			'disabledColor',
+			'enabled',
+			'font',
+			'image',
+			'selectedColor',
+			'shadowColor',
+			'shadowOffset',
+			'shadowRadius',
+			'style',
+			'systemButton',
+			'textAlign',
+			'title',
+			'titleid',
+			'verticalAlign',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Button.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Button';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.Button.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Button.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Button.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Button.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disabledColor = undefined;
+	} else {
+		this.disabledColor = __SLAG_PROPERTIES.disabledColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enabled = undefined;
+	} else {
+		this.enabled = __SLAG_PROPERTIES.enabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedColor = undefined;
+	} else {
+		this.selectedColor = __SLAG_PROPERTIES.selectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowColor = undefined;
+	} else {
+		this.shadowColor = __SLAG_PROPERTIES.shadowColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowOffset = undefined;
+	} else {
+		this.shadowOffset = __SLAG_PROPERTIES.shadowOffset || {};
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowRadius = undefined;
+	} else {
+		this.shadowRadius = __SLAG_PROPERTIES.shadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.systemButton = undefined;
+	} else {
+		this.systemButton = __SLAG_PROPERTIES.systemButton || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textAlign = undefined;
+	} else {
+		this.textAlign = __SLAG_PROPERTIES.textAlign || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.verticalAlign = undefined;
+	} else {
+		this.verticalAlign = __SLAG_PROPERTIES.verticalAlign || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Button.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Button.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Button.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Button.finishLayout was deprecated, since 3.0.0');
+};
+Button.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Button.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Button.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Button.startLayout was deprecated, since 3.0.0');
+};
+Button.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Button.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Button.updateLayout was deprecated, since 3.0.0');
+};
+Button.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Button.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Button.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Button.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Button.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Button.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Button.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Button.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Button.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Button.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Button.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Button.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Button.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Button.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Button.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Button.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Button.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Button.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Button.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+Button.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundDisabledImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+Button.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+Button.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundFocusedImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+Button.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Button.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Button.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+Button.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+Button.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+Button.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+Button.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+Button.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+Button.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+Button.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Button.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Button.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Button.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Button.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Button.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Button.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Button.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Button.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Button.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Button.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Button.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Button.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Button.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Button.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Button.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Button.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+Button.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+Button.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Button.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Button.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Button.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Button.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+Button.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+Button.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Button.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Button.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Button.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Button.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Button.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Button.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Button.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Button.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Button.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Button.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Button.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Button.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Button.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Button.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Button.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Button.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Button.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Button.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Button.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Button.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Button.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Button.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+Button.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+Button.prototype.getTintColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Button.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Button.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Button.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Button.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Button.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Button.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Button.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Button.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Button.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Button.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Button.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Button.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Button.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Button.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Button.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Button.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Button.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Button.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Button.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Button.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Button.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Button.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Button.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Button.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Button.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Button.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Button.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Button.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Button.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Button.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+Button.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+Button.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+Button.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+Button.prototype.getDisabledColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disabledColor;
+};
+Button.prototype.setDisabledColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disabledColor = __SLAG__PROPERTY;
+};
+Button.prototype.getEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enabled;
+};
+Button.prototype.setEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enabled = __SLAG__PROPERTY;
+};
+Button.prototype.getFont = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+Button.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+Button.prototype.getImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.image;
+};
+Button.prototype.setImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.image = __SLAG__PROPERTY;
+};
+Button.prototype.getSelectedColor = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedColor;
+};
+Button.prototype.setSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedColor = __SLAG__PROPERTY;
+};
+Button.prototype.getShadowColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowColor;
+};
+Button.prototype.setShadowColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowColor = __SLAG__PROPERTY;
+};
+Button.prototype.getShadowOffset = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowOffset;
+};
+Button.prototype.setShadowOffset = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowOffset = __SLAG__PROPERTY;
+};
+Button.prototype.getShadowRadius = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowRadius;
+};
+Button.prototype.setShadowRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowRadius = __SLAG__PROPERTY;
+};
+Button.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+Button.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+Button.prototype.getSystemButton = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.systemButton;
+};
+Button.prototype.setSystemButton = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.systemButton = __SLAG__PROPERTY;
+};
+Button.prototype.getTextAlign = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textAlign;
+};
+Button.prototype.setTextAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.textAlign = __SLAG__PROPERTY;
+};
+Button.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+Button.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+Button.prototype.getTitleid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+Button.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+Button.prototype.getVerticalAlign = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.verticalAlign;
+};
+Button.prototype.setVerticalAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.verticalAlign = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Button(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ButtonBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ButtonBar.js
@@ -1,0 +1,903 @@
+var crypto = require('crypto');
+function ButtonBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'index',
+			'labels',
+			'style',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ButtonBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ButtonBar';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.ButtonBar.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.ButtonBar.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.ButtonBar.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.ButtonBar.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.index = undefined;
+	} else {
+		this.index = __SLAG_PROPERTIES.index || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.labels = undefined;
+	} else {
+		this.labels = __SLAG_PROPERTIES.labels || '';
+	}
+	if (__SLAG_PROPERTIES.style) {
+		throw new Error('Ti.UI.ButtonBar.style was deprecated, since 3.4.1');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ButtonBar.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ButtonBar.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+ButtonBar.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.ButtonBar.finishLayout was deprecated, since 3.0.0');
+};
+ButtonBar.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+ButtonBar.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ButtonBar.prototype.startLayout = function () {
+	throw new Error('Ti.UI.ButtonBar.startLayout was deprecated, since 3.0.0');
+};
+ButtonBar.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ButtonBar.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.ButtonBar.updateLayout was deprecated, since 3.0.0');
+};
+ButtonBar.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+ButtonBar.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ButtonBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ButtonBar.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+ButtonBar.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+ButtonBar.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+ButtonBar.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+ButtonBar.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+ButtonBar.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+ButtonBar.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+ButtonBar.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+ButtonBar.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+ButtonBar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+ButtonBar.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+ButtonBar.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+ButtonBar.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+ButtonBar.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+ButtonBar.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+ButtonBar.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+ButtonBar.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+ButtonBar.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+ButtonBar.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+ButtonBar.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+ButtonBar.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+ButtonBar.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+ButtonBar.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+ButtonBar.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+ButtonBar.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+ButtonBar.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+ButtonBar.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+ButtonBar.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+ButtonBar.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+ButtonBar.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+ButtonBar.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+ButtonBar.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+ButtonBar.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+ButtonBar.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+ButtonBar.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+ButtonBar.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+ButtonBar.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+ButtonBar.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+ButtonBar.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+ButtonBar.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+ButtonBar.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.index;
+};
+ButtonBar.prototype.setIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.index = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getLabels = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.labels;
+};
+ButtonBar.prototype.setLabels = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.labels = __SLAG__PROPERTY;
+};
+ButtonBar.prototype.getStyle = function () {
+	throw new Error('Ti.UI.ButtonBar.getStyle was deprecated, since 3.4.1');
+};
+ButtonBar.prototype.setStyle = function () {
+	throw new Error('Ti.UI.ButtonBar.setStyle was deprecated, since 3.4.1');
+};
+module.exports = function (properties) {
+	return new ButtonBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Clipboard.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Clipboard.js
@@ -1,0 +1,223 @@
+var crypto = require('crypto');
+function Clipboard(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Clipboard.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Clipboard';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Clipboard.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Clipboard.prototype.clearData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.clearText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Clipboard.prototype.getText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Clipboard.prototype.hasData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Clipboard.prototype.hasText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Clipboard.prototype.hasURLs = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Clipboard.prototype.hasImages = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Clipboard.prototype.hasColors = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Clipboard.prototype.setData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.setText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.setItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Clipboard.prototype.getItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+Clipboard.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Clipboard.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Clipboard.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Clipboard.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Clipboard.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Clipboard(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/CoverFlowView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/CoverFlowView.js
@@ -1,0 +1,898 @@
+var crypto = require('crypto');
+function CoverFlowView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'images',
+			'selected',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.CoverFlowView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.CoverFlowView';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.CoverFlowView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.CoverFlowView.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.CoverFlowView.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.CoverFlowView.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.images = undefined;
+	} else {
+		this.images = __SLAG_PROPERTIES.images || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selected = undefined;
+	} else {
+		this.selected = __SLAG_PROPERTIES.selected || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+CoverFlowView.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+CoverFlowView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+CoverFlowView.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.CoverFlowView.finishLayout was deprecated, since 3.0.0');
+};
+CoverFlowView.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+CoverFlowView.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.CoverFlowView.startLayout was deprecated, since 3.0.0');
+};
+CoverFlowView.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CoverFlowView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.CoverFlowView.updateLayout was deprecated, since 3.0.0');
+};
+CoverFlowView.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+CoverFlowView.prototype.setImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+CoverFlowView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+CoverFlowView.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+CoverFlowView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+CoverFlowView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+CoverFlowView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+CoverFlowView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+CoverFlowView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+CoverFlowView.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+CoverFlowView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+CoverFlowView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+CoverFlowView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+CoverFlowView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+CoverFlowView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+CoverFlowView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+CoverFlowView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+CoverFlowView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+CoverFlowView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+CoverFlowView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+CoverFlowView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+CoverFlowView.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+CoverFlowView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+CoverFlowView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+CoverFlowView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+CoverFlowView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+CoverFlowView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+CoverFlowView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+CoverFlowView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+CoverFlowView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+CoverFlowView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+CoverFlowView.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+CoverFlowView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+CoverFlowView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+CoverFlowView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+CoverFlowView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+CoverFlowView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+CoverFlowView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+CoverFlowView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+CoverFlowView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+CoverFlowView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+CoverFlowView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+CoverFlowView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+CoverFlowView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getImages = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.images;
+};
+CoverFlowView.prototype.setImages = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.images = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getSelected = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selected;
+};
+CoverFlowView.prototype.setSelected = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selected = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new CoverFlowView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/DashboardItem.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/DashboardItem.js
@@ -1,0 +1,147 @@
+var crypto = require('crypto');
+function DashboardItem(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'badge',
+			'canDelete',
+			'image',
+			'selectedImage',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.DashboardItem.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.DashboardItem';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.badge = undefined;
+	} else {
+		this.badge = __SLAG_PROPERTIES.badge || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canDelete = undefined;
+	} else {
+		this.canDelete = __SLAG_PROPERTIES.canDelete || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedImage = undefined;
+	} else {
+		this.selectedImage = __SLAG_PROPERTIES.selectedImage || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DashboardItem.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardItem.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardItem.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardItem.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DashboardItem.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DashboardItem.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DashboardItem.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DashboardItem.prototype.getBadge = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.badge;
+};
+DashboardItem.prototype.setBadge = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.badge = __SLAG__PROPERTY;
+};
+DashboardItem.prototype.getCanDelete = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.canDelete;
+};
+DashboardItem.prototype.setCanDelete = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.canDelete = __SLAG__PROPERTY;
+};
+DashboardItem.prototype.getImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.image;
+};
+DashboardItem.prototype.setImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.image = __SLAG__PROPERTY;
+};
+DashboardItem.prototype.getSelectedImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedImage;
+};
+DashboardItem.prototype.setSelectedImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedImage = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DashboardItem(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/DashboardView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/DashboardView.js
@@ -1,0 +1,957 @@
+var crypto = require('crypto');
+function DashboardView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'columnCount',
+			'rowCount',
+			'data',
+			'editable',
+			'wobble',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.DashboardView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.DashboardView';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.DashboardView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.DashboardView.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.DashboardView.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.DashboardView.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.columnCount = undefined;
+	} else {
+		this.columnCount = __SLAG_PROPERTIES.columnCount || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowCount = undefined;
+	} else {
+		this.rowCount = __SLAG_PROPERTIES.rowCount || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editable = undefined;
+	} else {
+		this.editable = __SLAG_PROPERTIES.editable || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.wobble = undefined;
+	} else {
+		this.wobble = __SLAG_PROPERTIES.wobble || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DashboardView.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DashboardView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+DashboardView.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.DashboardView.finishLayout was deprecated, since 3.0.0');
+};
+DashboardView.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+DashboardView.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.DashboardView.startLayout was deprecated, since 3.0.0');
+};
+DashboardView.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DashboardView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.DashboardView.updateLayout was deprecated, since 3.0.0');
+};
+DashboardView.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+DashboardView.prototype.startEditing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.stopEditing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DashboardView.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DashboardView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DashboardView.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+DashboardView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+DashboardView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+DashboardView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+DashboardView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+DashboardView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+DashboardView.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+DashboardView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+DashboardView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+DashboardView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+DashboardView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+DashboardView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+DashboardView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+DashboardView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+DashboardView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+DashboardView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+DashboardView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+DashboardView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+DashboardView.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+DashboardView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+DashboardView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+DashboardView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+DashboardView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+DashboardView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+DashboardView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+DashboardView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+DashboardView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+DashboardView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+DashboardView.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+DashboardView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+DashboardView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+DashboardView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+DashboardView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+DashboardView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+DashboardView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+DashboardView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+DashboardView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+DashboardView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+DashboardView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+DashboardView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+DashboardView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getColumnCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.columnCount;
+};
+DashboardView.prototype.setColumnCount = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.columnCount = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getRowCount = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowCount;
+};
+DashboardView.prototype.setRowCount = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rowCount = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getData = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+DashboardView.prototype.setData = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getEditable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editable;
+};
+DashboardView.prototype.setEditable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editable = __SLAG__PROPERTY;
+};
+DashboardView.prototype.getWobble = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.wobble;
+};
+DashboardView.prototype.setWobble = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.wobble = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DashboardView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/EmailDialog.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/EmailDialog.js
@@ -1,0 +1,632 @@
+var crypto = require('crypto');
+function EmailDialog(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'elevation',
+			'previewContext',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'CANCELLED',
+			'FAILED',
+			'SAVED',
+			'SENT',
+			'barColor',
+			'bccRecipients',
+			'ccRecipients',
+			'html',
+			'messageBody',
+			'subject',
+			'toRecipients',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.EmailDialog.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.EmailDialog';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (__SLAG_PROPERTIES.CANCELLED) {
+		throw new Error('Ti.UI.EmailDialog.CANCELLED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CANCELLED = undefined;
+	} else {
+		this.CANCELLED = 0;
+	}
+	if (__SLAG_PROPERTIES.FAILED) {
+		throw new Error('Ti.UI.EmailDialog.FAILED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FAILED = undefined;
+	} else {
+		this.FAILED = 0;
+	}
+	if (__SLAG_PROPERTIES.SAVED) {
+		throw new Error('Ti.UI.EmailDialog.SAVED is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SAVED = undefined;
+	} else {
+		this.SAVED = 0;
+	}
+	if (__SLAG_PROPERTIES.SENT) {
+		throw new Error('Ti.UI.EmailDialog.SENT is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SENT = undefined;
+	} else {
+		this.SENT = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bccRecipients = undefined;
+	} else {
+		this.bccRecipients = __SLAG_PROPERTIES.bccRecipients || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ccRecipients = undefined;
+	} else {
+		this.ccRecipients = __SLAG_PROPERTIES.ccRecipients || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.html = undefined;
+	} else {
+		this.html = __SLAG_PROPERTIES.html || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.messageBody = undefined;
+	} else {
+		this.messageBody = __SLAG_PROPERTIES.messageBody || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subject = undefined;
+	} else {
+		this.subject = __SLAG_PROPERTIES.subject || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.toRecipients = undefined;
+	} else {
+		this.toRecipients = __SLAG_PROPERTIES.toRecipients || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+EmailDialog.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+EmailDialog.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.EmailDialog.finishLayout was deprecated, since 3.0.0');
+};
+EmailDialog.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.startLayout = function () {
+	throw new Error('Ti.UI.EmailDialog.startLayout was deprecated, since 3.0.0');
+};
+EmailDialog.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.EmailDialog.updateLayout was deprecated, since 3.0.0');
+};
+EmailDialog.prototype.addAttachment = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+EmailDialog.prototype.open = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EmailDialog.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+EmailDialog.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+EmailDialog.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+EmailDialog.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+EmailDialog.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+EmailDialog.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+EmailDialog.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+EmailDialog.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+EmailDialog.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+EmailDialog.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+EmailDialog.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+EmailDialog.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+EmailDialog.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+EmailDialog.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+EmailDialog.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getBarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+EmailDialog.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getBccRecipients = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bccRecipients;
+};
+EmailDialog.prototype.setBccRecipients = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bccRecipients = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getCcRecipients = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ccRecipients;
+};
+EmailDialog.prototype.setCcRecipients = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ccRecipients = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getHtml = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.html;
+};
+EmailDialog.prototype.setHtml = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.html = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getMessageBody = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.messageBody;
+};
+EmailDialog.prototype.setMessageBody = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.messageBody = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getSubject = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.subject;
+};
+EmailDialog.prototype.setSubject = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.subject = __SLAG__PROPERTY;
+};
+EmailDialog.prototype.getToRecipients = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.toRecipients;
+};
+EmailDialog.prototype.setToRecipients = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.toRecipients = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new EmailDialog(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ImageView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ImageView.js
@@ -1,0 +1,2005 @@
+var crypto = require('crypto');
+function ImageView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'animating',
+			'autorotate',
+			'decodeRetries',
+			'defaultImage',
+			'duration',
+			'enableZoomControls',
+			'hires',
+			'image',
+			'images',
+			'paused',
+			'preventDefaultImage',
+			'repeatCount',
+			'reverse',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ImageView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ImageView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.ImageView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.ImageView.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.ImageView.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.ImageView.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (__SLAG_PROPERTIES.animating) {
+		throw new Error('Ti.UI.ImageView.animating is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animating = undefined;
+	} else {
+		this.animating = true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autorotate = undefined;
+	} else {
+		this.autorotate = __SLAG_PROPERTIES.autorotate || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.decodeRetries = undefined;
+	} else {
+		this.decodeRetries = __SLAG_PROPERTIES.decodeRetries || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.defaultImage = undefined;
+	} else {
+		this.defaultImage = __SLAG_PROPERTIES.defaultImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enableZoomControls = undefined;
+	} else {
+		this.enableZoomControls = __SLAG_PROPERTIES.enableZoomControls || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hires = undefined;
+	} else {
+		this.hires = __SLAG_PROPERTIES.hires || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.images = undefined;
+	} else {
+		this.images = __SLAG_PROPERTIES.images || '';
+	}
+	if (__SLAG_PROPERTIES.paused) {
+		throw new Error('Ti.UI.ImageView.paused is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.paused = undefined;
+	} else {
+		this.paused = true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.preventDefaultImage = undefined;
+	} else {
+		this.preventDefaultImage = __SLAG_PROPERTIES.preventDefaultImage || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.repeatCount = undefined;
+	} else {
+		this.repeatCount = __SLAG_PROPERTIES.repeatCount || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.reverse = undefined;
+	} else {
+		this.reverse = __SLAG_PROPERTIES.reverse || true;
+	}
+	if (__SLAG_PROPERTIES.url) {
+		throw new Error('Ti.UI.ImageView.url was deprecated, since 1.5.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ImageView.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ImageView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+ImageView.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.ImageView.finishLayout was deprecated, since 3.0.0');
+};
+ImageView.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+ImageView.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.ImageView.startLayout was deprecated, since 3.0.0');
+};
+ImageView.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ImageView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.ImageView.updateLayout was deprecated, since 3.0.0');
+};
+ImageView.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+ImageView.prototype.pause = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.resume = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.start = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.stop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ImageView.prototype.toBlob = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ImageView.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ImageView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ImageView.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ImageView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ImageView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ImageView.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+ImageView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+ImageView.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+ImageView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+ImageView.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+ImageView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+ImageView.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+ImageView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+ImageView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+ImageView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+ImageView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+ImageView.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+ImageView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+ImageView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+ImageView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+ImageView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+ImageView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+ImageView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+ImageView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+ImageView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+ImageView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+ImageView.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+ImageView.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+ImageView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+ImageView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+ImageView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+ImageView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+ImageView.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+ImageView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+ImageView.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+ImageView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+ImageView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+ImageView.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+ImageView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+ImageView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+ImageView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+ImageView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+ImageView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+ImageView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+ImageView.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+ImageView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+ImageView.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+ImageView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+ImageView.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+ImageView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+ImageView.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+ImageView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+ImageView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+ImageView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+ImageView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+ImageView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+ImageView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+ImageView.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+ImageView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+ImageView.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+ImageView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+ImageView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+ImageView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+ImageView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+ImageView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+ImageView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+ImageView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+ImageView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+ImageView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+ImageView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+ImageView.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+ImageView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+ImageView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTintColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+ImageView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+ImageView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+ImageView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+ImageView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+ImageView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+ImageView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+ImageView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+ImageView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+ImageView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+ImageView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+ImageView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+ImageView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+ImageView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+ImageView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+ImageView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+ImageView.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+ImageView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+ImageView.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+ImageView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+ImageView.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+ImageView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+ImageView.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+ImageView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+ImageView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+ImageView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+ImageView.prototype.getAnimating = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animating;
+};
+ImageView.prototype.getAutorotate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autorotate;
+};
+ImageView.prototype.setAutorotate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autorotate = __SLAG__PROPERTY;
+};
+ImageView.prototype.getDecodeRetries = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.decodeRetries;
+};
+ImageView.prototype.setDecodeRetries = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.decodeRetries = __SLAG__PROPERTY;
+};
+ImageView.prototype.getDefaultImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.defaultImage;
+};
+ImageView.prototype.setDefaultImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.defaultImage = __SLAG__PROPERTY;
+};
+ImageView.prototype.getDuration = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.duration;
+};
+ImageView.prototype.setDuration = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.duration = __SLAG__PROPERTY;
+};
+ImageView.prototype.getEnableZoomControls = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enableZoomControls;
+};
+ImageView.prototype.setEnableZoomControls = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enableZoomControls = __SLAG__PROPERTY;
+};
+ImageView.prototype.getHires = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hires;
+};
+ImageView.prototype.setHires = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hires = __SLAG__PROPERTY;
+};
+ImageView.prototype.getImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.image;
+};
+ImageView.prototype.setImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.image = __SLAG__PROPERTY;
+};
+ImageView.prototype.getImages = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.images;
+};
+ImageView.prototype.setImages = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.images = __SLAG__PROPERTY;
+};
+ImageView.prototype.getPaused = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.paused;
+};
+ImageView.prototype.getPreventDefaultImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.preventDefaultImage;
+};
+ImageView.prototype.setPreventDefaultImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.preventDefaultImage = __SLAG__PROPERTY;
+};
+ImageView.prototype.getRepeatCount = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.repeatCount;
+};
+ImageView.prototype.setRepeatCount = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.repeatCount = __SLAG__PROPERTY;
+};
+ImageView.prototype.getReverse = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.reverse;
+};
+ImageView.prototype.setReverse = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.reverse = __SLAG__PROPERTY;
+};
+ImageView.prototype.getUrl = function () {
+	throw new Error('Ti.UI.ImageView.getUrl was deprecated, since 1.5.0');
+};
+ImageView.prototype.setUrl = function () {
+	throw new Error('Ti.UI.ImageView.setUrl was deprecated, since 1.5.0');
+};
+module.exports = function (properties) {
+	return new ImageView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Label.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Label.js
@@ -1,0 +1,2201 @@
+var crypto = require('crypto');
+function Label(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'attributedString',
+			'autoLink',
+			'backgroundPaddingBottom',
+			'backgroundPaddingLeft',
+			'backgroundPaddingRight',
+			'backgroundPaddingTop',
+			'color',
+			'ellipsize',
+			'font',
+			'highlightedColor',
+			'html',
+			'includeFontPadding',
+			'lines',
+			'lineSpacing',
+			'maxLines',
+			'minimumFontSize',
+			'shadowColor',
+			'shadowOffset',
+			'shadowRadius',
+			'text',
+			'textAlign',
+			'textid',
+			'wordWrap',
+			'verticalAlign',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Label.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Label';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.Label.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Label.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Label.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Label.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributedString = undefined;
+	} else {
+		this.attributedString = __SLAG_PROPERTIES.attributedString || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoLink = undefined;
+	} else {
+		this.autoLink = __SLAG_PROPERTIES.autoLink || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundPaddingBottom = undefined;
+	} else {
+		this.backgroundPaddingBottom = __SLAG_PROPERTIES.backgroundPaddingBottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundPaddingLeft = undefined;
+	} else {
+		this.backgroundPaddingLeft = __SLAG_PROPERTIES.backgroundPaddingLeft || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundPaddingRight = undefined;
+	} else {
+		this.backgroundPaddingRight = __SLAG_PROPERTIES.backgroundPaddingRight || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundPaddingTop = undefined;
+	} else {
+		this.backgroundPaddingTop = __SLAG_PROPERTIES.backgroundPaddingTop || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ellipsize = undefined;
+	} else {
+		this.ellipsize = __SLAG_PROPERTIES.ellipsize || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.highlightedColor = undefined;
+	} else {
+		this.highlightedColor = __SLAG_PROPERTIES.highlightedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.html = undefined;
+	} else {
+		this.html = __SLAG_PROPERTIES.html || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.includeFontPadding = undefined;
+	} else {
+		this.includeFontPadding = __SLAG_PROPERTIES.includeFontPadding || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lines = undefined;
+	} else {
+		this.lines = __SLAG_PROPERTIES.lines || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lineSpacing = undefined;
+	} else {
+		this.lineSpacing = __SLAG_PROPERTIES.lineSpacing || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxLines = undefined;
+	} else {
+		this.maxLines = __SLAG_PROPERTIES.maxLines || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minimumFontSize = undefined;
+	} else {
+		this.minimumFontSize = __SLAG_PROPERTIES.minimumFontSize || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowColor = undefined;
+	} else {
+		this.shadowColor = __SLAG_PROPERTIES.shadowColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowOffset = undefined;
+	} else {
+		this.shadowOffset = __SLAG_PROPERTIES.shadowOffset || {};
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowRadius = undefined;
+	} else {
+		this.shadowRadius = __SLAG_PROPERTIES.shadowRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.text = undefined;
+	} else {
+		this.text = __SLAG_PROPERTIES.text || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textAlign = undefined;
+	} else {
+		this.textAlign = __SLAG_PROPERTIES.textAlign || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textid = undefined;
+	} else {
+		this.textid = __SLAG_PROPERTIES.textid || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.wordWrap = undefined;
+	} else {
+		this.wordWrap = __SLAG_PROPERTIES.wordWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.verticalAlign = undefined;
+	} else {
+		this.verticalAlign = __SLAG_PROPERTIES.verticalAlign || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Label.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Label.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Label.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Label.finishLayout was deprecated, since 3.0.0');
+};
+Label.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Label.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Label.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Label.startLayout was deprecated, since 3.0.0');
+};
+Label.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Label.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Label.updateLayout was deprecated, since 3.0.0');
+};
+Label.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Label.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Label.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Label.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Label.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Label.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Label.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Label.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Label.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Label.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Label.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Label.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Label.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Label.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Label.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Label.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Label.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Label.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Label.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+Label.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+Label.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+Label.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+Label.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Label.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Label.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+Label.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+Label.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+Label.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+Label.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+Label.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+Label.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Label.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Label.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Label.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Label.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Label.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Label.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Label.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Label.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Label.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Label.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Label.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Label.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Label.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Label.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Label.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Label.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+Label.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+Label.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Label.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Label.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Label.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Label.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+Label.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+Label.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Label.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Label.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Label.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Label.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Label.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Label.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Label.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Label.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Label.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Label.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Label.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Label.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Label.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Label.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Label.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Label.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Label.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Label.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Label.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Label.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Label.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Label.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+Label.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+Label.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Label.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Label.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Label.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Label.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Label.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Label.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Label.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Label.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Label.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Label.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Label.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Label.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Label.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Label.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Label.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Label.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Label.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Label.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Label.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Label.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Label.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Label.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Label.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Label.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Label.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Label.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Label.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Label.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Label.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Label.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+Label.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+Label.prototype.getAttributedString = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributedString;
+};
+Label.prototype.setAttributedString = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.attributedString = __SLAG__PROPERTY;
+};
+Label.prototype.getAutoLink = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoLink;
+};
+Label.prototype.setAutoLink = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoLink = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundPaddingBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundPaddingBottom;
+};
+Label.prototype.setBackgroundPaddingBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundPaddingBottom = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundPaddingLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundPaddingLeft;
+};
+Label.prototype.setBackgroundPaddingLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundPaddingLeft = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundPaddingRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundPaddingRight;
+};
+Label.prototype.setBackgroundPaddingRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundPaddingRight = __SLAG__PROPERTY;
+};
+Label.prototype.getBackgroundPaddingTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundPaddingTop;
+};
+Label.prototype.setBackgroundPaddingTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundPaddingTop = __SLAG__PROPERTY;
+};
+Label.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+Label.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+Label.prototype.getEllipsize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ellipsize;
+};
+Label.prototype.setEllipsize = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ellipsize = __SLAG__PROPERTY;
+};
+Label.prototype.getFont = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+Label.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+Label.prototype.getHighlightedColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.highlightedColor;
+};
+Label.prototype.setHighlightedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.highlightedColor = __SLAG__PROPERTY;
+};
+Label.prototype.getHtml = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.html;
+};
+Label.prototype.setHtml = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.html = __SLAG__PROPERTY;
+};
+Label.prototype.getIncludeFontPadding = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.includeFontPadding;
+};
+Label.prototype.setIncludeFontPadding = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.includeFontPadding = __SLAG__PROPERTY;
+};
+Label.prototype.getLines = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lines;
+};
+Label.prototype.setLines = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lines = __SLAG__PROPERTY;
+};
+Label.prototype.getLineSpacing = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lineSpacing;
+};
+Label.prototype.setLineSpacing = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lineSpacing = __SLAG__PROPERTY;
+};
+Label.prototype.getMaxLines = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxLines;
+};
+Label.prototype.setMaxLines = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxLines = __SLAG__PROPERTY;
+};
+Label.prototype.getMinimumFontSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minimumFontSize;
+};
+Label.prototype.setMinimumFontSize = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minimumFontSize = __SLAG__PROPERTY;
+};
+Label.prototype.getShadowColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowColor;
+};
+Label.prototype.setShadowColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowColor = __SLAG__PROPERTY;
+};
+Label.prototype.getShadowOffset = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowOffset;
+};
+Label.prototype.setShadowOffset = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowOffset = __SLAG__PROPERTY;
+};
+Label.prototype.getShadowRadius = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowRadius;
+};
+Label.prototype.setShadowRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowRadius = __SLAG__PROPERTY;
+};
+Label.prototype.getText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.text;
+};
+Label.prototype.setText = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.text = __SLAG__PROPERTY;
+};
+Label.prototype.getTextAlign = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textAlign;
+};
+Label.prototype.setTextAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.textAlign = __SLAG__PROPERTY;
+};
+Label.prototype.getTextid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textid;
+};
+Label.prototype.setTextid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.textid = __SLAG__PROPERTY;
+};
+Label.prototype.getWordWrap = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.wordWrap;
+};
+Label.prototype.setWordWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.wordWrap = __SLAG__PROPERTY;
+};
+Label.prototype.getVerticalAlign = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.verticalAlign;
+};
+Label.prototype.setVerticalAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.verticalAlign = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Label(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ListItem.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ListItem.js
@@ -1,0 +1,247 @@
+var crypto = require('crypto');
+function ListItem(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'lifecycleContainer',
+			'itemId',
+			'accessoryType',
+			'backgroundColor',
+			'backgroundImage',
+			'backgroundGradient',
+			'selectedBackgroundColor',
+			'selectedBackgroundImage',
+			'selectedBackgroundGradient',
+			'canEdit',
+			'canInsert',
+			'canMove',
+			'editActions',
+			'searchableText',
+			'color',
+			'selectedColor',
+			'font',
+			'height',
+			'image',
+			'title',
+			'selectionStyle',
+			'subtitle',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ListItem.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ListItem';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.itemId = undefined;
+	} else {
+		this.itemId = __SLAG_PROPERTIES.itemId || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessoryType = undefined;
+	} else {
+		this.accessoryType = __SLAG_PROPERTIES.accessoryType || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedBackgroundColor = undefined;
+	} else {
+		this.selectedBackgroundColor = __SLAG_PROPERTIES.selectedBackgroundColor || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedBackgroundImage = undefined;
+	} else {
+		this.selectedBackgroundImage = __SLAG_PROPERTIES.selectedBackgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedBackgroundGradient = undefined;
+	} else {
+		this.selectedBackgroundGradient = __SLAG_PROPERTIES.selectedBackgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canEdit = undefined;
+	} else {
+		this.canEdit = __SLAG_PROPERTIES.canEdit || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canInsert = undefined;
+	} else {
+		this.canInsert = __SLAG_PROPERTIES.canInsert || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canMove = undefined;
+	} else {
+		this.canMove = __SLAG_PROPERTIES.canMove || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editActions = undefined;
+	} else {
+		this.editActions = __SLAG_PROPERTIES.editActions || [];
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.searchableText = undefined;
+	} else {
+		this.searchableText = __SLAG_PROPERTIES.searchableText || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedColor = undefined;
+	} else {
+		this.selectedColor = __SLAG_PROPERTIES.selectedColor || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectionStyle = undefined;
+	} else {
+		this.selectionStyle = __SLAG_PROPERTIES.selectionStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.subtitle = undefined;
+	} else {
+		this.subtitle = __SLAG_PROPERTIES.subtitle || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListItem.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ListItem.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ListItem.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ListItem.prototype.getEditActions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editActions;
+};
+ListItem.prototype.setEditActions = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editActions = __SLAG__PROPERTY;
+};
+ListItem.prototype.getSelectedColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedColor;
+};
+ListItem.prototype.setSelectedColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedColor = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ListItem(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ListSection.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ListSection.js
@@ -1,0 +1,247 @@
+var crypto = require('crypto');
+function ListSection(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'lifecycleContainer',
+			'footerTitle',
+			'footerView',
+			'headerTitle',
+			'headerView',
+			'items',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ListSection.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ListSection';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerTitle = undefined;
+	} else {
+		this.footerTitle = __SLAG_PROPERTIES.footerTitle || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerView = undefined;
+	} else {
+		this.footerView = __SLAG_PROPERTIES.footerView || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerTitle = undefined;
+	} else {
+		this.headerTitle = __SLAG_PROPERTIES.headerTitle || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerView = undefined;
+	} else {
+		this.headerView = __SLAG_PROPERTIES.headerView || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = __SLAG_PROPERTIES.items || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListSection.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ListSection.prototype.setItems = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.items = __SLAG__PROPERTY;
+};
+ListSection.prototype.appendItems = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListSection.prototype.insertItemsAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListSection.prototype.replaceItemsAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListSection.prototype.deleteItemsAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListSection.prototype.getItemAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ListSection.prototype.updateItemAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListSection.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ListSection.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ListSection.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ListSection.prototype.getFooterTitle = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerTitle;
+};
+ListSection.prototype.setFooterTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerTitle = __SLAG__PROPERTY;
+};
+ListSection.prototype.getFooterView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerView;
+};
+ListSection.prototype.setFooterView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerView = __SLAG__PROPERTY;
+};
+ListSection.prototype.getHeaderTitle = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerTitle;
+};
+ListSection.prototype.setHeaderTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerTitle = __SLAG__PROPERTY;
+};
+ListSection.prototype.getHeaderView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerView;
+};
+ListSection.prototype.setHeaderView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerView = __SLAG__PROPERTY;
+};
+ListSection.prototype.getItems = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+module.exports = function (properties) {
+	return new ListSection(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ListView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ListView.js
@@ -1,0 +1,2306 @@
+var crypto = require('crypto');
+function ListView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'allowsSelection',
+			'canScroll',
+			'disableBounce',
+			'editing',
+			'allowsSelectionDuringEditing',
+			'lazyLoadingEnabled',
+			'pruneSectionsOnEdit',
+			'templates',
+			'sections',
+			'defaultItemTemplate',
+			'separatorHeight',
+			'footerDividersEnabled',
+			'footerTitle',
+			'footerView',
+			'headerDividersEnabled',
+			'headerTitle',
+			'headerView',
+			'pullView',
+			'refreshControl',
+			'searchView',
+			'searchText',
+			'caseInsensitiveSearch',
+			'keepSectionsInSearch',
+			'keyboardDismissMode',
+			'sectionIndexTitles',
+			'scrollIndicatorStyle',
+			'willScrollOnStatusTap',
+			'sectionCount',
+			'showVerticalScrollIndicator',
+			'separatorColor',
+			'separatorInsets',
+			'separatorStyle',
+			'style',
+			'tableSeparatorInsets',
+			'listSeparatorInsets',
+			'rowSeparatorInsets',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ListView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ListView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.ListView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.ListView.children is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.ListView.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.ListView.size is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsSelection = undefined;
+	} else {
+		this.allowsSelection = __SLAG_PROPERTIES.allowsSelection || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canScroll = undefined;
+	} else {
+		this.canScroll = __SLAG_PROPERTIES.canScroll || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disableBounce = undefined;
+	} else {
+		this.disableBounce = __SLAG_PROPERTIES.disableBounce || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editing = undefined;
+	} else {
+		this.editing = __SLAG_PROPERTIES.editing || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsSelectionDuringEditing = undefined;
+	} else {
+		this.allowsSelectionDuringEditing = __SLAG_PROPERTIES.allowsSelectionDuringEditing || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lazyLoadingEnabled = undefined;
+	} else {
+		this.lazyLoadingEnabled = __SLAG_PROPERTIES.lazyLoadingEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pruneSectionsOnEdit = undefined;
+	} else {
+		this.pruneSectionsOnEdit = __SLAG_PROPERTIES.pruneSectionsOnEdit || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.templates = undefined;
+	} else {
+		this.templates = __SLAG_PROPERTIES.templates || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sections = undefined;
+	} else {
+		this.sections = __SLAG_PROPERTIES.sections || [];
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.defaultItemTemplate = undefined;
+	} else {
+		this.defaultItemTemplate = __SLAG_PROPERTIES.defaultItemTemplate || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.separatorHeight = undefined;
+	} else {
+		this.separatorHeight = __SLAG_PROPERTIES.separatorHeight || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerDividersEnabled = undefined;
+	} else {
+		this.footerDividersEnabled = __SLAG_PROPERTIES.footerDividersEnabled || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerTitle = undefined;
+	} else {
+		this.footerTitle = __SLAG_PROPERTIES.footerTitle || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerView = undefined;
+	} else {
+		this.footerView = __SLAG_PROPERTIES.footerView || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerDividersEnabled = undefined;
+	} else {
+		this.headerDividersEnabled = __SLAG_PROPERTIES.headerDividersEnabled || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerTitle = undefined;
+	} else {
+		this.headerTitle = __SLAG_PROPERTIES.headerTitle || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerView = undefined;
+	} else {
+		this.headerView = __SLAG_PROPERTIES.headerView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullView = undefined;
+	} else {
+		this.pullView = __SLAG_PROPERTIES.pullView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.refreshControl = undefined;
+	} else {
+		this.refreshControl = __SLAG_PROPERTIES.refreshControl || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.searchView = undefined;
+	} else {
+		this.searchView = __SLAG_PROPERTIES.searchView || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.searchText = undefined;
+	} else {
+		this.searchText = __SLAG_PROPERTIES.searchText || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.caseInsensitiveSearch = undefined;
+	} else {
+		this.caseInsensitiveSearch = __SLAG_PROPERTIES.caseInsensitiveSearch || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepSectionsInSearch = undefined;
+	} else {
+		this.keepSectionsInSearch = __SLAG_PROPERTIES.keepSectionsInSearch || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardDismissMode = undefined;
+	} else {
+		this.keyboardDismissMode = __SLAG_PROPERTIES.keyboardDismissMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sectionIndexTitles = undefined;
+	} else {
+		this.sectionIndexTitles = __SLAG_PROPERTIES.sectionIndexTitles || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollIndicatorStyle = undefined;
+	} else {
+		this.scrollIndicatorStyle = __SLAG_PROPERTIES.scrollIndicatorStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.willScrollOnStatusTap = undefined;
+	} else {
+		this.willScrollOnStatusTap = __SLAG_PROPERTIES.willScrollOnStatusTap || true;
+	}
+	if (__SLAG_PROPERTIES.sectionCount) {
+		throw new Error('Ti.UI.ListView.sectionCount is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sectionCount = undefined;
+	} else {
+		this.sectionCount = 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showVerticalScrollIndicator = undefined;
+	} else {
+		this.showVerticalScrollIndicator = __SLAG_PROPERTIES.showVerticalScrollIndicator || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.separatorColor = undefined;
+	} else {
+		this.separatorColor = __SLAG_PROPERTIES.separatorColor || '';
+	}
+	if (__SLAG_PROPERTIES.separatorInsets) {
+		throw new Error('Ti.UI.ListView.separatorInsets was deprecated, since 5.2.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.separatorStyle = undefined;
+	} else {
+		this.separatorStyle = __SLAG_PROPERTIES.separatorStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if (__SLAG_PROPERTIES.tableSeparatorInsets) {
+		throw new Error('Ti.UI.ListView.tableSeparatorInsets was deprecated, since 5.4.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.listSeparatorInsets = undefined;
+	} else {
+		this.listSeparatorInsets = __SLAG_PROPERTIES.listSeparatorInsets || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowSeparatorInsets = undefined;
+	} else {
+		this.rowSeparatorInsets = __SLAG_PROPERTIES.rowSeparatorInsets || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListView.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ListView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+ListView.prototype.animate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.ListView.finishLayout was deprecated, since 3.0.0');
+};
+ListView.prototype.hide = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+ListView.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.show = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.ListView.startLayout was deprecated, since 3.0.0');
+};
+ListView.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ListView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.ListView.updateLayout was deprecated, since 3.0.0');
+};
+ListView.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+ListView.prototype.scrollToItem = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.deselectItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.appendSection = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.deleteSectionAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.insertSectionAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.replaceSectionAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.selectItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.setContentInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.setContentOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.setMarker = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.addMarker = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListView.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ListView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ListView.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ListView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ListView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ListView.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+ListView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+ListView.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+ListView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+ListView.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+ListView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+ListView.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+ListView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+ListView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+ListView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+ListView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+ListView.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+ListView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+ListView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+ListView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+ListView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+ListView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+ListView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+ListView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+ListView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+ListView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+ListView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+ListView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+ListView.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+ListView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+ListView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+ListView.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+ListView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+ListView.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+ListView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+ListView.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+ListView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+ListView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+ListView.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+ListView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+ListView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+ListView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+ListView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+ListView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+ListView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+ListView.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+ListView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+ListView.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+ListView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+ListView.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+ListView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+ListView.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+ListView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+ListView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+ListView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+ListView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+ListView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+ListView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+ListView.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+ListView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+ListView.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+ListView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+ListView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+ListView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+ListView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+ListView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+ListView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+ListView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+ListView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+ListView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+ListView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+ListView.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+ListView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+ListView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+ListView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+ListView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+ListView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+ListView.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+ListView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+ListView.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+ListView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+ListView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+ListView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+ListView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+ListView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+ListView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+ListView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+ListView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+ListView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+ListView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+ListView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+ListView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+ListView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+ListView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+ListView.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+ListView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+ListView.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+ListView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+ListView.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+ListView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+ListView.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+ListView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+ListView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+ListView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+ListView.prototype.getAllowsSelection = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsSelection;
+};
+ListView.prototype.setAllowsSelection = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsSelection = __SLAG__PROPERTY;
+};
+ListView.prototype.getCanScroll = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.canScroll;
+};
+ListView.prototype.setCanScroll = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.canScroll = __SLAG__PROPERTY;
+};
+ListView.prototype.getDisableBounce = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disableBounce;
+};
+ListView.prototype.setDisableBounce = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disableBounce = __SLAG__PROPERTY;
+};
+ListView.prototype.getEditing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editing;
+};
+ListView.prototype.setEditing = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editing = __SLAG__PROPERTY;
+};
+ListView.prototype.getAllowsSelectionDuringEditing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsSelectionDuringEditing;
+};
+ListView.prototype.setAllowsSelectionDuringEditing = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsSelectionDuringEditing = __SLAG__PROPERTY;
+};
+ListView.prototype.getLazyLoadingEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lazyLoadingEnabled;
+};
+ListView.prototype.setLazyLoadingEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lazyLoadingEnabled = __SLAG__PROPERTY;
+};
+ListView.prototype.getPruneSectionsOnEdit = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pruneSectionsOnEdit;
+};
+ListView.prototype.setPruneSectionsOnEdit = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pruneSectionsOnEdit = __SLAG__PROPERTY;
+};
+ListView.prototype.getTemplates = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.templates;
+};
+ListView.prototype.setTemplates = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.templates = __SLAG__PROPERTY;
+};
+ListView.prototype.getSections = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sections;
+};
+ListView.prototype.setSections = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.sections = __SLAG__PROPERTY;
+};
+ListView.prototype.getDefaultItemTemplate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.defaultItemTemplate;
+};
+ListView.prototype.setDefaultItemTemplate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.defaultItemTemplate = __SLAG__PROPERTY;
+};
+ListView.prototype.getSeparatorHeight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.separatorHeight;
+};
+ListView.prototype.setSeparatorHeight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.separatorHeight = __SLAG__PROPERTY;
+};
+ListView.prototype.getFooterDividersEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerDividersEnabled;
+};
+ListView.prototype.setFooterDividersEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerDividersEnabled = __SLAG__PROPERTY;
+};
+ListView.prototype.getFooterTitle = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerTitle;
+};
+ListView.prototype.setFooterTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerTitle = __SLAG__PROPERTY;
+};
+ListView.prototype.getFooterView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerView;
+};
+ListView.prototype.setFooterView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerView = __SLAG__PROPERTY;
+};
+ListView.prototype.getHeaderDividersEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerDividersEnabled;
+};
+ListView.prototype.setHeaderDividersEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerDividersEnabled = __SLAG__PROPERTY;
+};
+ListView.prototype.getHeaderTitle = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerTitle;
+};
+ListView.prototype.setHeaderTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerTitle = __SLAG__PROPERTY;
+};
+ListView.prototype.getHeaderView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerView;
+};
+ListView.prototype.setHeaderView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerView = __SLAG__PROPERTY;
+};
+ListView.prototype.getPullView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullView;
+};
+ListView.prototype.setPullView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullView = __SLAG__PROPERTY;
+};
+ListView.prototype.getRefreshControl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.refreshControl;
+};
+ListView.prototype.setRefreshControl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.refreshControl = __SLAG__PROPERTY;
+};
+ListView.prototype.getSearchView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.searchView;
+};
+ListView.prototype.setSearchView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.searchView = __SLAG__PROPERTY;
+};
+ListView.prototype.getSearchText = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.searchText;
+};
+ListView.prototype.setSearchText = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.searchText = __SLAG__PROPERTY;
+};
+ListView.prototype.getCaseInsensitiveSearch = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.caseInsensitiveSearch;
+};
+ListView.prototype.setCaseInsensitiveSearch = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.caseInsensitiveSearch = __SLAG__PROPERTY;
+};
+ListView.prototype.getKeepSectionsInSearch = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepSectionsInSearch;
+};
+ListView.prototype.setKeepSectionsInSearch = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepSectionsInSearch = __SLAG__PROPERTY;
+};
+ListView.prototype.getKeyboardDismissMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardDismissMode;
+};
+ListView.prototype.setKeyboardDismissMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardDismissMode = __SLAG__PROPERTY;
+};
+ListView.prototype.getSectionIndexTitles = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sectionIndexTitles;
+};
+ListView.prototype.setSectionIndexTitles = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.sectionIndexTitles = __SLAG__PROPERTY;
+};
+ListView.prototype.getScrollIndicatorStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollIndicatorStyle;
+};
+ListView.prototype.setScrollIndicatorStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollIndicatorStyle = __SLAG__PROPERTY;
+};
+ListView.prototype.getWillScrollOnStatusTap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.willScrollOnStatusTap;
+};
+ListView.prototype.setWillScrollOnStatusTap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.willScrollOnStatusTap = __SLAG__PROPERTY;
+};
+ListView.prototype.getSectionCount = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sectionCount;
+};
+ListView.prototype.getShowVerticalScrollIndicator = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showVerticalScrollIndicator;
+};
+ListView.prototype.setShowVerticalScrollIndicator = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showVerticalScrollIndicator = __SLAG__PROPERTY;
+};
+ListView.prototype.getSeparatorColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.separatorColor;
+};
+ListView.prototype.setSeparatorColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.separatorColor = __SLAG__PROPERTY;
+};
+ListView.prototype.getSeparatorInsets = function () {
+	throw new Error('Ti.UI.ListView.getSeparatorInsets was deprecated, since 5.2.0');
+};
+ListView.prototype.setSeparatorInsets = function () {
+	throw new Error('Ti.UI.ListView.setSeparatorInsets was deprecated, since 5.2.0');
+};
+ListView.prototype.getSeparatorStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.separatorStyle;
+};
+ListView.prototype.setSeparatorStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.separatorStyle = __SLAG__PROPERTY;
+};
+ListView.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+ListView.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+ListView.prototype.getTableSeparatorInsets = function () {
+	throw new Error('Ti.UI.ListView.getTableSeparatorInsets was deprecated, since 5.4.0');
+};
+ListView.prototype.setTableSeparatorInsets = function () {
+	throw new Error('Ti.UI.ListView.setTableSeparatorInsets was deprecated, since 5.4.0');
+};
+ListView.prototype.getListSeparatorInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.listSeparatorInsets;
+};
+ListView.prototype.setListSeparatorInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.listSeparatorInsets = __SLAG__PROPERTY;
+};
+ListView.prototype.getRowSeparatorInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowSeparatorInsets;
+};
+ListView.prototype.setRowSeparatorInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rowSeparatorInsets = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ListView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/MaskedImage.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/MaskedImage.js
@@ -1,0 +1,929 @@
+var crypto = require('crypto');
+function MaskedImage(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'mask',
+			'image',
+			'mode',
+			'tint',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.MaskedImage.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.MaskedImage';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.MaskedImage.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.MaskedImage.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.MaskedImage.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.MaskedImage.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mask = undefined;
+	} else {
+		this.mask = __SLAG_PROPERTIES.mask || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.image = undefined;
+	} else {
+		this.image = __SLAG_PROPERTIES.image || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.mode = undefined;
+	} else {
+		this.mode = __SLAG_PROPERTIES.mode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tint = undefined;
+	} else {
+		this.tint = __SLAG_PROPERTIES.tint || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+MaskedImage.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+MaskedImage.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+MaskedImage.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.MaskedImage.finishLayout was deprecated, since 3.0.0');
+};
+MaskedImage.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+MaskedImage.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MaskedImage.prototype.startLayout = function () {
+	throw new Error('Ti.UI.MaskedImage.startLayout was deprecated, since 3.0.0');
+};
+MaskedImage.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+MaskedImage.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.MaskedImage.updateLayout was deprecated, since 3.0.0');
+};
+MaskedImage.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+MaskedImage.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+MaskedImage.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+MaskedImage.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+MaskedImage.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+MaskedImage.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+MaskedImage.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+MaskedImage.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+MaskedImage.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+MaskedImage.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+MaskedImage.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+MaskedImage.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+MaskedImage.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+MaskedImage.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+MaskedImage.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+MaskedImage.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+MaskedImage.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+MaskedImage.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+MaskedImage.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+MaskedImage.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+MaskedImage.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+MaskedImage.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+MaskedImage.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+MaskedImage.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+MaskedImage.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+MaskedImage.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+MaskedImage.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+MaskedImage.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+MaskedImage.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+MaskedImage.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+MaskedImage.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+MaskedImage.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+MaskedImage.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+MaskedImage.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+MaskedImage.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+MaskedImage.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+MaskedImage.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+MaskedImage.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+MaskedImage.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+MaskedImage.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+MaskedImage.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+MaskedImage.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+MaskedImage.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+MaskedImage.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getMask = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mask;
+};
+MaskedImage.prototype.setMask = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mask = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.image;
+};
+MaskedImage.prototype.setImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.image = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.mode;
+};
+MaskedImage.prototype.setMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.mode = __SLAG__PROPERTY;
+};
+MaskedImage.prototype.getTint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tint;
+};
+MaskedImage.prototype.setTint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tint = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new MaskedImage(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/MobileWeb.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/MobileWeb.js
@@ -1,0 +1,64 @@
+var crypto = require('crypto');
+function MobileWeb(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.MobileWeb.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.MobileWeb';
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+MobileWeb.prototype.addEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MobileWeb.prototype.removeEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MobileWeb.prototype.fireEvent = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MobileWeb.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+MobileWeb.prototype.getApiName = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+MobileWeb.prototype.createNavigationGroup = function (__SLAG_PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var NavigationGroup = require('./MobileWeb/NavigationGroup');
+	return NavigationGroup(__SLAG_PROPERTY);
+};
+module.exports = function (properties) {
+	return new MobileWeb(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/MobileWeb/NavigationGroup.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/MobileWeb/NavigationGroup.js
@@ -1,0 +1,606 @@
+var crypto = require('crypto');
+function NavigationGroup(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'right',
+			'rect',
+			'size',
+			'top',
+			'touchEnabled',
+			'transform',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'window',
+			'navBarAtTop',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.MobileWeb.NavigationGroup.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.MobileWeb.NavigationGroup';
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.MobileWeb.NavigationGroup.children is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.MobileWeb.NavigationGroup.rect is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.MobileWeb.NavigationGroup.size is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.window = undefined;
+	} else {
+		this.window = __SLAG_PROPERTIES.window || {};
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navBarAtTop = undefined;
+	} else {
+		this.navBarAtTop = __SLAG_PROPERTIES.navBarAtTop || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+NavigationGroup.prototype.addEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.removeEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.fireEvent = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+NavigationGroup.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+NavigationGroup.prototype.animate = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.MobileWeb.NavigationGroup.finishLayout was deprecated, since 3.0.0');
+};
+NavigationGroup.prototype.hide = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+NavigationGroup.prototype.show = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.startLayout = function () {
+	throw new Error('Ti.UI.MobileWeb.NavigationGroup.startLayout was deprecated, since 3.0.0');
+};
+NavigationGroup.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.MobileWeb.NavigationGroup.updateLayout was deprecated, since 3.0.0');
+};
+NavigationGroup.prototype.convertPointToView = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+NavigationGroup.prototype.close = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.open = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.getApiName = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+NavigationGroup.prototype.getBackgroundColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+NavigationGroup.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundGradient = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+NavigationGroup.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+NavigationGroup.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundSelectedColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+NavigationGroup.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundSelectedImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+NavigationGroup.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBorderColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+NavigationGroup.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBorderRadius = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+NavigationGroup.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBorderWidth = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+NavigationGroup.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBottom = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+NavigationGroup.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getCenter = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+NavigationGroup.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+NavigationGroup.prototype.getChildren = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+NavigationGroup.prototype.getHeight = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+NavigationGroup.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getLeft = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+NavigationGroup.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getLayout = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+NavigationGroup.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getOpacity = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+NavigationGroup.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getRight = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+NavigationGroup.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getRect = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+NavigationGroup.prototype.getSize = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+NavigationGroup.prototype.getTop = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+NavigationGroup.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getTouchEnabled = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+NavigationGroup.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getTransform = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+NavigationGroup.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getVisible = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+NavigationGroup.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getWidth = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+NavigationGroup.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getHorizontalWrap = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+NavigationGroup.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getZIndex = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+NavigationGroup.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getWindow = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.window;
+};
+NavigationGroup.prototype.setWindow = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.window = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getNavBarAtTop = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navBarAtTop;
+};
+NavigationGroup.prototype.setNavBarAtTop = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navBarAtTop = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new NavigationGroup(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/MobileWeb/TableViewSeparatorStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/MobileWeb/TableViewSeparatorStyle.js
@@ -1,0 +1,75 @@
+var crypto = require('crypto');
+function TableViewSeparatorStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'NONE',
+			'SINGLE_LINE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.MobileWeb.TableViewSeparatorStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.MobileWeb.TableViewSeparatorStyle';
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.MobileWeb.TableViewSeparatorStyle.NONE is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.SINGLE_LINE) {
+		throw new Error('Ti.UI.MobileWeb.TableViewSeparatorStyle.SINGLE_LINE is read only property');
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SINGLE_LINE = undefined;
+	} else {
+		this.SINGLE_LINE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewSeparatorStyle.prototype.addEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSeparatorStyle.prototype.removeEventListener = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSeparatorStyle.prototype.fireEvent = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSeparatorStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewSeparatorStyle.prototype.getApiName = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewSeparatorStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Notification.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Notification.js
@@ -1,0 +1,1157 @@
+var crypto = require('crypto');
+function Notification(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'message',
+			'duration',
+			'gravity',
+			'xOffset',
+			'yOffset',
+			'horizontalMargin',
+			'verticalMargin',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Notification.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Notification';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Notification.children is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Notification.rect is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Notification.size is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.gravity = undefined;
+	} else {
+		this.gravity = __SLAG_PROPERTIES.gravity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.xOffset = undefined;
+	} else {
+		this.xOffset = __SLAG_PROPERTIES.xOffset || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.yOffset = undefined;
+	} else {
+		this.yOffset = __SLAG_PROPERTIES.yOffset || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalMargin = undefined;
+	} else {
+		this.horizontalMargin = __SLAG_PROPERTIES.horizontalMargin || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.verticalMargin = undefined;
+	} else {
+		this.verticalMargin = __SLAG_PROPERTIES.verticalMargin || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Notification.prototype.addEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.removeEventListener = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.fireEvent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Notification.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Notification.prototype.animate = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Notification.finishLayout was deprecated, since 3.0.0');
+};
+Notification.prototype.hide = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.insertAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Notification.prototype.removeAllChildren = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.replaceAt = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.show = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notification.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Notification.startLayout was deprecated, since 3.0.0');
+};
+Notification.prototype.toImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Notification.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Notification.updateLayout was deprecated, since 3.0.0');
+};
+Notification.prototype.convertPointToView = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Notification.prototype.getBubbleParent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Notification.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Notification.prototype.getApiName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Notification.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Notification.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Notification.prototype.getAccessibilityHidden = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Notification.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Notification.prototype.getAccessibilityHint = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Notification.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Notification.prototype.getAccessibilityLabel = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Notification.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Notification.prototype.getAccessibilityValue = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Notification.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Notification.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+Notification.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+Notification.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+Notification.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+Notification.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundGradient = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Notification.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Notification.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundRepeat = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+Notification.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundSelectedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+Notification.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+Notification.prototype.getBackgroundSelectedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+Notification.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+Notification.prototype.getBorderColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Notification.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Notification.prototype.getBorderRadius = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Notification.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Notification.prototype.getBorderWidth = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Notification.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Notification.prototype.getBottom = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Notification.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Notification.prototype.getCenter = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Notification.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Notification.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Notification.prototype.getChildren = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Notification.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Notification.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Notification.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+Notification.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+Notification.prototype.getHeight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Notification.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Notification.prototype.getLeft = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Notification.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Notification.prototype.getLayout = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+Notification.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+Notification.prototype.getOpacity = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Notification.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Notification.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Notification.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Notification.prototype.getRight = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Notification.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Notification.prototype.getRect = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Notification.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Notification.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Notification.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Notification.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Notification.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Notification.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Notification.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Notification.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Notification.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Notification.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Notification.prototype.getSize = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Notification.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+Notification.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+Notification.prototype.getTop = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Notification.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Notification.prototype.getTouchEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Notification.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Notification.prototype.getTransform = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Notification.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Notification.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Notification.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Notification.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Notification.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Notification.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Notification.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Notification.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Notification.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Notification.prototype.getVisible = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Notification.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Notification.prototype.getWidth = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Notification.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Notification.prototype.getHorizontalWrap = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Notification.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Notification.prototype.getZIndex = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Notification.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Notification.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+Notification.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+Notification.prototype.getMessage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.message;
+};
+Notification.prototype.setMessage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.message = __SLAG__PROPERTY;
+};
+Notification.prototype.getDuration = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.duration;
+};
+Notification.prototype.setDuration = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.duration = __SLAG__PROPERTY;
+};
+Notification.prototype.getGravity = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.gravity;
+};
+Notification.prototype.setGravity = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.gravity = __SLAG__PROPERTY;
+};
+Notification.prototype.getXOffset = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.xOffset;
+};
+Notification.prototype.setXOffset = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.xOffset = __SLAG__PROPERTY;
+};
+Notification.prototype.getYOffset = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.yOffset;
+};
+Notification.prototype.setYOffset = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.yOffset = __SLAG__PROPERTY;
+};
+Notification.prototype.getHorizontalMargin = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalMargin;
+};
+Notification.prototype.setHorizontalMargin = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalMargin = __SLAG__PROPERTY;
+};
+Notification.prototype.getVerticalMargin = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.verticalMargin;
+};
+Notification.prototype.setVerticalMargin = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.verticalMargin = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Notification(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/OptionDialog.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/OptionDialog.js
@@ -1,0 +1,623 @@
+var crypto = require('crypto');
+function OptionDialog(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'elevation',
+			'previewContext',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'tintColor',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'androidView',
+			'buttonNames',
+			'cancel',
+			'destructive',
+			'options',
+			'opaquebackground',
+			'persistent',
+			'selectedIndex',
+			'title',
+			'titleid',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.OptionDialog.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.OptionDialog';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.androidView = undefined;
+	} else {
+		this.androidView = __SLAG_PROPERTIES.androidView || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.buttonNames = undefined;
+	} else {
+		this.buttonNames = __SLAG_PROPERTIES.buttonNames || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancel = undefined;
+	} else {
+		this.cancel = __SLAG_PROPERTIES.cancel || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.destructive = undefined;
+	} else {
+		this.destructive = __SLAG_PROPERTIES.destructive || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.options = undefined;
+	} else {
+		this.options = __SLAG_PROPERTIES.options || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opaquebackground = undefined;
+	} else {
+		this.opaquebackground = __SLAG_PROPERTIES.opaquebackground || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.persistent = undefined;
+	} else {
+		this.persistent = __SLAG_PROPERTIES.persistent || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedIndex = undefined;
+	} else {
+		this.selectedIndex = __SLAG_PROPERTIES.selectedIndex || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+OptionDialog.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+OptionDialog.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+OptionDialog.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+OptionDialog.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+OptionDialog.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.OptionDialog.finishLayout was deprecated, since 3.0.0');
+};
+OptionDialog.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+OptionDialog.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+OptionDialog.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+OptionDialog.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+OptionDialog.prototype.startLayout = function () {
+	throw new Error('Ti.UI.OptionDialog.startLayout was deprecated, since 3.0.0');
+};
+OptionDialog.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.OptionDialog.updateLayout was deprecated, since 3.0.0');
+};
+OptionDialog.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+OptionDialog.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+OptionDialog.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+OptionDialog.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+OptionDialog.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+OptionDialog.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+OptionDialog.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+OptionDialog.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+OptionDialog.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+OptionDialog.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+OptionDialog.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+OptionDialog.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+OptionDialog.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+OptionDialog.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+OptionDialog.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+OptionDialog.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getAndroidView = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.androidView;
+};
+OptionDialog.prototype.setAndroidView = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.androidView = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getButtonNames = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.buttonNames;
+};
+OptionDialog.prototype.setButtonNames = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.buttonNames = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getCancel = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cancel;
+};
+OptionDialog.prototype.setCancel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cancel = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getDestructive = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.destructive;
+};
+OptionDialog.prototype.setDestructive = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.destructive = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getOptions = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.options;
+};
+OptionDialog.prototype.setOptions = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.options = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getOpaquebackground = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opaquebackground;
+};
+OptionDialog.prototype.setOpaquebackground = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opaquebackground = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getPersistent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.persistent;
+};
+OptionDialog.prototype.setPersistent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.persistent = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getSelectedIndex = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedIndex;
+};
+OptionDialog.prototype.setSelectedIndex = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedIndex = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+OptionDialog.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+OptionDialog.prototype.getTitleid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+OptionDialog.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new OptionDialog(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Picker.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Picker.js
@@ -1,0 +1,1621 @@
+var crypto = require('crypto');
+function Picker(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'animatedCenter',
+			'backgroundColor',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'keepScreenOn',
+			'columns',
+			'countDownDuration',
+			'dateTimeColor',
+			'format24',
+			'locale',
+			'maxDate',
+			'minDate',
+			'minuteInterval',
+			'selectionIndicator',
+			'selectionOpens',
+			'type',
+			'useSpinner',
+			'nativeSpinner',
+			'value',
+			'visibleItems',
+			'calendarViewShown',
+			'font',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Picker.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Picker';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.Picker.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Picker.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Picker.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Picker.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.columns = undefined;
+	} else {
+		this.columns = __SLAG_PROPERTIES.columns || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.countDownDuration = undefined;
+	} else {
+		this.countDownDuration = __SLAG_PROPERTIES.countDownDuration || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.dateTimeColor = undefined;
+	} else {
+		this.dateTimeColor = __SLAG_PROPERTIES.dateTimeColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.format24 = undefined;
+	} else {
+		this.format24 = __SLAG_PROPERTIES.format24 || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.locale = undefined;
+	} else {
+		this.locale = __SLAG_PROPERTIES.locale || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxDate = undefined;
+	} else {
+		this.maxDate = __SLAG_PROPERTIES.maxDate || new Date();
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minDate = undefined;
+	} else {
+		this.minDate = __SLAG_PROPERTIES.minDate || new Date();
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minuteInterval = undefined;
+	} else {
+		this.minuteInterval = __SLAG_PROPERTIES.minuteInterval || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectionIndicator = undefined;
+	} else {
+		this.selectionIndicator = __SLAG_PROPERTIES.selectionIndicator || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectionOpens = undefined;
+	} else {
+		this.selectionOpens = __SLAG_PROPERTIES.selectionOpens || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || 0;
+	}
+	if (__SLAG_PROPERTIES.useSpinner) {
+		throw new Error('Ti.UI.Picker.useSpinner was deprecated, since 5.2.1');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nativeSpinner = undefined;
+	} else {
+		this.nativeSpinner = __SLAG_PROPERTIES.nativeSpinner || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || new Date();
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visibleItems = undefined;
+	} else {
+		this.visibleItems = __SLAG_PROPERTIES.visibleItems || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.calendarViewShown = undefined;
+	} else {
+		this.calendarViewShown = __SLAG_PROPERTIES.calendarViewShown || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Picker.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Picker.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Picker.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Picker.finishLayout was deprecated, since 3.0.0');
+};
+Picker.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Picker.startLayout was deprecated, since 3.0.0');
+};
+Picker.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Picker.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Picker.updateLayout was deprecated, since 3.0.0');
+};
+Picker.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Picker.prototype.getSelectedRow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Picker.prototype.reloadColumn = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.setSelectedRow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.setValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Picker.prototype.showDatePickerDialog = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.showTimePickerDialog = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Picker.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Picker.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Picker.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Picker.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Picker.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Picker.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Picker.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Picker.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Picker.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Picker.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Picker.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Picker.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Picker.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Picker.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Picker.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Picker.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Picker.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Picker.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Picker.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Picker.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Picker.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Picker.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Picker.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Picker.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Picker.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Picker.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Picker.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Picker.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Picker.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Picker.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Picker.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+Picker.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+Picker.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Picker.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Picker.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Picker.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Picker.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Picker.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Picker.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Picker.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Picker.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Picker.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Picker.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Picker.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Picker.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Picker.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Picker.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Picker.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Picker.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Picker.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Picker.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Picker.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Picker.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Picker.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Picker.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Picker.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Picker.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Picker.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Picker.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+Picker.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+Picker.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Picker.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Picker.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Picker.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Picker.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Picker.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Picker.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Picker.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Picker.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Picker.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Picker.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Picker.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Picker.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Picker.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Picker.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Picker.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Picker.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Picker.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Picker.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Picker.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Picker.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Picker.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Picker.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Picker.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Picker.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Picker.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Picker.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+Picker.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+Picker.prototype.getColumns = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.columns;
+};
+Picker.prototype.setColumns = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.columns = __SLAG__PROPERTY;
+};
+Picker.prototype.getCountDownDuration = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.countDownDuration;
+};
+Picker.prototype.setCountDownDuration = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.countDownDuration = __SLAG__PROPERTY;
+};
+Picker.prototype.getDateTimeColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.dateTimeColor;
+};
+Picker.prototype.setDateTimeColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.dateTimeColor = __SLAG__PROPERTY;
+};
+Picker.prototype.getFormat24 = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.format24;
+};
+Picker.prototype.setFormat24 = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.format24 = __SLAG__PROPERTY;
+};
+Picker.prototype.getLocale = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.locale;
+};
+Picker.prototype.setLocale = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.locale = __SLAG__PROPERTY;
+};
+Picker.prototype.getMaxDate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxDate;
+};
+Picker.prototype.setMaxDate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxDate = __SLAG__PROPERTY;
+};
+Picker.prototype.getMinDate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minDate;
+};
+Picker.prototype.setMinDate = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minDate = __SLAG__PROPERTY;
+};
+Picker.prototype.getMinuteInterval = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minuteInterval;
+};
+Picker.prototype.setMinuteInterval = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minuteInterval = __SLAG__PROPERTY;
+};
+Picker.prototype.getSelectionIndicator = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectionIndicator;
+};
+Picker.prototype.setSelectionIndicator = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectionIndicator = __SLAG__PROPERTY;
+};
+Picker.prototype.getSelectionOpens = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectionOpens;
+};
+Picker.prototype.setSelectionOpens = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectionOpens = __SLAG__PROPERTY;
+};
+Picker.prototype.getType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+Picker.prototype.setType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.type = __SLAG__PROPERTY;
+};
+Picker.prototype.getUseSpinner = function () {
+	throw new Error('Ti.UI.Picker.getUseSpinner was deprecated, since 5.2.1');
+};
+Picker.prototype.setUseSpinner = function () {
+	throw new Error('Ti.UI.Picker.setUseSpinner was deprecated, since 5.2.1');
+};
+Picker.prototype.getNativeSpinner = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nativeSpinner;
+};
+Picker.prototype.setNativeSpinner = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nativeSpinner = __SLAG__PROPERTY;
+};
+Picker.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+Picker.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Picker.prototype.getVisibleItems = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visibleItems;
+};
+Picker.prototype.setVisibleItems = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visibleItems = __SLAG__PROPERTY;
+};
+Picker.prototype.getCalendarViewShown = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.calendarViewShown;
+};
+Picker.prototype.setCalendarViewShown = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.calendarViewShown = __SLAG__PROPERTY;
+};
+Picker.prototype.getFont = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+Picker.prototype.setFont = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Picker(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/PickerColumn.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/PickerColumn.js
@@ -1,0 +1,1716 @@
+var crypto = require('crypto');
+function PickerColumn(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'rowCount',
+			'rows',
+			'selectedRow',
+			'font',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.PickerColumn.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.PickerColumn';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.PickerColumn.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.PickerColumn.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.PickerColumn.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.PickerColumn.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (__SLAG_PROPERTIES.rowCount) {
+		throw new Error('Ti.UI.PickerColumn.rowCount is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowCount = undefined;
+	} else {
+		this.rowCount = 0;
+	}
+	if (__SLAG_PROPERTIES.rows) {
+		throw new Error('Ti.UI.PickerColumn.rows is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rows = undefined;
+	} else {
+		this.rows = [];
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedRow = undefined;
+	} else {
+		this.selectedRow = __SLAG_PROPERTIES.selectedRow || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PickerColumn.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PickerColumn.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+PickerColumn.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.PickerColumn.finishLayout was deprecated, since 3.0.0');
+};
+PickerColumn.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+PickerColumn.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.startLayout = function () {
+	throw new Error('Ti.UI.PickerColumn.startLayout was deprecated, since 3.0.0');
+};
+PickerColumn.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+PickerColumn.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.PickerColumn.updateLayout was deprecated, since 3.0.0');
+};
+PickerColumn.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+PickerColumn.prototype.addRow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.removeRow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerColumn.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PickerColumn.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PickerColumn.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+PickerColumn.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+PickerColumn.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+PickerColumn.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+PickerColumn.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+PickerColumn.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+PickerColumn.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+PickerColumn.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+PickerColumn.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+PickerColumn.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+PickerColumn.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+PickerColumn.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+PickerColumn.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+PickerColumn.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+PickerColumn.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+PickerColumn.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+PickerColumn.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+PickerColumn.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+PickerColumn.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+PickerColumn.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+PickerColumn.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+PickerColumn.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+PickerColumn.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+PickerColumn.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+PickerColumn.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+PickerColumn.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+PickerColumn.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+PickerColumn.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+PickerColumn.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+PickerColumn.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+PickerColumn.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+PickerColumn.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+PickerColumn.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+PickerColumn.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+PickerColumn.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+PickerColumn.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+PickerColumn.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+PickerColumn.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+PickerColumn.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+PickerColumn.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+PickerColumn.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+PickerColumn.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+PickerColumn.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+PickerColumn.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+PickerColumn.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+PickerColumn.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+PickerColumn.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+PickerColumn.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+PickerColumn.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+PickerColumn.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+PickerColumn.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+PickerColumn.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+PickerColumn.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+PickerColumn.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+PickerColumn.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+PickerColumn.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+PickerColumn.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+PickerColumn.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+PickerColumn.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+PickerColumn.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+PickerColumn.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+PickerColumn.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getRowCount = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowCount;
+};
+PickerColumn.prototype.getRows = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rows;
+};
+PickerColumn.prototype.getSelectedRow = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedRow;
+};
+PickerColumn.prototype.setSelectedRow = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedRow = __SLAG__PROPERTY;
+};
+PickerColumn.prototype.getFont = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+PickerColumn.prototype.setFont = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PickerColumn(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/PickerRow.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/PickerRow.js
@@ -1,0 +1,1703 @@
+var crypto = require('crypto');
+function PickerRow(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'color',
+			'font',
+			'title',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.PickerRow.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.PickerRow';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.PickerRow.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.PickerRow.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.PickerRow.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.PickerRow.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PickerRow.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PickerRow.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+PickerRow.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.PickerRow.finishLayout was deprecated, since 3.0.0');
+};
+PickerRow.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+PickerRow.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PickerRow.prototype.startLayout = function () {
+	throw new Error('Ti.UI.PickerRow.startLayout was deprecated, since 3.0.0');
+};
+PickerRow.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+PickerRow.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.PickerRow.updateLayout was deprecated, since 3.0.0');
+};
+PickerRow.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+PickerRow.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PickerRow.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PickerRow.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+PickerRow.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+PickerRow.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+PickerRow.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+PickerRow.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+PickerRow.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+PickerRow.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+PickerRow.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+PickerRow.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+PickerRow.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+PickerRow.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+PickerRow.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+PickerRow.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+PickerRow.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+PickerRow.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+PickerRow.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+PickerRow.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+PickerRow.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+PickerRow.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+PickerRow.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+PickerRow.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+PickerRow.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+PickerRow.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+PickerRow.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+PickerRow.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+PickerRow.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+PickerRow.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+PickerRow.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+PickerRow.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+PickerRow.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+PickerRow.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+PickerRow.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+PickerRow.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+PickerRow.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+PickerRow.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+PickerRow.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+PickerRow.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+PickerRow.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+PickerRow.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+PickerRow.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+PickerRow.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+PickerRow.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+PickerRow.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+PickerRow.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+PickerRow.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+PickerRow.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+PickerRow.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+PickerRow.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+PickerRow.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+PickerRow.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+PickerRow.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+PickerRow.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+PickerRow.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+PickerRow.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+PickerRow.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+PickerRow.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+PickerRow.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+PickerRow.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+PickerRow.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+PickerRow.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+PickerRow.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+PickerRow.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+PickerRow.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getFont = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+PickerRow.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+PickerRow.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+PickerRow.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PickerRow(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ProgressBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ProgressBar.js
@@ -1,0 +1,1832 @@
+var crypto = require('crypto');
+function ProgressBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'color',
+			'font',
+			'max',
+			'message',
+			'trackTintColor',
+			'min',
+			'style',
+			'value',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ProgressBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ProgressBar';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.ProgressBar.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.ProgressBar.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.ProgressBar.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.ProgressBar.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.max = undefined;
+	} else {
+		this.max = __SLAG_PROPERTIES.max || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.message = undefined;
+	} else {
+		this.message = __SLAG_PROPERTIES.message || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.trackTintColor = undefined;
+	} else {
+		this.trackTintColor = __SLAG_PROPERTIES.trackTintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.min = undefined;
+	} else {
+		this.min = __SLAG_PROPERTIES.min || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ProgressBar.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ProgressBar.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+ProgressBar.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.ProgressBar.finishLayout was deprecated, since 3.0.0');
+};
+ProgressBar.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+ProgressBar.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBar.prototype.startLayout = function () {
+	throw new Error('Ti.UI.ProgressBar.startLayout was deprecated, since 3.0.0');
+};
+ProgressBar.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ProgressBar.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.ProgressBar.updateLayout was deprecated, since 3.0.0');
+};
+ProgressBar.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+ProgressBar.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ProgressBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ProgressBar.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ProgressBar.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+ProgressBar.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+ProgressBar.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+ProgressBar.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+ProgressBar.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+ProgressBar.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+ProgressBar.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+ProgressBar.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+ProgressBar.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+ProgressBar.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+ProgressBar.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+ProgressBar.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+ProgressBar.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+ProgressBar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+ProgressBar.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+ProgressBar.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+ProgressBar.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+ProgressBar.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+ProgressBar.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+ProgressBar.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+ProgressBar.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+ProgressBar.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+ProgressBar.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+ProgressBar.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+ProgressBar.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+ProgressBar.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+ProgressBar.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+ProgressBar.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+ProgressBar.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+ProgressBar.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+ProgressBar.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+ProgressBar.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+ProgressBar.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+ProgressBar.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+ProgressBar.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+ProgressBar.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+ProgressBar.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+ProgressBar.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+ProgressBar.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+ProgressBar.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+ProgressBar.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+ProgressBar.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+ProgressBar.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+ProgressBar.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+ProgressBar.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+ProgressBar.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+ProgressBar.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+ProgressBar.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+ProgressBar.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+ProgressBar.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+ProgressBar.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+ProgressBar.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+ProgressBar.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+ProgressBar.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+ProgressBar.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+ProgressBar.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+ProgressBar.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+ProgressBar.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+ProgressBar.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+ProgressBar.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+ProgressBar.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+ProgressBar.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getFont = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+ProgressBar.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getMax = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.max;
+};
+ProgressBar.prototype.setMax = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.max = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getMessage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.message;
+};
+ProgressBar.prototype.setMessage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.message = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getTrackTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.trackTintColor;
+};
+ProgressBar.prototype.setTrackTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.trackTintColor = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getMin = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.min;
+};
+ProgressBar.prototype.setMin = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.min = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+ProgressBar.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+ProgressBar.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+ProgressBar.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ProgressBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/RefreshControl.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/RefreshControl.js
@@ -1,0 +1,121 @@
+var crypto = require('crypto');
+function RefreshControl(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'title',
+			'tintColor',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.RefreshControl.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.RefreshControl';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+RefreshControl.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RefreshControl.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RefreshControl.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RefreshControl.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+RefreshControl.prototype.beginRefreshing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RefreshControl.prototype.endRefreshing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RefreshControl.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+RefreshControl.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+RefreshControl.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+RefreshControl.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+RefreshControl.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+RefreshControl.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+RefreshControl.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new RefreshControl(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ScrollView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ScrollView.js
@@ -1,0 +1,2110 @@
+var crypto = require('crypto');
+function ScrollView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'canCancelEvents',
+			'contentHeight',
+			'contentOffset',
+			'contentWidth',
+			'decelerationRate',
+			'disableBounce',
+			'horizontalBounce',
+			'keyboardDismissMode',
+			'maxZoomScale',
+			'minZoomScale',
+			'overScrollMode',
+			'refreshControl',
+			'scrollsToTop',
+			'scrollIndicatorStyle',
+			'scrollType',
+			'scrollingEnabled',
+			'showHorizontalScrollIndicator',
+			'showVerticalScrollIndicator',
+			'verticalBounce',
+			'zoomScale',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ScrollView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ScrollView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.ScrollView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.ScrollView.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.ScrollView.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.ScrollView.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.canCancelEvents = undefined;
+	} else {
+		this.canCancelEvents = __SLAG_PROPERTIES.canCancelEvents || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentHeight = undefined;
+	} else {
+		this.contentHeight = __SLAG_PROPERTIES.contentHeight || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentOffset = undefined;
+	} else {
+		this.contentOffset = __SLAG_PROPERTIES.contentOffset || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentWidth = undefined;
+	} else {
+		this.contentWidth = __SLAG_PROPERTIES.contentWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.decelerationRate = undefined;
+	} else {
+		this.decelerationRate = __SLAG_PROPERTIES.decelerationRate || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disableBounce = undefined;
+	} else {
+		this.disableBounce = __SLAG_PROPERTIES.disableBounce || true;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalBounce = undefined;
+	} else {
+		this.horizontalBounce = __SLAG_PROPERTIES.horizontalBounce || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardDismissMode = undefined;
+	} else {
+		this.keyboardDismissMode = __SLAG_PROPERTIES.keyboardDismissMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxZoomScale = undefined;
+	} else {
+		this.maxZoomScale = __SLAG_PROPERTIES.maxZoomScale || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minZoomScale = undefined;
+	} else {
+		this.minZoomScale = __SLAG_PROPERTIES.minZoomScale || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overScrollMode = undefined;
+	} else {
+		this.overScrollMode = __SLAG_PROPERTIES.overScrollMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.refreshControl = undefined;
+	} else {
+		this.refreshControl = __SLAG_PROPERTIES.refreshControl || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollsToTop = undefined;
+	} else {
+		this.scrollsToTop = __SLAG_PROPERTIES.scrollsToTop || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollIndicatorStyle = undefined;
+	} else {
+		this.scrollIndicatorStyle = __SLAG_PROPERTIES.scrollIndicatorStyle || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollType = undefined;
+	} else {
+		this.scrollType = __SLAG_PROPERTIES.scrollType || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollingEnabled = undefined;
+	} else {
+		this.scrollingEnabled = __SLAG_PROPERTIES.scrollingEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showHorizontalScrollIndicator = undefined;
+	} else {
+		this.showHorizontalScrollIndicator = __SLAG_PROPERTIES.showHorizontalScrollIndicator || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showVerticalScrollIndicator = undefined;
+	} else {
+		this.showVerticalScrollIndicator = __SLAG_PROPERTIES.showVerticalScrollIndicator || true;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.verticalBounce = undefined;
+	} else {
+		this.verticalBounce = __SLAG_PROPERTIES.verticalBounce || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zoomScale = undefined;
+	} else {
+		this.zoomScale = __SLAG_PROPERTIES.zoomScale || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ScrollView.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ScrollView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+ScrollView.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.ScrollView.finishLayout was deprecated, since 3.0.0');
+};
+ScrollView.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+ScrollView.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.ScrollView.startLayout was deprecated, since 3.0.0');
+};
+ScrollView.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ScrollView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.ScrollView.updateLayout was deprecated, since 3.0.0');
+};
+ScrollView.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+ScrollView.prototype.scrollTo = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.setContentOffset = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentOffset = __SLAG__PROPERTY;
+};
+ScrollView.prototype.setZoomScale = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zoomScale = __SLAG__PROPERTY;
+};
+ScrollView.prototype.scrollToBottom = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollView.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ScrollView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ScrollView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ScrollView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+ScrollView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+ScrollView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+ScrollView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+ScrollView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+ScrollView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+ScrollView.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+ScrollView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+ScrollView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+ScrollView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+ScrollView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+ScrollView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+ScrollView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+ScrollView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+ScrollView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+ScrollView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+ScrollView.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+ScrollView.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+ScrollView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+ScrollView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+ScrollView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+ScrollView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+ScrollView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+ScrollView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+ScrollView.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+ScrollView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+ScrollView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+ScrollView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+ScrollView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+ScrollView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+ScrollView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+ScrollView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+ScrollView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+ScrollView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+ScrollView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+ScrollView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+ScrollView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+ScrollView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+ScrollView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+ScrollView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+ScrollView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+ScrollView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+ScrollView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+ScrollView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+ScrollView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+ScrollView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+ScrollView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+ScrollView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+ScrollView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+ScrollView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+ScrollView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+ScrollView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+ScrollView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+ScrollView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+ScrollView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+ScrollView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+ScrollView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+ScrollView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+ScrollView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+ScrollView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+ScrollView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getCanCancelEvents = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.canCancelEvents;
+};
+ScrollView.prototype.setCanCancelEvents = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.canCancelEvents = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getContentHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentHeight;
+};
+ScrollView.prototype.setContentHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentHeight = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getContentOffset = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentOffset;
+};
+ScrollView.prototype.setContentOffset = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentOffset = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getContentWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentWidth;
+};
+ScrollView.prototype.setContentWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentWidth = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getDecelerationRate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.decelerationRate;
+};
+ScrollView.prototype.setDecelerationRate = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.decelerationRate = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getDisableBounce = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disableBounce;
+};
+ScrollView.prototype.setDisableBounce = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disableBounce = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getHorizontalBounce = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalBounce;
+};
+ScrollView.prototype.setHorizontalBounce = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalBounce = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getKeyboardDismissMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardDismissMode;
+};
+ScrollView.prototype.setKeyboardDismissMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardDismissMode = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getMaxZoomScale = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxZoomScale;
+};
+ScrollView.prototype.setMaxZoomScale = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxZoomScale = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getMinZoomScale = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minZoomScale;
+};
+ScrollView.prototype.setMinZoomScale = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minZoomScale = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getOverScrollMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overScrollMode;
+};
+ScrollView.prototype.setOverScrollMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overScrollMode = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getRefreshControl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.refreshControl;
+};
+ScrollView.prototype.setRefreshControl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.refreshControl = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getScrollsToTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollsToTop;
+};
+ScrollView.prototype.setScrollsToTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollsToTop = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getScrollIndicatorStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollIndicatorStyle;
+};
+ScrollView.prototype.setScrollIndicatorStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollIndicatorStyle = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getScrollType = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollType;
+};
+ScrollView.prototype.setScrollType = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollType = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getScrollingEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollingEnabled;
+};
+ScrollView.prototype.setScrollingEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollingEnabled = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getShowHorizontalScrollIndicator = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showHorizontalScrollIndicator;
+};
+ScrollView.prototype.setShowHorizontalScrollIndicator = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showHorizontalScrollIndicator = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getShowVerticalScrollIndicator = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showVerticalScrollIndicator;
+};
+ScrollView.prototype.setShowVerticalScrollIndicator = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showVerticalScrollIndicator = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getVerticalBounce = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.verticalBounce;
+};
+ScrollView.prototype.setVerticalBounce = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.verticalBounce = __SLAG__PROPERTY;
+};
+ScrollView.prototype.getZoomScale = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zoomScale;
+};
+module.exports = function (properties) {
+	return new ScrollView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/ScrollableView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/ScrollableView.js
@@ -1,0 +1,2044 @@
+var crypto = require('crypto');
+function ScrollableView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'cacheSize',
+			'currentPage',
+			'currentPageIndicatorColor',
+			'disableBounce',
+			'overScrollMode',
+			'pagingControlColor',
+			'pagingControlHeight',
+			'pageIndicatorColor',
+			'showPagingControl',
+			'pagingControlTimeout',
+			'pagingControlAlpha',
+			'pagingControlOnTop',
+			'overlayEnabled',
+			'scrollingEnabled',
+			'views',
+			'clipViews',
+			'hitRect',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.ScrollableView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.ScrollableView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.ScrollableView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.ScrollableView.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.ScrollableView.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.ScrollableView.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cacheSize = undefined;
+	} else {
+		this.cacheSize = __SLAG_PROPERTIES.cacheSize || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentPage = undefined;
+	} else {
+		this.currentPage = __SLAG_PROPERTIES.currentPage || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.currentPageIndicatorColor = undefined;
+	} else {
+		this.currentPageIndicatorColor = __SLAG_PROPERTIES.currentPageIndicatorColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disableBounce = undefined;
+	} else {
+		this.disableBounce = __SLAG_PROPERTIES.disableBounce || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overScrollMode = undefined;
+	} else {
+		this.overScrollMode = __SLAG_PROPERTIES.overScrollMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pagingControlColor = undefined;
+	} else {
+		this.pagingControlColor = __SLAG_PROPERTIES.pagingControlColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pagingControlHeight = undefined;
+	} else {
+		this.pagingControlHeight = __SLAG_PROPERTIES.pagingControlHeight || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pageIndicatorColor = undefined;
+	} else {
+		this.pageIndicatorColor = __SLAG_PROPERTIES.pageIndicatorColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showPagingControl = undefined;
+	} else {
+		this.showPagingControl = __SLAG_PROPERTIES.showPagingControl || true;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pagingControlTimeout = undefined;
+	} else {
+		this.pagingControlTimeout = __SLAG_PROPERTIES.pagingControlTimeout || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pagingControlAlpha = undefined;
+	} else {
+		this.pagingControlAlpha = __SLAG_PROPERTIES.pagingControlAlpha || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pagingControlOnTop = undefined;
+	} else {
+		this.pagingControlOnTop = __SLAG_PROPERTIES.pagingControlOnTop || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overlayEnabled = undefined;
+	} else {
+		this.overlayEnabled = __SLAG_PROPERTIES.overlayEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollingEnabled = undefined;
+	} else {
+		this.scrollingEnabled = __SLAG_PROPERTIES.scrollingEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.views = undefined;
+	} else {
+		this.views = __SLAG_PROPERTIES.views || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipViews = undefined;
+	} else {
+		this.clipViews = __SLAG_PROPERTIES.clipViews || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hitRect = undefined;
+	} else {
+		this.hitRect = __SLAG_PROPERTIES.hitRect || {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ScrollableView.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ScrollableView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+ScrollableView.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.ScrollableView.finishLayout was deprecated, since 3.0.0');
+};
+ScrollableView.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+ScrollableView.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.ScrollableView.startLayout was deprecated, since 3.0.0');
+};
+ScrollableView.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ScrollableView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.ScrollableView.updateLayout was deprecated, since 3.0.0');
+};
+ScrollableView.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+ScrollableView.prototype.insertViewsAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.addView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.moveNext = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.movePrevious = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.removeView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.scrollToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollableView.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ScrollableView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ScrollableView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ScrollableView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+ScrollableView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+ScrollableView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+ScrollableView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+ScrollableView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+ScrollableView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+ScrollableView.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+ScrollableView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+ScrollableView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+ScrollableView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+ScrollableView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+ScrollableView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+ScrollableView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+ScrollableView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+ScrollableView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+ScrollableView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+ScrollableView.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+ScrollableView.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+ScrollableView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+ScrollableView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+ScrollableView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+ScrollableView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+ScrollableView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+ScrollableView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+ScrollableView.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+ScrollableView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+ScrollableView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+ScrollableView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+ScrollableView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+ScrollableView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+ScrollableView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+ScrollableView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+ScrollableView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+ScrollableView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+ScrollableView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+ScrollableView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+ScrollableView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+ScrollableView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+ScrollableView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+ScrollableView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+ScrollableView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+ScrollableView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+ScrollableView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+ScrollableView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+ScrollableView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+ScrollableView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+ScrollableView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+ScrollableView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+ScrollableView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+ScrollableView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+ScrollableView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+ScrollableView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+ScrollableView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+ScrollableView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+ScrollableView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+ScrollableView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+ScrollableView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+ScrollableView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+ScrollableView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+ScrollableView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+ScrollableView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getCacheSize = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cacheSize;
+};
+ScrollableView.prototype.setCacheSize = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cacheSize = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getCurrentPage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentPage;
+};
+ScrollableView.prototype.setCurrentPage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.currentPage = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getCurrentPageIndicatorColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.currentPageIndicatorColor;
+};
+ScrollableView.prototype.setCurrentPageIndicatorColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.currentPageIndicatorColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getDisableBounce = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disableBounce;
+};
+ScrollableView.prototype.setDisableBounce = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disableBounce = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getOverScrollMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overScrollMode;
+};
+ScrollableView.prototype.setOverScrollMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overScrollMode = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPagingControlColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pagingControlColor;
+};
+ScrollableView.prototype.setPagingControlColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pagingControlColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPagingControlHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pagingControlHeight;
+};
+ScrollableView.prototype.setPagingControlHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pagingControlHeight = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPageIndicatorColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pageIndicatorColor;
+};
+ScrollableView.prototype.setPageIndicatorColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pageIndicatorColor = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getShowPagingControl = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showPagingControl;
+};
+ScrollableView.prototype.setShowPagingControl = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showPagingControl = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPagingControlTimeout = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pagingControlTimeout;
+};
+ScrollableView.prototype.setPagingControlTimeout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pagingControlTimeout = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPagingControlAlpha = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pagingControlAlpha;
+};
+ScrollableView.prototype.setPagingControlAlpha = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pagingControlAlpha = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getPagingControlOnTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pagingControlOnTop;
+};
+ScrollableView.prototype.setPagingControlOnTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pagingControlOnTop = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getOverlayEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overlayEnabled;
+};
+ScrollableView.prototype.setOverlayEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overlayEnabled = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getScrollingEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollingEnabled;
+};
+ScrollableView.prototype.setScrollingEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollingEnabled = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getViews = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.views;
+};
+ScrollableView.prototype.setViews = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.views = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getClipViews = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipViews;
+};
+ScrollableView.prototype.setClipViews = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipViews = __SLAG__PROPERTY;
+};
+ScrollableView.prototype.getHitRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hitRect;
+};
+ScrollableView.prototype.setHitRect = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hitRect = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ScrollableView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/SearchBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/SearchBar.js
@@ -1,0 +1,1842 @@
+var crypto = require('crypto');
+function SearchBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'autocapitalization',
+			'autocorrect',
+			'barColor',
+			'cancelButtonTitle',
+			'hintText',
+			'hinttextid',
+			'keyboardType',
+			'keyboardAppearance',
+			'prompt',
+			'promptid',
+			'showBookmark',
+			'showCancel',
+			'style',
+			'value',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.SearchBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.SearchBar';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.SearchBar.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.SearchBar.children is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.SearchBar.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.SearchBar.size is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autocapitalization = undefined;
+	} else {
+		this.autocapitalization = __SLAG_PROPERTIES.autocapitalization || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autocorrect = undefined;
+	} else {
+		this.autocorrect = __SLAG_PROPERTIES.autocorrect || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancelButtonTitle = undefined;
+	} else {
+		this.cancelButtonTitle = __SLAG_PROPERTIES.cancelButtonTitle || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hintText = undefined;
+	} else {
+		this.hintText = __SLAG_PROPERTIES.hintText || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hinttextid = undefined;
+	} else {
+		this.hinttextid = __SLAG_PROPERTIES.hinttextid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardType = undefined;
+	} else {
+		this.keyboardType = __SLAG_PROPERTIES.keyboardType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardAppearance = undefined;
+	} else {
+		this.keyboardAppearance = __SLAG_PROPERTIES.keyboardAppearance || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prompt = undefined;
+	} else {
+		this.prompt = __SLAG_PROPERTIES.prompt || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.promptid = undefined;
+	} else {
+		this.promptid = __SLAG_PROPERTIES.promptid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showBookmark = undefined;
+	} else {
+		this.showBookmark = __SLAG_PROPERTIES.showBookmark || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showCancel = undefined;
+	} else {
+		this.showCancel = __SLAG_PROPERTIES.showCancel || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SearchBar.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SearchBar.prototype.animate = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.SearchBar.finishLayout was deprecated, since 3.0.0');
+};
+SearchBar.prototype.hide = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+SearchBar.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.show = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.startLayout = function () {
+	throw new Error('Ti.UI.SearchBar.startLayout was deprecated, since 3.0.0');
+};
+SearchBar.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+SearchBar.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.SearchBar.updateLayout was deprecated, since 3.0.0');
+};
+SearchBar.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+SearchBar.prototype.blur = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.focus = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SearchBar.prototype.setShowCancel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showCancel = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SearchBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SearchBar.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+SearchBar.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+SearchBar.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+SearchBar.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+SearchBar.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+SearchBar.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+SearchBar.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+SearchBar.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+SearchBar.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+SearchBar.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+SearchBar.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+SearchBar.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+SearchBar.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+SearchBar.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+SearchBar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+SearchBar.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+SearchBar.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundSelectedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+SearchBar.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundSelectedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+SearchBar.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+SearchBar.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+SearchBar.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+SearchBar.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+SearchBar.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+SearchBar.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+SearchBar.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+SearchBar.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+SearchBar.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+SearchBar.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+SearchBar.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+SearchBar.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+SearchBar.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+SearchBar.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+SearchBar.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+SearchBar.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+SearchBar.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+SearchBar.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+SearchBar.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+SearchBar.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+SearchBar.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+SearchBar.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+SearchBar.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+SearchBar.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+SearchBar.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+SearchBar.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+SearchBar.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+SearchBar.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+SearchBar.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+SearchBar.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+SearchBar.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+SearchBar.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+SearchBar.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+SearchBar.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+SearchBar.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+SearchBar.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+SearchBar.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+SearchBar.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+SearchBar.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+SearchBar.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+SearchBar.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+SearchBar.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+SearchBar.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+SearchBar.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAutocapitalization = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autocapitalization;
+};
+SearchBar.prototype.setAutocapitalization = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autocapitalization = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getAutocorrect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autocorrect;
+};
+SearchBar.prototype.setAutocorrect = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autocorrect = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getBarColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+SearchBar.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getCancelButtonTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cancelButtonTitle;
+};
+SearchBar.prototype.setCancelButtonTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cancelButtonTitle = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getHintText = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hintText;
+};
+SearchBar.prototype.setHintText = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hintText = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getHinttextid = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hinttextid;
+};
+SearchBar.prototype.setHinttextid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hinttextid = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getKeyboardType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardType;
+};
+SearchBar.prototype.setKeyboardType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardType = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getKeyboardAppearance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardAppearance;
+};
+SearchBar.prototype.setKeyboardAppearance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardAppearance = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getPrompt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prompt;
+};
+SearchBar.prototype.setPrompt = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prompt = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getPromptid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.promptid;
+};
+SearchBar.prototype.setPromptid = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.promptid = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getShowBookmark = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showBookmark;
+};
+SearchBar.prototype.setShowBookmark = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showBookmark = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getShowCancel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showCancel;
+};
+SearchBar.prototype.setShowCancel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showCancel = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+SearchBar.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+SearchBar.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+SearchBar.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SearchBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Slider.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Slider.js
@@ -1,0 +1,2075 @@
+var crypto = require('crypto');
+function Slider(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'disabledLeftTrackImage',
+			'disabledRightTrackImage',
+			'disabledThumbImage',
+			'enabled',
+			'highlightedLeftTrackImage',
+			'highlightedRightTrackImage',
+			'highlightedThumbImage',
+			'leftTrackImage',
+			'leftTrackLeftCap',
+			'leftTrackTopCap',
+			'max',
+			'maxRange',
+			'min',
+			'minRange',
+			'rightTrackImage',
+			'rightTrackLeftCap',
+			'rightTrackTopCap',
+			'selectedLeftTrackImage',
+			'selectedRightTrackImage',
+			'selectedThumbImage',
+			'thumbImage',
+			'value',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Slider.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Slider';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.Slider.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Slider.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Slider.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Slider.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disabledLeftTrackImage = undefined;
+	} else {
+		this.disabledLeftTrackImage = __SLAG_PROPERTIES.disabledLeftTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disabledRightTrackImage = undefined;
+	} else {
+		this.disabledRightTrackImage = __SLAG_PROPERTIES.disabledRightTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disabledThumbImage = undefined;
+	} else {
+		this.disabledThumbImage = __SLAG_PROPERTIES.disabledThumbImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enabled = undefined;
+	} else {
+		this.enabled = __SLAG_PROPERTIES.enabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.highlightedLeftTrackImage = undefined;
+	} else {
+		this.highlightedLeftTrackImage = __SLAG_PROPERTIES.highlightedLeftTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.highlightedRightTrackImage = undefined;
+	} else {
+		this.highlightedRightTrackImage = __SLAG_PROPERTIES.highlightedRightTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.highlightedThumbImage = undefined;
+	} else {
+		this.highlightedThumbImage = __SLAG_PROPERTIES.highlightedThumbImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftTrackImage = undefined;
+	} else {
+		this.leftTrackImage = __SLAG_PROPERTIES.leftTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftTrackLeftCap = undefined;
+	} else {
+		this.leftTrackLeftCap = __SLAG_PROPERTIES.leftTrackLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftTrackTopCap = undefined;
+	} else {
+		this.leftTrackTopCap = __SLAG_PROPERTIES.leftTrackTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.max = undefined;
+	} else {
+		this.max = __SLAG_PROPERTIES.max || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxRange = undefined;
+	} else {
+		this.maxRange = __SLAG_PROPERTIES.maxRange || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.min = undefined;
+	} else {
+		this.min = __SLAG_PROPERTIES.min || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minRange = undefined;
+	} else {
+		this.minRange = __SLAG_PROPERTIES.minRange || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightTrackImage = undefined;
+	} else {
+		this.rightTrackImage = __SLAG_PROPERTIES.rightTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightTrackLeftCap = undefined;
+	} else {
+		this.rightTrackLeftCap = __SLAG_PROPERTIES.rightTrackLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightTrackTopCap = undefined;
+	} else {
+		this.rightTrackTopCap = __SLAG_PROPERTIES.rightTrackTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedLeftTrackImage = undefined;
+	} else {
+		this.selectedLeftTrackImage = __SLAG_PROPERTIES.selectedLeftTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedRightTrackImage = undefined;
+	} else {
+		this.selectedRightTrackImage = __SLAG_PROPERTIES.selectedRightTrackImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedThumbImage = undefined;
+	} else {
+		this.selectedThumbImage = __SLAG_PROPERTIES.selectedThumbImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.thumbImage = undefined;
+	} else {
+		this.thumbImage = __SLAG_PROPERTIES.thumbImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Slider.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Slider.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Slider.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Slider.finishLayout was deprecated, since 3.0.0');
+};
+Slider.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Slider.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Slider.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Slider.startLayout was deprecated, since 3.0.0');
+};
+Slider.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Slider.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Slider.updateLayout was deprecated, since 3.0.0');
+};
+Slider.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Slider.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Slider.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Slider.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Slider.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Slider.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Slider.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Slider.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Slider.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Slider.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Slider.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Slider.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Slider.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Slider.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Slider.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Slider.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Slider.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Slider.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Slider.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Slider.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+Slider.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+Slider.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+Slider.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+Slider.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Slider.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Slider.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+Slider.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+Slider.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+Slider.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+Slider.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+Slider.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+Slider.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Slider.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Slider.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Slider.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Slider.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Slider.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Slider.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Slider.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Slider.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Slider.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Slider.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Slider.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Slider.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Slider.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Slider.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Slider.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+Slider.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+Slider.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Slider.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Slider.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+Slider.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+Slider.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Slider.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Slider.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Slider.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Slider.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Slider.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Slider.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Slider.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Slider.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Slider.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Slider.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Slider.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Slider.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Slider.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Slider.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Slider.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Slider.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Slider.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Slider.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Slider.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Slider.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Slider.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+Slider.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+Slider.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Slider.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Slider.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Slider.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Slider.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Slider.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Slider.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Slider.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Slider.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Slider.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Slider.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Slider.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Slider.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Slider.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Slider.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Slider.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Slider.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Slider.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Slider.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Slider.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Slider.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Slider.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Slider.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Slider.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Slider.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Slider.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Slider.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Slider.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Slider.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Slider.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+Slider.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+Slider.prototype.getDisabledLeftTrackImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disabledLeftTrackImage;
+};
+Slider.prototype.setDisabledLeftTrackImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disabledLeftTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getDisabledRightTrackImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disabledRightTrackImage;
+};
+Slider.prototype.setDisabledRightTrackImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disabledRightTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getDisabledThumbImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disabledThumbImage;
+};
+Slider.prototype.setDisabledThumbImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disabledThumbImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enabled;
+};
+Slider.prototype.setEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enabled = __SLAG__PROPERTY;
+};
+Slider.prototype.getHighlightedLeftTrackImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.highlightedLeftTrackImage;
+};
+Slider.prototype.setHighlightedLeftTrackImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.highlightedLeftTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getHighlightedRightTrackImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.highlightedRightTrackImage;
+};
+Slider.prototype.setHighlightedRightTrackImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.highlightedRightTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getHighlightedThumbImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.highlightedThumbImage;
+};
+Slider.prototype.setHighlightedThumbImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.highlightedThumbImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getLeftTrackImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftTrackImage;
+};
+Slider.prototype.setLeftTrackImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getLeftTrackLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftTrackLeftCap;
+};
+Slider.prototype.setLeftTrackLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftTrackLeftCap = __SLAG__PROPERTY;
+};
+Slider.prototype.getLeftTrackTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftTrackTopCap;
+};
+Slider.prototype.setLeftTrackTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftTrackTopCap = __SLAG__PROPERTY;
+};
+Slider.prototype.getMax = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.max;
+};
+Slider.prototype.setMax = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.max = __SLAG__PROPERTY;
+};
+Slider.prototype.getMaxRange = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxRange;
+};
+Slider.prototype.setMaxRange = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxRange = __SLAG__PROPERTY;
+};
+Slider.prototype.getMin = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.min;
+};
+Slider.prototype.setMin = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.min = __SLAG__PROPERTY;
+};
+Slider.prototype.getMinRange = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minRange;
+};
+Slider.prototype.setMinRange = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minRange = __SLAG__PROPERTY;
+};
+Slider.prototype.getRightTrackImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightTrackImage;
+};
+Slider.prototype.setRightTrackImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getRightTrackLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightTrackLeftCap;
+};
+Slider.prototype.setRightTrackLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightTrackLeftCap = __SLAG__PROPERTY;
+};
+Slider.prototype.getRightTrackTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightTrackTopCap;
+};
+Slider.prototype.setRightTrackTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightTrackTopCap = __SLAG__PROPERTY;
+};
+Slider.prototype.getSelectedLeftTrackImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedLeftTrackImage;
+};
+Slider.prototype.setSelectedLeftTrackImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedLeftTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getSelectedRightTrackImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedRightTrackImage;
+};
+Slider.prototype.setSelectedRightTrackImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedRightTrackImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getSelectedThumbImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedThumbImage;
+};
+Slider.prototype.setSelectedThumbImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedThumbImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getThumbImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.thumbImage;
+};
+Slider.prototype.setThumbImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.thumbImage = __SLAG__PROPERTY;
+};
+Slider.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+module.exports = function (properties) {
+	return new Slider(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Switch.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Switch.js
@@ -1,0 +1,1937 @@
+var crypto = require('crypto');
+function Switch(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'animated',
+			'color',
+			'enabled',
+			'font',
+			'style',
+			'textAlign',
+			'title',
+			'titleOff',
+			'titleOn',
+			'onTintColor',
+			'thumbTintColor',
+			'value',
+			'verticalAlign',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Switch.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Switch';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.Switch.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Switch.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Switch.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Switch.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enabled = undefined;
+	} else {
+		this.enabled = __SLAG_PROPERTIES.enabled || true;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textAlign = undefined;
+	} else {
+		this.textAlign = __SLAG_PROPERTIES.textAlign || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleOff = undefined;
+	} else {
+		this.titleOff = __SLAG_PROPERTIES.titleOff || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleOn = undefined;
+	} else {
+		this.titleOn = __SLAG_PROPERTIES.titleOn || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onTintColor = undefined;
+	} else {
+		this.onTintColor = __SLAG_PROPERTIES.onTintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.thumbTintColor = undefined;
+	} else {
+		this.thumbTintColor = __SLAG_PROPERTIES.thumbTintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || true;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.verticalAlign = undefined;
+	} else {
+		this.verticalAlign = __SLAG_PROPERTIES.verticalAlign || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Switch.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Switch.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Switch.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Switch.finishLayout was deprecated, since 3.0.0');
+};
+Switch.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Switch.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Switch.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Switch.startLayout was deprecated, since 3.0.0');
+};
+Switch.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Switch.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Switch.updateLayout was deprecated, since 3.0.0');
+};
+Switch.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Switch.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Switch.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Switch.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Switch.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Switch.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Switch.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Switch.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Switch.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Switch.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Switch.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Switch.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Switch.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Switch.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Switch.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Switch.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Switch.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Switch.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Switch.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+Switch.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+Switch.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+Switch.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+Switch.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Switch.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Switch.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+Switch.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+Switch.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+Switch.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+Switch.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+Switch.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+Switch.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+Switch.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Switch.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Switch.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Switch.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Switch.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Switch.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Switch.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Switch.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Switch.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Switch.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Switch.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Switch.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Switch.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Switch.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Switch.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Switch.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+Switch.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+Switch.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Switch.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Switch.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Switch.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Switch.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+Switch.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+Switch.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Switch.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Switch.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Switch.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Switch.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Switch.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Switch.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Switch.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Switch.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Switch.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Switch.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Switch.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Switch.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Switch.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Switch.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Switch.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Switch.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Switch.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Switch.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Switch.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Switch.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Switch.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+Switch.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+Switch.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Switch.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Switch.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Switch.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Switch.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Switch.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Switch.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Switch.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Switch.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Switch.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Switch.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Switch.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Switch.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Switch.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Switch.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Switch.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Switch.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Switch.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Switch.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Switch.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Switch.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Switch.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Switch.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Switch.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Switch.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Switch.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Switch.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Switch.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Switch.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+Switch.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+Switch.prototype.getAnimated = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animated;
+};
+Switch.prototype.setAnimated = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.animated = __SLAG__PROPERTY;
+};
+Switch.prototype.getColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+Switch.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+Switch.prototype.getEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enabled;
+};
+Switch.prototype.setEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enabled = __SLAG__PROPERTY;
+};
+Switch.prototype.getFont = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+Switch.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+Switch.prototype.getStyle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+Switch.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+Switch.prototype.getTextAlign = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textAlign;
+};
+Switch.prototype.setTextAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.textAlign = __SLAG__PROPERTY;
+};
+Switch.prototype.getTitle = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+Switch.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+Switch.prototype.getTitleOff = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleOff;
+};
+Switch.prototype.setTitleOff = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleOff = __SLAG__PROPERTY;
+};
+Switch.prototype.getTitleOn = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleOn;
+};
+Switch.prototype.setTitleOn = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleOn = __SLAG__PROPERTY;
+};
+Switch.prototype.getOnTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onTintColor;
+};
+Switch.prototype.setOnTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onTintColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getThumbTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.thumbTintColor;
+};
+Switch.prototype.setThumbTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.thumbTintColor = __SLAG__PROPERTY;
+};
+Switch.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+Switch.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Switch.prototype.getVerticalAlign = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.verticalAlign;
+};
+Switch.prototype.setVerticalAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.verticalAlign = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Switch(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Tab.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Tab.js
@@ -1,0 +1,972 @@
+var crypto = require('crypto');
+function Tab(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundImage',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'clipMode',
+			'elevation',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'tintColor',
+			'touchEnabled',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'active',
+			'activeIcon',
+			'badge',
+			'icon',
+			'iconInsets',
+			'iconIsMask',
+			'activeIconIsMask',
+			'title',
+			'titleid',
+			'titleColor',
+			'activeTitleColor',
+			'window',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Tab.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Tab';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.active = undefined;
+	} else {
+		this.active = __SLAG_PROPERTIES.active || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeIcon = undefined;
+	} else {
+		this.activeIcon = __SLAG_PROPERTIES.activeIcon || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.badge = undefined;
+	} else {
+		this.badge = __SLAG_PROPERTIES.badge || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.icon = undefined;
+	} else {
+		this.icon = __SLAG_PROPERTIES.icon || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.iconInsets = undefined;
+	} else {
+		this.iconInsets = __SLAG_PROPERTIES.iconInsets || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.iconIsMask = undefined;
+	} else {
+		this.iconIsMask = __SLAG_PROPERTIES.iconIsMask || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeIconIsMask = undefined;
+	} else {
+		this.activeIconIsMask = __SLAG_PROPERTIES.activeIconIsMask || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleColor = undefined;
+	} else {
+		this.titleColor = __SLAG_PROPERTIES.titleColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTitleColor = undefined;
+	} else {
+		this.activeTitleColor = __SLAG_PROPERTIES.activeTitleColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.window = undefined;
+	} else {
+		this.window = __SLAG_PROPERTIES.window || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Tab.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Tab.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Tab.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Tab.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Tab.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Tab.finishLayout was deprecated, since 3.0.0');
+};
+Tab.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Tab.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Tab.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Tab.startLayout was deprecated, since 3.0.0');
+};
+Tab.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Tab.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Tab.updateLayout was deprecated, since 3.0.0');
+};
+Tab.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Tab.prototype.open = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Tab.prototype.close = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Tab.prototype.setWindow = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.window = __SLAG__PROPERTY;
+};
+Tab.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Tab.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Tab.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Tab.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Tab.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Tab.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundDisabledColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+Tab.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundDisabledImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+Tab.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundFocusedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+Tab.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundFocusedImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+Tab.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Tab.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+Tab.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getBackgroundSelectedImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+Tab.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+Tab.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Tab.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Tab.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Tab.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Tab.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Tab.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Tab.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Tab.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Tab.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Tab.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Tab.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Tab.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Tab.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Tab.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Tab.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Tab.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Tab.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Tab.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Tab.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Tab.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Tab.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getTouchEnabled = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Tab.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Tab.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Tab.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Tab.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Tab.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Tab.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Tab.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Tab.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Tab.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Tab.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Tab.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Tab.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Tab.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Tab.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Tab.prototype.getActive = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.active;
+};
+Tab.prototype.setActive = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.active = __SLAG__PROPERTY;
+};
+Tab.prototype.getActiveIcon = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeIcon;
+};
+Tab.prototype.setActiveIcon = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeIcon = __SLAG__PROPERTY;
+};
+Tab.prototype.getBadge = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.badge;
+};
+Tab.prototype.setBadge = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.badge = __SLAG__PROPERTY;
+};
+Tab.prototype.getIcon = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.icon;
+};
+Tab.prototype.setIcon = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.icon = __SLAG__PROPERTY;
+};
+Tab.prototype.getIconInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.iconInsets;
+};
+Tab.prototype.setIconInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.iconInsets = __SLAG__PROPERTY;
+};
+Tab.prototype.getIconIsMask = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.iconIsMask;
+};
+Tab.prototype.setIconIsMask = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.iconIsMask = __SLAG__PROPERTY;
+};
+Tab.prototype.getActiveIconIsMask = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeIconIsMask;
+};
+Tab.prototype.setActiveIconIsMask = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeIconIsMask = __SLAG__PROPERTY;
+};
+Tab.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+Tab.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+Tab.prototype.getTitleid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+Tab.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+Tab.prototype.getTitleColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleColor;
+};
+Tab.prototype.setTitleColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getActiveTitleColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTitleColor;
+};
+Tab.prototype.setActiveTitleColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTitleColor = __SLAG__PROPERTY;
+};
+Tab.prototype.getWindow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.window;
+};
+module.exports = function (properties) {
+	return new Tab(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/TabGroup.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/TabGroup.js
@@ -1,0 +1,1482 @@
+var crypto = require('crypto');
+function TabGroup(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'center',
+			'clipMode',
+			'elevation',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'tintColor',
+			'touchEnabled',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'keepScreenOn',
+			'activeTab',
+			'activity',
+			'allowUserCustomization',
+			'barColor',
+			'translucent',
+			'titleAttributes',
+			'navTintColor',
+			'editButtonTitle',
+			'exitOnClose',
+			'swipeable',
+			'smoothScrollOnTabClick',
+			'tabs',
+			'windowSoftInputMode',
+			'tabsBackgroundColor',
+			'tabsTintColor',
+			'title',
+			'tabsBackgroundImage',
+			'shadowImage',
+			'activeTabIconTint',
+			'tabsBackgroundDisabledColor',
+			'tabsBackgroundDisabledImage',
+			'tabsBackgroundFocusedColor',
+			'tabsBackgroundFocusedImage',
+			'tabsBackgroundSelectedColor',
+			'tabsBackgroundSelectedImage',
+			'activeTabBackgroundColor',
+			'activeTabBackgroundImage',
+			'activeTabBackgroundDisabledColor',
+			'activeTabBackgroundDisabledImage',
+			'activeTabBackgroundFocusedColor',
+			'activeTabBackgroundFocusedImage',
+			'activeTabBackgroundSelectedColor',
+			'activeTabBackgroundSelectedImage',
+			'tabDividerColor',
+			'tabDividerWidth',
+			'tabHeight',
+			'tabsAtBottom',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.TabGroup.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.TabGroup';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.TabGroup.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.TabGroup.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTab = undefined;
+	} else {
+		this.activeTab = __SLAG_PROPERTIES.activeTab || {};
+	}
+	if (__SLAG_PROPERTIES.activity) {
+		throw new Error('Ti.UI.TabGroup.activity is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activity = undefined;
+	} else {
+		this.activity = {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowUserCustomization = undefined;
+	} else {
+		this.allowUserCustomization = __SLAG_PROPERTIES.allowUserCustomization || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translucent = undefined;
+	} else {
+		this.translucent = __SLAG_PROPERTIES.translucent || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleAttributes = undefined;
+	} else {
+		this.titleAttributes = __SLAG_PROPERTIES.titleAttributes || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navTintColor = undefined;
+	} else {
+		this.navTintColor = __SLAG_PROPERTIES.navTintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editButtonTitle = undefined;
+	} else {
+		this.editButtonTitle = __SLAG_PROPERTIES.editButtonTitle || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.exitOnClose = undefined;
+	} else {
+		this.exitOnClose = __SLAG_PROPERTIES.exitOnClose || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.swipeable = undefined;
+	} else {
+		this.swipeable = __SLAG_PROPERTIES.swipeable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.smoothScrollOnTabClick = undefined;
+	} else {
+		this.smoothScrollOnTabClick = __SLAG_PROPERTIES.smoothScrollOnTabClick || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabs = undefined;
+	} else {
+		this.tabs = __SLAG_PROPERTIES.tabs || [];
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.windowSoftInputMode = undefined;
+	} else {
+		this.windowSoftInputMode = __SLAG_PROPERTIES.windowSoftInputMode || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundColor = undefined;
+	} else {
+		this.tabsBackgroundColor = __SLAG_PROPERTIES.tabsBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsTintColor = undefined;
+	} else {
+		this.tabsTintColor = __SLAG_PROPERTIES.tabsTintColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundImage = undefined;
+	} else {
+		this.tabsBackgroundImage = __SLAG_PROPERTIES.tabsBackgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowImage = undefined;
+	} else {
+		this.shadowImage = __SLAG_PROPERTIES.shadowImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabIconTint = undefined;
+	} else {
+		this.activeTabIconTint = __SLAG_PROPERTIES.activeTabIconTint || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundDisabledColor = undefined;
+	} else {
+		this.tabsBackgroundDisabledColor = __SLAG_PROPERTIES.tabsBackgroundDisabledColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundDisabledImage = undefined;
+	} else {
+		this.tabsBackgroundDisabledImage = __SLAG_PROPERTIES.tabsBackgroundDisabledImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundFocusedColor = undefined;
+	} else {
+		this.tabsBackgroundFocusedColor = __SLAG_PROPERTIES.tabsBackgroundFocusedColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundFocusedImage = undefined;
+	} else {
+		this.tabsBackgroundFocusedImage = __SLAG_PROPERTIES.tabsBackgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundSelectedColor = undefined;
+	} else {
+		this.tabsBackgroundSelectedColor = __SLAG_PROPERTIES.tabsBackgroundSelectedColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsBackgroundSelectedImage = undefined;
+	} else {
+		this.tabsBackgroundSelectedImage = __SLAG_PROPERTIES.tabsBackgroundSelectedImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundColor = undefined;
+	} else {
+		this.activeTabBackgroundColor = __SLAG_PROPERTIES.activeTabBackgroundColor || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundImage = undefined;
+	} else {
+		this.activeTabBackgroundImage = __SLAG_PROPERTIES.activeTabBackgroundImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundDisabledColor = undefined;
+	} else {
+		this.activeTabBackgroundDisabledColor = __SLAG_PROPERTIES.activeTabBackgroundDisabledColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundDisabledImage = undefined;
+	} else {
+		this.activeTabBackgroundDisabledImage = __SLAG_PROPERTIES.activeTabBackgroundDisabledImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundFocusedColor = undefined;
+	} else {
+		this.activeTabBackgroundFocusedColor = __SLAG_PROPERTIES.activeTabBackgroundFocusedColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundFocusedImage = undefined;
+	} else {
+		this.activeTabBackgroundFocusedImage = __SLAG_PROPERTIES.activeTabBackgroundFocusedImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundSelectedColor = undefined;
+	} else {
+		this.activeTabBackgroundSelectedColor = __SLAG_PROPERTIES.activeTabBackgroundSelectedColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activeTabBackgroundSelectedImage = undefined;
+	} else {
+		this.activeTabBackgroundSelectedImage = __SLAG_PROPERTIES.activeTabBackgroundSelectedImage || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabDividerColor = undefined;
+	} else {
+		this.tabDividerColor = __SLAG_PROPERTIES.tabDividerColor || '';
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabDividerWidth = undefined;
+	} else {
+		this.tabDividerWidth = __SLAG_PROPERTIES.tabDividerWidth || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabHeight = undefined;
+	} else {
+		this.tabHeight = __SLAG_PROPERTIES.tabHeight || 0;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabsAtBottom = undefined;
+	} else {
+		this.tabsAtBottom = __SLAG_PROPERTIES.tabsAtBottom || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TabGroup.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TabGroup.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.TabGroup.finishLayout was deprecated, since 3.0.0');
+};
+TabGroup.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.startLayout = function () {
+	throw new Error('Ti.UI.TabGroup.startLayout was deprecated, since 3.0.0');
+};
+TabGroup.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TabGroup.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.TabGroup.updateLayout was deprecated, since 3.0.0');
+};
+TabGroup.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+TabGroup.prototype.addTab = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.close = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.disableTabNavigation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.getActiveTab = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTab;
+};
+TabGroup.prototype.open = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.removeTab = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabGroup.prototype.setActiveTab = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTab = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabs = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabs;
+};
+TabGroup.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TabGroup.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TabGroup.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TabGroup.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+TabGroup.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+TabGroup.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+TabGroup.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+TabGroup.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+TabGroup.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+TabGroup.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+TabGroup.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+TabGroup.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+TabGroup.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+TabGroup.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+TabGroup.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+TabGroup.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+TabGroup.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+TabGroup.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+TabGroup.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+TabGroup.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+TabGroup.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+TabGroup.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+TabGroup.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+TabGroup.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+TabGroup.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+TabGroup.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+TabGroup.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+TabGroup.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTab = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTab;
+};
+TabGroup.prototype.setActiveTab = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTab = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActivity = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activity;
+};
+TabGroup.prototype.getAllowUserCustomization = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowUserCustomization;
+};
+TabGroup.prototype.setAllowUserCustomization = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowUserCustomization = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getBarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+TabGroup.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTranslucent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translucent;
+};
+TabGroup.prototype.setTranslucent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translucent = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTitleAttributes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleAttributes;
+};
+TabGroup.prototype.setTitleAttributes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleAttributes = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getNavTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navTintColor;
+};
+TabGroup.prototype.setNavTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navTintColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getEditButtonTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editButtonTitle;
+};
+TabGroup.prototype.setEditButtonTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editButtonTitle = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getExitOnClose = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.exitOnClose;
+};
+TabGroup.prototype.setExitOnClose = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.exitOnClose = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getSwipeable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.swipeable;
+};
+TabGroup.prototype.setSwipeable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.swipeable = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getSmoothScrollOnTabClick = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.smoothScrollOnTabClick;
+};
+TabGroup.prototype.setSmoothScrollOnTabClick = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.smoothScrollOnTabClick = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabs = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabs;
+};
+TabGroup.prototype.setTabs = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabs = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getWindowSoftInputMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.windowSoftInputMode;
+};
+TabGroup.prototype.setWindowSoftInputMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.windowSoftInputMode = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundColor;
+};
+TabGroup.prototype.setTabsBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsTintColor;
+};
+TabGroup.prototype.setTabsTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsTintColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTitle = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+TabGroup.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundImage = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundImage;
+};
+TabGroup.prototype.setTabsBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getShadowImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowImage;
+};
+TabGroup.prototype.setShadowImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabIconTint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabIconTint;
+};
+TabGroup.prototype.setActiveTabIconTint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabIconTint = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundDisabledColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundDisabledColor;
+};
+TabGroup.prototype.setTabsBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundDisabledColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundDisabledImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundDisabledImage;
+};
+TabGroup.prototype.setTabsBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundDisabledImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundFocusedColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundFocusedColor;
+};
+TabGroup.prototype.setTabsBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundFocusedColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundFocusedImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundFocusedImage;
+};
+TabGroup.prototype.setTabsBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundFocusedImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundSelectedColor;
+};
+TabGroup.prototype.setTabsBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundSelectedColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsBackgroundSelectedImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsBackgroundSelectedImage;
+};
+TabGroup.prototype.setTabsBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsBackgroundSelectedImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundColor;
+};
+TabGroup.prototype.setActiveTabBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundImage = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundImage;
+};
+TabGroup.prototype.setActiveTabBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundDisabledColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundDisabledColor;
+};
+TabGroup.prototype.setActiveTabBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundDisabledColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundDisabledImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundDisabledImage;
+};
+TabGroup.prototype.setActiveTabBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundDisabledImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundFocusedColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundFocusedColor;
+};
+TabGroup.prototype.setActiveTabBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundFocusedColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundFocusedImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundFocusedImage;
+};
+TabGroup.prototype.setActiveTabBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundFocusedImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundSelectedColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundSelectedColor;
+};
+TabGroup.prototype.setActiveTabBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundSelectedColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getActiveTabBackgroundSelectedImage = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activeTabBackgroundSelectedImage;
+};
+TabGroup.prototype.setActiveTabBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activeTabBackgroundSelectedImage = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabDividerColor = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabDividerColor;
+};
+TabGroup.prototype.setTabDividerColor = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabDividerColor = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabDividerWidth = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabDividerWidth;
+};
+TabGroup.prototype.setTabDividerWidth = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabDividerWidth = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabHeight = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabHeight;
+};
+TabGroup.prototype.setTabHeight = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabHeight = __SLAG__PROPERTY;
+};
+TabGroup.prototype.getTabsAtBottom = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabsAtBottom;
+};
+TabGroup.prototype.setTabsAtBottom = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabsAtBottom = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TabGroup(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/TabbedBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/TabbedBar.js
@@ -1,0 +1,911 @@
+var crypto = require('crypto');
+function TabbedBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'index',
+			'labels',
+			'style',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.TabbedBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.TabbedBar';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.TabbedBar.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.TabbedBar.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.TabbedBar.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.TabbedBar.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.index = undefined;
+	} else {
+		this.index = __SLAG_PROPERTIES.index || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.labels = undefined;
+	} else {
+		this.labels = __SLAG_PROPERTIES.labels || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TabbedBar.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TabbedBar.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+TabbedBar.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.TabbedBar.finishLayout was deprecated, since 3.0.0');
+};
+TabbedBar.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+TabbedBar.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.startLayout = function () {
+	throw new Error('Ti.UI.TabbedBar.startLayout was deprecated, since 3.0.0');
+};
+TabbedBar.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TabbedBar.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.TabbedBar.updateLayout was deprecated, since 3.0.0');
+};
+TabbedBar.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+TabbedBar.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TabbedBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TabbedBar.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+TabbedBar.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+TabbedBar.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+TabbedBar.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+TabbedBar.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+TabbedBar.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+TabbedBar.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+TabbedBar.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+TabbedBar.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+TabbedBar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+TabbedBar.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+TabbedBar.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+TabbedBar.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+TabbedBar.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+TabbedBar.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+TabbedBar.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+TabbedBar.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+TabbedBar.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+TabbedBar.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+TabbedBar.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+TabbedBar.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+TabbedBar.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+TabbedBar.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+TabbedBar.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+TabbedBar.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+TabbedBar.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+TabbedBar.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+TabbedBar.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+TabbedBar.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+TabbedBar.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+TabbedBar.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+TabbedBar.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+TabbedBar.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+TabbedBar.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+TabbedBar.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+TabbedBar.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+TabbedBar.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+TabbedBar.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+TabbedBar.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+TabbedBar.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+TabbedBar.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.index;
+};
+TabbedBar.prototype.setIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.index = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getLabels = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.labels;
+};
+TabbedBar.prototype.setLabels = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.labels = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+TabbedBar.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TabbedBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/TableView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/TableView.js
@@ -1,0 +1,2594 @@
+var crypto = require('crypto');
+function TableView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'allowsSelection',
+			'allowsSelectionDuringEditing',
+			'data',
+			'editable',
+			'editing',
+			'filterAttribute',
+			'filterAnchored',
+			'filterCaseInsensitive',
+			'footerDividersEnabled',
+			'footerTitle',
+			'maxClassname',
+			'headerPullView',
+			'refreshControl',
+			'hideSearchOnSelection',
+			'footerView',
+			'headerDividersEnabled',
+			'headerTitle',
+			'headerView',
+			'index',
+			'maxRowHeight',
+			'minRowHeight',
+			'moveable',
+			'moving',
+			'overScrollMode',
+			'rowHeight',
+			'scrollable',
+			'scrollIndicatorStyle',
+			'scrollsToTop',
+			'search',
+			'searchAsChild',
+			'searchHidden',
+			'sectionCount',
+			'sections',
+			'separatorColor',
+			'separatorInsets',
+			'tableSeparatorInsets',
+			'rowSeparatorInsets',
+			'separatorStyle',
+			'showVerticalScrollIndicator',
+			'style',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.TableView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.TableView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.TableView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.TableView.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.TableView.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.TableView.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsSelection = undefined;
+	} else {
+		this.allowsSelection = __SLAG_PROPERTIES.allowsSelection || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsSelectionDuringEditing = undefined;
+	} else {
+		this.allowsSelectionDuringEditing = __SLAG_PROPERTIES.allowsSelectionDuringEditing || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editable = undefined;
+	} else {
+		this.editable = __SLAG_PROPERTIES.editable || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editing = undefined;
+	} else {
+		this.editing = __SLAG_PROPERTIES.editing || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.filterAttribute = undefined;
+	} else {
+		this.filterAttribute = __SLAG_PROPERTIES.filterAttribute || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.filterAnchored = undefined;
+	} else {
+		this.filterAnchored = __SLAG_PROPERTIES.filterAnchored || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.filterCaseInsensitive = undefined;
+	} else {
+		this.filterCaseInsensitive = __SLAG_PROPERTIES.filterCaseInsensitive || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerDividersEnabled = undefined;
+	} else {
+		this.footerDividersEnabled = __SLAG_PROPERTIES.footerDividersEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerTitle = undefined;
+	} else {
+		this.footerTitle = __SLAG_PROPERTIES.footerTitle || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxClassname = undefined;
+	} else {
+		this.maxClassname = __SLAG_PROPERTIES.maxClassname || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerPullView = undefined;
+	} else {
+		this.headerPullView = __SLAG_PROPERTIES.headerPullView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.refreshControl = undefined;
+	} else {
+		this.refreshControl = __SLAG_PROPERTIES.refreshControl || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hideSearchOnSelection = undefined;
+	} else {
+		this.hideSearchOnSelection = __SLAG_PROPERTIES.hideSearchOnSelection || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerView = undefined;
+	} else {
+		this.footerView = __SLAG_PROPERTIES.footerView || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerDividersEnabled = undefined;
+	} else {
+		this.headerDividersEnabled = __SLAG_PROPERTIES.headerDividersEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerTitle = undefined;
+	} else {
+		this.headerTitle = __SLAG_PROPERTIES.headerTitle || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerView = undefined;
+	} else {
+		this.headerView = __SLAG_PROPERTIES.headerView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.index = undefined;
+	} else {
+		this.index = __SLAG_PROPERTIES.index || [];
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxRowHeight = undefined;
+	} else {
+		this.maxRowHeight = __SLAG_PROPERTIES.maxRowHeight || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minRowHeight = undefined;
+	} else {
+		this.minRowHeight = __SLAG_PROPERTIES.minRowHeight || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.moveable = undefined;
+	} else {
+		this.moveable = __SLAG_PROPERTIES.moveable || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.moving = undefined;
+	} else {
+		this.moving = __SLAG_PROPERTIES.moving || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overScrollMode = undefined;
+	} else {
+		this.overScrollMode = __SLAG_PROPERTIES.overScrollMode || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowHeight = undefined;
+	} else {
+		this.rowHeight = __SLAG_PROPERTIES.rowHeight || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollable = undefined;
+	} else {
+		this.scrollable = __SLAG_PROPERTIES.scrollable || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollIndicatorStyle = undefined;
+	} else {
+		this.scrollIndicatorStyle = __SLAG_PROPERTIES.scrollIndicatorStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollsToTop = undefined;
+	} else {
+		this.scrollsToTop = __SLAG_PROPERTIES.scrollsToTop || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.search = undefined;
+	} else {
+		this.search = __SLAG_PROPERTIES.search || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.searchAsChild = undefined;
+	} else {
+		this.searchAsChild = __SLAG_PROPERTIES.searchAsChild || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.searchHidden = undefined;
+	} else {
+		this.searchHidden = __SLAG_PROPERTIES.searchHidden || true;
+	}
+	if (__SLAG_PROPERTIES.sectionCount) {
+		throw new Error('Ti.UI.TableView.sectionCount is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sectionCount = undefined;
+	} else {
+		this.sectionCount = 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.sections = undefined;
+	} else {
+		this.sections = __SLAG_PROPERTIES.sections || [];
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.separatorColor = undefined;
+	} else {
+		this.separatorColor = __SLAG_PROPERTIES.separatorColor || '';
+	}
+	if (__SLAG_PROPERTIES.separatorInsets) {
+		throw new Error('Ti.UI.TableView.separatorInsets was deprecated, since 5.2.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tableSeparatorInsets = undefined;
+	} else {
+		this.tableSeparatorInsets = __SLAG_PROPERTIES.tableSeparatorInsets || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowSeparatorInsets = undefined;
+	} else {
+		this.rowSeparatorInsets = __SLAG_PROPERTIES.rowSeparatorInsets || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.separatorStyle = undefined;
+	} else {
+		this.separatorStyle = __SLAG_PROPERTIES.separatorStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showVerticalScrollIndicator = undefined;
+	} else {
+		this.showVerticalScrollIndicator = __SLAG_PROPERTIES.showVerticalScrollIndicator || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableView.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+TableView.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.TableView.finishLayout was deprecated, since 3.0.0');
+};
+TableView.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+TableView.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.TableView.startLayout was deprecated, since 3.0.0');
+};
+TableView.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TableView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.TableView.updateLayout was deprecated, since 3.0.0');
+};
+TableView.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+TableView.prototype.appendRow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.appendSection = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.deleteRow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.deleteSection = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.deselectRow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.insertRowAfter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.insertSectionAfter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.insertRowBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.insertSectionBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.scrollToIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.scrollToTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.setContentInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.setContentOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.selectRow = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+TableView.prototype.setHeaderPullView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerPullView = __SLAG__PROPERTY;
+};
+TableView.prototype.updateRow = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.updateSection = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableView.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableView.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TableView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TableView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TableView.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+TableView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+TableView.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+TableView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+TableView.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+TableView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+TableView.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+TableView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+TableView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+TableView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+TableView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+TableView.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+TableView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+TableView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+TableView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+TableView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+TableView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+TableView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+TableView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+TableView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+TableView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+TableView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+TableView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+TableView.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+TableView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+TableView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+TableView.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+TableView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+TableView.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+TableView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+TableView.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+TableView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+TableView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+TableView.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+TableView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+TableView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+TableView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+TableView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+TableView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+TableView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+TableView.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+TableView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+TableView.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+TableView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+TableView.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+TableView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+TableView.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+TableView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+TableView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+TableView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+TableView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+TableView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+TableView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+TableView.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+TableView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+TableView.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+TableView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+TableView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+TableView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+TableView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+TableView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+TableView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+TableView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+TableView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+TableView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+TableView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+TableView.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+TableView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+TableView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+TableView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+TableView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+TableView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+TableView.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+TableView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+TableView.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+TableView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+TableView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+TableView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+TableView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+TableView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+TableView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+TableView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+TableView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+TableView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+TableView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+TableView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+TableView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+TableView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+TableView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+TableView.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+TableView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+TableView.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+TableView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+TableView.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+TableView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+TableView.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+TableView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+TableView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+TableView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+TableView.prototype.getAllowsSelection = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsSelection;
+};
+TableView.prototype.setAllowsSelection = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsSelection = __SLAG__PROPERTY;
+};
+TableView.prototype.getAllowsSelectionDuringEditing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsSelectionDuringEditing;
+};
+TableView.prototype.setAllowsSelectionDuringEditing = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsSelectionDuringEditing = __SLAG__PROPERTY;
+};
+TableView.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+TableView.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+TableView.prototype.getEditable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editable;
+};
+TableView.prototype.setEditable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editable = __SLAG__PROPERTY;
+};
+TableView.prototype.getEditing = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editing;
+};
+TableView.prototype.setEditing = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editing = __SLAG__PROPERTY;
+};
+TableView.prototype.getFilterAttribute = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.filterAttribute;
+};
+TableView.prototype.setFilterAttribute = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.filterAttribute = __SLAG__PROPERTY;
+};
+TableView.prototype.getFilterAnchored = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.filterAnchored;
+};
+TableView.prototype.setFilterAnchored = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.filterAnchored = __SLAG__PROPERTY;
+};
+TableView.prototype.getFilterCaseInsensitive = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.filterCaseInsensitive;
+};
+TableView.prototype.setFilterCaseInsensitive = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.filterCaseInsensitive = __SLAG__PROPERTY;
+};
+TableView.prototype.getFooterDividersEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerDividersEnabled;
+};
+TableView.prototype.setFooterDividersEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerDividersEnabled = __SLAG__PROPERTY;
+};
+TableView.prototype.getFooterTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerTitle;
+};
+TableView.prototype.setFooterTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerTitle = __SLAG__PROPERTY;
+};
+TableView.prototype.getMaxClassname = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxClassname;
+};
+TableView.prototype.setMaxClassname = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxClassname = __SLAG__PROPERTY;
+};
+TableView.prototype.getHeaderPullView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerPullView;
+};
+TableView.prototype.setHeaderPullView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerPullView = __SLAG__PROPERTY;
+};
+TableView.prototype.getRefreshControl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.refreshControl;
+};
+TableView.prototype.setRefreshControl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.refreshControl = __SLAG__PROPERTY;
+};
+TableView.prototype.getHideSearchOnSelection = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hideSearchOnSelection;
+};
+TableView.prototype.setHideSearchOnSelection = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hideSearchOnSelection = __SLAG__PROPERTY;
+};
+TableView.prototype.getFooterView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerView;
+};
+TableView.prototype.setFooterView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerView = __SLAG__PROPERTY;
+};
+TableView.prototype.getHeaderDividersEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerDividersEnabled;
+};
+TableView.prototype.setHeaderDividersEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerDividersEnabled = __SLAG__PROPERTY;
+};
+TableView.prototype.getHeaderTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerTitle;
+};
+TableView.prototype.setHeaderTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerTitle = __SLAG__PROPERTY;
+};
+TableView.prototype.getHeaderView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerView;
+};
+TableView.prototype.setHeaderView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerView = __SLAG__PROPERTY;
+};
+TableView.prototype.getIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.index;
+};
+TableView.prototype.setIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.index = __SLAG__PROPERTY;
+};
+TableView.prototype.getMaxRowHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxRowHeight;
+};
+TableView.prototype.setMaxRowHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxRowHeight = __SLAG__PROPERTY;
+};
+TableView.prototype.getMinRowHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minRowHeight;
+};
+TableView.prototype.setMinRowHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minRowHeight = __SLAG__PROPERTY;
+};
+TableView.prototype.getMoveable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.moveable;
+};
+TableView.prototype.setMoveable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.moveable = __SLAG__PROPERTY;
+};
+TableView.prototype.getMoving = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.moving;
+};
+TableView.prototype.setMoving = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.moving = __SLAG__PROPERTY;
+};
+TableView.prototype.getOverScrollMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overScrollMode;
+};
+TableView.prototype.setOverScrollMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overScrollMode = __SLAG__PROPERTY;
+};
+TableView.prototype.getRowHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowHeight;
+};
+TableView.prototype.setRowHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rowHeight = __SLAG__PROPERTY;
+};
+TableView.prototype.getScrollable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollable;
+};
+TableView.prototype.setScrollable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollable = __SLAG__PROPERTY;
+};
+TableView.prototype.getScrollIndicatorStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollIndicatorStyle;
+};
+TableView.prototype.setScrollIndicatorStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollIndicatorStyle = __SLAG__PROPERTY;
+};
+TableView.prototype.getScrollsToTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollsToTop;
+};
+TableView.prototype.setScrollsToTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollsToTop = __SLAG__PROPERTY;
+};
+TableView.prototype.getSearch = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.search;
+};
+TableView.prototype.setSearch = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.search = __SLAG__PROPERTY;
+};
+TableView.prototype.getSearchAsChild = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.searchAsChild;
+};
+TableView.prototype.setSearchAsChild = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.searchAsChild = __SLAG__PROPERTY;
+};
+TableView.prototype.getSearchHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.searchHidden;
+};
+TableView.prototype.setSearchHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.searchHidden = __SLAG__PROPERTY;
+};
+TableView.prototype.getSectionCount = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sectionCount;
+};
+TableView.prototype.getSections = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.sections;
+};
+TableView.prototype.setSections = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.sections = __SLAG__PROPERTY;
+};
+TableView.prototype.getSeparatorColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.separatorColor;
+};
+TableView.prototype.setSeparatorColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.separatorColor = __SLAG__PROPERTY;
+};
+TableView.prototype.getSeparatorInsets = function () {
+	throw new Error('Ti.UI.TableView.getSeparatorInsets was deprecated, since 5.2.0');
+};
+TableView.prototype.setSeparatorInsets = function () {
+	throw new Error('Ti.UI.TableView.setSeparatorInsets was deprecated, since 5.2.0');
+};
+TableView.prototype.getTableSeparatorInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tableSeparatorInsets;
+};
+TableView.prototype.setTableSeparatorInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tableSeparatorInsets = __SLAG__PROPERTY;
+};
+TableView.prototype.getRowSeparatorInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowSeparatorInsets;
+};
+TableView.prototype.setRowSeparatorInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rowSeparatorInsets = __SLAG__PROPERTY;
+};
+TableView.prototype.getSeparatorStyle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.separatorStyle;
+};
+TableView.prototype.setSeparatorStyle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.separatorStyle = __SLAG__PROPERTY;
+};
+TableView.prototype.getShowVerticalScrollIndicator = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showVerticalScrollIndicator;
+};
+TableView.prototype.setShowVerticalScrollIndicator = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showVerticalScrollIndicator = __SLAG__PROPERTY;
+};
+TableView.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+TableView.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TableView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/TableViewRow.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/TableViewRow.js
@@ -1,0 +1,2075 @@
+var crypto = require('crypto');
+function TableViewRow(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'className',
+			'color',
+			'deleteButtonTitle',
+			'editable',
+			'font',
+			'footer',
+			'hasCheck',
+			'hasChild',
+			'hasDetail',
+			'header',
+			'indentionLevel',
+			'leftImage',
+			'moveable',
+			'rightImage',
+			'selectedBackgroundColor',
+			'selectedBackgroundImage',
+			'selectedColor',
+			'selectionStyle',
+			'title',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.TableViewRow.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.TableViewRow';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.TableViewRow.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.TableViewRow.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.TableViewRow.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.TableViewRow.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.className = undefined;
+	} else {
+		this.className = __SLAG_PROPERTIES.className || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.deleteButtonTitle = undefined;
+	} else {
+		this.deleteButtonTitle = __SLAG_PROPERTIES.deleteButtonTitle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editable = undefined;
+	} else {
+		this.editable = __SLAG_PROPERTIES.editable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footer = undefined;
+	} else {
+		this.footer = __SLAG_PROPERTIES.footer || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasCheck = undefined;
+	} else {
+		this.hasCheck = __SLAG_PROPERTIES.hasCheck || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasChild = undefined;
+	} else {
+		this.hasChild = __SLAG_PROPERTIES.hasChild || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasDetail = undefined;
+	} else {
+		this.hasDetail = __SLAG_PROPERTIES.hasDetail || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.header = undefined;
+	} else {
+		this.header = __SLAG_PROPERTIES.header || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.indentionLevel = undefined;
+	} else {
+		this.indentionLevel = __SLAG_PROPERTIES.indentionLevel || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftImage = undefined;
+	} else {
+		this.leftImage = __SLAG_PROPERTIES.leftImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.moveable = undefined;
+	} else {
+		this.moveable = __SLAG_PROPERTIES.moveable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightImage = undefined;
+	} else {
+		this.rightImage = __SLAG_PROPERTIES.rightImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedBackgroundColor = undefined;
+	} else {
+		this.selectedBackgroundColor = __SLAG_PROPERTIES.selectedBackgroundColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedBackgroundImage = undefined;
+	} else {
+		this.selectedBackgroundImage = __SLAG_PROPERTIES.selectedBackgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedColor = undefined;
+	} else {
+		this.selectedColor = __SLAG_PROPERTIES.selectedColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectionStyle = undefined;
+	} else {
+		this.selectionStyle = __SLAG_PROPERTIES.selectionStyle || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewRow.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewRow.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+TableViewRow.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.TableViewRow.finishLayout was deprecated, since 3.0.0');
+};
+TableViewRow.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+TableViewRow.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewRow.prototype.startLayout = function () {
+	throw new Error('Ti.UI.TableViewRow.startLayout was deprecated, since 3.0.0');
+};
+TableViewRow.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TableViewRow.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.TableViewRow.updateLayout was deprecated, since 3.0.0');
+};
+TableViewRow.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+TableViewRow.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewRow.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TableViewRow.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TableViewRow.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+TableViewRow.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+TableViewRow.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+TableViewRow.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+TableViewRow.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+TableViewRow.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+TableViewRow.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+TableViewRow.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+TableViewRow.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+TableViewRow.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+TableViewRow.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+TableViewRow.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+TableViewRow.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+TableViewRow.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+TableViewRow.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+TableViewRow.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+TableViewRow.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+TableViewRow.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+TableViewRow.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+TableViewRow.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+TableViewRow.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+TableViewRow.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+TableViewRow.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+TableViewRow.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+TableViewRow.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+TableViewRow.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+TableViewRow.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+TableViewRow.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+TableViewRow.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+TableViewRow.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+TableViewRow.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+TableViewRow.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+TableViewRow.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+TableViewRow.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+TableViewRow.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+TableViewRow.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+TableViewRow.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+TableViewRow.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+TableViewRow.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+TableViewRow.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+TableViewRow.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+TableViewRow.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+TableViewRow.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+TableViewRow.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+TableViewRow.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+TableViewRow.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+TableViewRow.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+TableViewRow.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+TableViewRow.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+TableViewRow.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+TableViewRow.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+TableViewRow.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+TableViewRow.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+TableViewRow.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+TableViewRow.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+TableViewRow.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+TableViewRow.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+TableViewRow.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+TableViewRow.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+TableViewRow.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+TableViewRow.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getClassName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.className;
+};
+TableViewRow.prototype.setClassName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.className = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+TableViewRow.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getDeleteButtonTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.deleteButtonTitle;
+};
+TableViewRow.prototype.setDeleteButtonTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.deleteButtonTitle = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getEditable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editable;
+};
+TableViewRow.prototype.setEditable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editable = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getFont = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+TableViewRow.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getFooter = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footer;
+};
+TableViewRow.prototype.setFooter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footer = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getHasCheck = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasCheck;
+};
+TableViewRow.prototype.setHasCheck = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hasCheck = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getHasChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasChild;
+};
+TableViewRow.prototype.setHasChild = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hasChild = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getHasDetail = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasDetail;
+};
+TableViewRow.prototype.setHasDetail = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hasDetail = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getHeader = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.header;
+};
+TableViewRow.prototype.setHeader = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.header = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getIndentionLevel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.indentionLevel;
+};
+TableViewRow.prototype.setIndentionLevel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.indentionLevel = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getLeftImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftImage;
+};
+TableViewRow.prototype.setLeftImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftImage = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getMoveable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.moveable;
+};
+TableViewRow.prototype.setMoveable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.moveable = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getRightImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightImage;
+};
+TableViewRow.prototype.setRightImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightImage = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getSelectedBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedBackgroundColor;
+};
+TableViewRow.prototype.setSelectedBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedBackgroundColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getSelectedBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedBackgroundImage;
+};
+TableViewRow.prototype.setSelectedBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedBackgroundImage = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getSelectedColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectedColor;
+};
+TableViewRow.prototype.setSelectedColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectedColor = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getSelectionStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selectionStyle;
+};
+TableViewRow.prototype.setSelectionStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selectionStyle = __SLAG__PROPERTY;
+};
+TableViewRow.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+TableViewRow.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TableViewRow(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/TableViewSection.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/TableViewSection.js
@@ -1,0 +1,308 @@
+var crypto = require('crypto');
+function TableViewSection(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'footerTitle',
+			'footerView',
+			'headerTitle',
+			'headerView',
+			'rowCount',
+			'rows',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.TableViewSection.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.TableViewSection';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerTitle = undefined;
+	} else {
+		this.footerTitle = __SLAG_PROPERTIES.footerTitle || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.footerView = undefined;
+	} else {
+		this.footerView = __SLAG_PROPERTIES.footerView || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerTitle = undefined;
+	} else {
+		this.headerTitle = __SLAG_PROPERTIES.headerTitle || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.headerView = undefined;
+	} else {
+		this.headerView = __SLAG_PROPERTIES.headerView || {};
+	}
+	if (__SLAG_PROPERTIES.rowCount) {
+		throw new Error('Ti.UI.TableViewSection.rowCount is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rowCount = undefined;
+	} else {
+		this.rowCount = 0;
+	}
+	if (__SLAG_PROPERTIES.rows) {
+		throw new Error('Ti.UI.TableViewSection.rows is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rows = undefined;
+	} else {
+		this.rows = [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewSection.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSection.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSection.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSection.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewSection.prototype.add = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSection.prototype.remove = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSection.prototype.rowAtIndex = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TableViewSection.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewSection.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewSection.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TableViewSection.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TableViewSection.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TableViewSection.prototype.getFooterTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerTitle;
+};
+TableViewSection.prototype.setFooterTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerTitle = __SLAG__PROPERTY;
+};
+TableViewSection.prototype.getFooterView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.footerView;
+};
+TableViewSection.prototype.setFooterView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.footerView = __SLAG__PROPERTY;
+};
+TableViewSection.prototype.getHeaderTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerTitle;
+};
+TableViewSection.prototype.setHeaderTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerTitle = __SLAG__PROPERTY;
+};
+TableViewSection.prototype.getHeaderView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.headerView;
+};
+TableViewSection.prototype.setHeaderView = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.headerView = __SLAG__PROPERTY;
+};
+TableViewSection.prototype.getRowCount = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rowCount;
+};
+TableViewSection.prototype.getRows = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rows;
+};
+module.exports = function (properties) {
+	return new TableViewSection(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/TextArea.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/TextArea.js
@@ -1,0 +1,2355 @@
+var crypto = require('crypto');
+function TextArea(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'appearance',
+			'keyboardAppearance',
+			'attributedString',
+			'autocapitalization',
+			'autocorrect',
+			'autoLink',
+			'clearOnEdit',
+			'color',
+			'editable',
+			'ellipsize',
+			'enableReturnKey',
+			'font',
+			'hintText',
+			'hintTextColor',
+			'handleLinks',
+			'keyboardToolbar',
+			'keyboardToolbarColor',
+			'keyboardToolbarHeight',
+			'keyboardType',
+			'maxLength',
+			'padding',
+			'paddingLeft',
+			'paddingRight',
+			'returnKeyType',
+			'scrollsToTop',
+			'showUndoRedoActions',
+			'suppressReturn',
+			'textAlign',
+			'value',
+			'scrollable',
+			'selection',
+			'verticalAlign',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.TextArea.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.TextArea';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.TextArea.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.TextArea.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.TextArea.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.TextArea.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (__SLAG_PROPERTIES.appearance) {
+		throw new Error('Ti.UI.TextArea.appearance was deprecated, since 5.2.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardAppearance = undefined;
+	} else {
+		this.keyboardAppearance = __SLAG_PROPERTIES.keyboardAppearance || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributedString = undefined;
+	} else {
+		this.attributedString = __SLAG_PROPERTIES.attributedString || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autocapitalization = undefined;
+	} else {
+		this.autocapitalization = __SLAG_PROPERTIES.autocapitalization || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autocorrect = undefined;
+	} else {
+		this.autocorrect = __SLAG_PROPERTIES.autocorrect || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoLink = undefined;
+	} else {
+		this.autoLink = __SLAG_PROPERTIES.autoLink || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clearOnEdit = undefined;
+	} else {
+		this.clearOnEdit = __SLAG_PROPERTIES.clearOnEdit || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editable = undefined;
+	} else {
+		this.editable = __SLAG_PROPERTIES.editable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ellipsize = undefined;
+	} else {
+		this.ellipsize = __SLAG_PROPERTIES.ellipsize || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enableReturnKey = undefined;
+	} else {
+		this.enableReturnKey = __SLAG_PROPERTIES.enableReturnKey || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hintText = undefined;
+	} else {
+		this.hintText = __SLAG_PROPERTIES.hintText || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hintTextColor = undefined;
+	} else {
+		this.hintTextColor = __SLAG_PROPERTIES.hintTextColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.handleLinks = undefined;
+	} else {
+		this.handleLinks = __SLAG_PROPERTIES.handleLinks || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardToolbar = undefined;
+	} else {
+		this.keyboardToolbar = __SLAG_PROPERTIES.keyboardToolbar || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardToolbarColor = undefined;
+	} else {
+		this.keyboardToolbarColor = __SLAG_PROPERTIES.keyboardToolbarColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardToolbarHeight = undefined;
+	} else {
+		this.keyboardToolbarHeight = __SLAG_PROPERTIES.keyboardToolbarHeight || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardType = undefined;
+	} else {
+		this.keyboardType = __SLAG_PROPERTIES.keyboardType || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxLength = undefined;
+	} else {
+		this.maxLength = __SLAG_PROPERTIES.maxLength || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.padding = undefined;
+	} else {
+		this.padding = __SLAG_PROPERTIES.padding || {};
+	}
+	if (__SLAG_PROPERTIES.paddingLeft) {
+		throw new Error('Ti.UI.TextArea.paddingLeft was deprecated, since 6.0.0');
+	}
+	if (__SLAG_PROPERTIES.paddingRight) {
+		throw new Error('Ti.UI.TextArea.paddingRight was deprecated, since 6.0.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.returnKeyType = undefined;
+	} else {
+		this.returnKeyType = __SLAG_PROPERTIES.returnKeyType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollsToTop = undefined;
+	} else {
+		this.scrollsToTop = __SLAG_PROPERTIES.scrollsToTop || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showUndoRedoActions = undefined;
+	} else {
+		this.showUndoRedoActions = __SLAG_PROPERTIES.showUndoRedoActions || true;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.suppressReturn = undefined;
+	} else {
+		this.suppressReturn = __SLAG_PROPERTIES.suppressReturn || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textAlign = undefined;
+	} else {
+		this.textAlign = __SLAG_PROPERTIES.textAlign || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollable = undefined;
+	} else {
+		this.scrollable = __SLAG_PROPERTIES.scrollable || true;
+	}
+	if (__SLAG_PROPERTIES.selection) {
+		throw new Error('Ti.UI.TextArea.selection is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selection = undefined;
+	} else {
+		this.selection = {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.verticalAlign = undefined;
+	} else {
+		this.verticalAlign = __SLAG_PROPERTIES.verticalAlign || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TextArea.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TextArea.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+TextArea.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.TextArea.finishLayout was deprecated, since 3.0.0');
+};
+TextArea.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+TextArea.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.startLayout = function () {
+	throw new Error('Ti.UI.TextArea.startLayout was deprecated, since 3.0.0');
+};
+TextArea.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TextArea.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.TextArea.updateLayout was deprecated, since 3.0.0');
+};
+TextArea.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+TextArea.prototype.blur = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.focus = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextArea.prototype.hasText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+TextArea.prototype.setSelection = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selection = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TextArea.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TextArea.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TextArea.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TextArea.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+TextArea.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+TextArea.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+TextArea.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+TextArea.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+TextArea.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+TextArea.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+TextArea.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+TextArea.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+TextArea.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+TextArea.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+TextArea.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+TextArea.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+TextArea.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+TextArea.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+TextArea.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+TextArea.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+TextArea.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+TextArea.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+TextArea.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+TextArea.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+TextArea.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+TextArea.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+TextArea.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+TextArea.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+TextArea.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+TextArea.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+TextArea.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+TextArea.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+TextArea.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+TextArea.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+TextArea.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+TextArea.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+TextArea.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+TextArea.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+TextArea.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+TextArea.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+TextArea.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+TextArea.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+TextArea.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+TextArea.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+TextArea.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+TextArea.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+TextArea.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+TextArea.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+TextArea.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+TextArea.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+TextArea.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+TextArea.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+TextArea.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+TextArea.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+TextArea.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+TextArea.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+TextArea.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+TextArea.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+TextArea.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+TextArea.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+TextArea.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+TextArea.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+TextArea.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+TextArea.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+TextArea.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+TextArea.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+TextArea.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+TextArea.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+TextArea.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+TextArea.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+TextArea.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+TextArea.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+TextArea.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+TextArea.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+TextArea.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+TextArea.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+TextArea.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+TextArea.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+TextArea.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+TextArea.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+TextArea.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+TextArea.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+TextArea.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+TextArea.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+TextArea.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+TextArea.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+TextArea.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+TextArea.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+TextArea.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAppearance = function () {
+	throw new Error('Ti.UI.TextArea.getAppearance was deprecated, since 5.2.0');
+};
+TextArea.prototype.setAppearance = function () {
+	throw new Error('Ti.UI.TextArea.setAppearance was deprecated, since 5.2.0');
+};
+TextArea.prototype.getKeyboardAppearance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardAppearance;
+};
+TextArea.prototype.setKeyboardAppearance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardAppearance = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAttributedString = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributedString;
+};
+TextArea.prototype.setAttributedString = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.attributedString = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAutocapitalization = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autocapitalization;
+};
+TextArea.prototype.setAutocapitalization = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autocapitalization = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAutocorrect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autocorrect;
+};
+TextArea.prototype.setAutocorrect = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autocorrect = __SLAG__PROPERTY;
+};
+TextArea.prototype.getAutoLink = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoLink;
+};
+TextArea.prototype.setAutoLink = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoLink = __SLAG__PROPERTY;
+};
+TextArea.prototype.getClearOnEdit = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clearOnEdit;
+};
+TextArea.prototype.setClearOnEdit = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clearOnEdit = __SLAG__PROPERTY;
+};
+TextArea.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+TextArea.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+TextArea.prototype.getEditable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editable;
+};
+TextArea.prototype.setEditable = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editable = __SLAG__PROPERTY;
+};
+TextArea.prototype.getEllipsize = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ellipsize;
+};
+TextArea.prototype.setEllipsize = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ellipsize = __SLAG__PROPERTY;
+};
+TextArea.prototype.getEnableReturnKey = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enableReturnKey;
+};
+TextArea.prototype.setEnableReturnKey = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enableReturnKey = __SLAG__PROPERTY;
+};
+TextArea.prototype.getFont = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+TextArea.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+TextArea.prototype.getHintText = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hintText;
+};
+TextArea.prototype.setHintText = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hintText = __SLAG__PROPERTY;
+};
+TextArea.prototype.getHintTextColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hintTextColor;
+};
+TextArea.prototype.setHintTextColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hintTextColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getHandleLinks = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.handleLinks;
+};
+TextArea.prototype.setHandleLinks = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.handleLinks = __SLAG__PROPERTY;
+};
+TextArea.prototype.getKeyboardToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardToolbar;
+};
+TextArea.prototype.setKeyboardToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardToolbar = __SLAG__PROPERTY;
+};
+TextArea.prototype.getKeyboardToolbarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardToolbarColor;
+};
+TextArea.prototype.setKeyboardToolbarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardToolbarColor = __SLAG__PROPERTY;
+};
+TextArea.prototype.getKeyboardToolbarHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardToolbarHeight;
+};
+TextArea.prototype.setKeyboardToolbarHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardToolbarHeight = __SLAG__PROPERTY;
+};
+TextArea.prototype.getKeyboardType = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardType;
+};
+TextArea.prototype.setKeyboardType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardType = __SLAG__PROPERTY;
+};
+TextArea.prototype.getMaxLength = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxLength;
+};
+TextArea.prototype.setMaxLength = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxLength = __SLAG__PROPERTY;
+};
+TextArea.prototype.getPadding = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.padding;
+};
+TextArea.prototype.setPadding = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.padding = __SLAG__PROPERTY;
+};
+TextArea.prototype.getPaddingLeft = function () {
+	throw new Error('Ti.UI.TextArea.getPaddingLeft was deprecated, since 6.0.0');
+};
+TextArea.prototype.setPaddingLeft = function () {
+	throw new Error('Ti.UI.TextArea.setPaddingLeft was deprecated, since 6.0.0');
+};
+TextArea.prototype.getPaddingRight = function () {
+	throw new Error('Ti.UI.TextArea.getPaddingRight was deprecated, since 6.0.0');
+};
+TextArea.prototype.setPaddingRight = function () {
+	throw new Error('Ti.UI.TextArea.setPaddingRight was deprecated, since 6.0.0');
+};
+TextArea.prototype.getReturnKeyType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.returnKeyType;
+};
+TextArea.prototype.setReturnKeyType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.returnKeyType = __SLAG__PROPERTY;
+};
+TextArea.prototype.getScrollsToTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollsToTop;
+};
+TextArea.prototype.setScrollsToTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollsToTop = __SLAG__PROPERTY;
+};
+TextArea.prototype.getShowUndoRedoActions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showUndoRedoActions;
+};
+TextArea.prototype.setShowUndoRedoActions = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showUndoRedoActions = __SLAG__PROPERTY;
+};
+TextArea.prototype.getSuppressReturn = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.suppressReturn;
+};
+TextArea.prototype.setSuppressReturn = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.suppressReturn = __SLAG__PROPERTY;
+};
+TextArea.prototype.getTextAlign = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textAlign;
+};
+TextArea.prototype.setTextAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.textAlign = __SLAG__PROPERTY;
+};
+TextArea.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+TextArea.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+TextArea.prototype.getScrollable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollable;
+};
+TextArea.prototype.setScrollable = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollable = __SLAG__PROPERTY;
+};
+TextArea.prototype.getSelection = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selection;
+};
+TextArea.prototype.getVerticalAlign = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.verticalAlign;
+};
+TextArea.prototype.setVerticalAlign = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.verticalAlign = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TextArea(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/TextField.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/TextField.js
@@ -1,0 +1,2601 @@
+var crypto = require('crypto');
+function TextField(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'appearance',
+			'keyboardAppearance',
+			'attributedString',
+			'attributedHintText',
+			'autocapitalization',
+			'autocorrect',
+			'autoLink',
+			'borderStyle',
+			'clearButtonMode',
+			'clearOnEdit',
+			'color',
+			'editable',
+			'ellipsize',
+			'enableReturnKey',
+			'font',
+			'hintText',
+			'hintTextColor',
+			'inputType',
+			'keyboardToolbar',
+			'keyboardToolbarColor',
+			'keyboardToolbarHeight',
+			'keyboardType',
+			'leftButton',
+			'leftButtonMode',
+			'leftButtonPadding',
+			'minimumFontSize',
+			'padding',
+			'paddingLeft',
+			'paddingRight',
+			'passwordMask',
+			'returnKeyType',
+			'rightButton',
+			'rightButtonMode',
+			'rightButtonPadding',
+			'suppressReturn',
+			'selection',
+			'showUndoRedoActions',
+			'textAlign',
+			'value',
+			'verticalAlign',
+			'maxLength',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.TextField.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.TextField';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.TextField.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.TextField.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.TextField.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.TextField.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (__SLAG_PROPERTIES.appearance) {
+		throw new Error('Ti.UI.TextField.appearance was deprecated, since 5.2.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardAppearance = undefined;
+	} else {
+		this.keyboardAppearance = __SLAG_PROPERTIES.keyboardAppearance || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributedString = undefined;
+	} else {
+		this.attributedString = __SLAG_PROPERTIES.attributedString || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributedHintText = undefined;
+	} else {
+		this.attributedHintText = __SLAG_PROPERTIES.attributedHintText || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autocapitalization = undefined;
+	} else {
+		this.autocapitalization = __SLAG_PROPERTIES.autocapitalization || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autocorrect = undefined;
+	} else {
+		this.autocorrect = __SLAG_PROPERTIES.autocorrect || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoLink = undefined;
+	} else {
+		this.autoLink = __SLAG_PROPERTIES.autoLink || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderStyle = undefined;
+	} else {
+		this.borderStyle = __SLAG_PROPERTIES.borderStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clearButtonMode = undefined;
+	} else {
+		this.clearButtonMode = __SLAG_PROPERTIES.clearButtonMode || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clearOnEdit = undefined;
+	} else {
+		this.clearOnEdit = __SLAG_PROPERTIES.clearOnEdit || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.editable = undefined;
+	} else {
+		this.editable = __SLAG_PROPERTIES.editable || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ellipsize = undefined;
+	} else {
+		this.ellipsize = __SLAG_PROPERTIES.ellipsize || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enableReturnKey = undefined;
+	} else {
+		this.enableReturnKey = __SLAG_PROPERTIES.enableReturnKey || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hintText = undefined;
+	} else {
+		this.hintText = __SLAG_PROPERTIES.hintText || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hintTextColor = undefined;
+	} else {
+		this.hintTextColor = __SLAG_PROPERTIES.hintTextColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.inputType = undefined;
+	} else {
+		this.inputType = __SLAG_PROPERTIES.inputType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardToolbar = undefined;
+	} else {
+		this.keyboardToolbar = __SLAG_PROPERTIES.keyboardToolbar || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardToolbarColor = undefined;
+	} else {
+		this.keyboardToolbarColor = __SLAG_PROPERTIES.keyboardToolbarColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardToolbarHeight = undefined;
+	} else {
+		this.keyboardToolbarHeight = __SLAG_PROPERTIES.keyboardToolbarHeight || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keyboardType = undefined;
+	} else {
+		this.keyboardType = __SLAG_PROPERTIES.keyboardType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftButton = undefined;
+	} else {
+		this.leftButton = __SLAG_PROPERTIES.leftButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftButtonMode = undefined;
+	} else {
+		this.leftButtonMode = __SLAG_PROPERTIES.leftButtonMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftButtonPadding = undefined;
+	} else {
+		this.leftButtonPadding = __SLAG_PROPERTIES.leftButtonPadding || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minimumFontSize = undefined;
+	} else {
+		this.minimumFontSize = __SLAG_PROPERTIES.minimumFontSize || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.padding = undefined;
+	} else {
+		this.padding = __SLAG_PROPERTIES.padding || {};
+	}
+	if (__SLAG_PROPERTIES.paddingLeft) {
+		throw new Error('Ti.UI.TextField.paddingLeft was deprecated, since 6.0.0');
+	}
+	if (__SLAG_PROPERTIES.paddingRight) {
+		throw new Error('Ti.UI.TextField.paddingRight was deprecated, since 6.0.0');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.passwordMask = undefined;
+	} else {
+		this.passwordMask = __SLAG_PROPERTIES.passwordMask || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.returnKeyType = undefined;
+	} else {
+		this.returnKeyType = __SLAG_PROPERTIES.returnKeyType || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightButton = undefined;
+	} else {
+		this.rightButton = __SLAG_PROPERTIES.rightButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightButtonMode = undefined;
+	} else {
+		this.rightButtonMode = __SLAG_PROPERTIES.rightButtonMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightButtonPadding = undefined;
+	} else {
+		this.rightButtonPadding = __SLAG_PROPERTIES.rightButtonPadding || 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.suppressReturn = undefined;
+	} else {
+		this.suppressReturn = __SLAG_PROPERTIES.suppressReturn || true;
+	}
+	if (__SLAG_PROPERTIES.selection) {
+		throw new Error('Ti.UI.TextField.selection is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selection = undefined;
+	} else {
+		this.selection = {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showUndoRedoActions = undefined;
+	} else {
+		this.showUndoRedoActions = __SLAG_PROPERTIES.showUndoRedoActions || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textAlign = undefined;
+	} else {
+		this.textAlign = __SLAG_PROPERTIES.textAlign || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.verticalAlign = undefined;
+	} else {
+		this.verticalAlign = __SLAG_PROPERTIES.verticalAlign || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maxLength = undefined;
+	} else {
+		this.maxLength = __SLAG_PROPERTIES.maxLength || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TextField.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TextField.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+TextField.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.TextField.finishLayout was deprecated, since 3.0.0');
+};
+TextField.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+TextField.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.startLayout = function () {
+	throw new Error('Ti.UI.TextField.startLayout was deprecated, since 3.0.0');
+};
+TextField.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TextField.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.TextField.updateLayout was deprecated, since 3.0.0');
+};
+TextField.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+TextField.prototype.blur = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.focus = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TextField.prototype.hasText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+TextField.prototype.setSelection = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selection = __SLAG__PROPERTY;
+};
+TextField.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TextField.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TextField.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TextField.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+TextField.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+TextField.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+TextField.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+TextField.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+TextField.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+TextField.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+TextField.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+TextField.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+TextField.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+TextField.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+TextField.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+TextField.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+TextField.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+TextField.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+TextField.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+TextField.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+TextField.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+TextField.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+TextField.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+TextField.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+TextField.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+TextField.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+TextField.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+TextField.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+TextField.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+TextField.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+TextField.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+TextField.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+TextField.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+TextField.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+TextField.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+TextField.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+TextField.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+TextField.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+TextField.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+TextField.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+TextField.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+TextField.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+TextField.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+TextField.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+TextField.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+TextField.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+TextField.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+TextField.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+TextField.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+TextField.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+TextField.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+TextField.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+TextField.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+TextField.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+TextField.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+TextField.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+TextField.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+TextField.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+TextField.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+TextField.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+TextField.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+TextField.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+TextField.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+TextField.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+TextField.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+TextField.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+TextField.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+TextField.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+TextField.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+TextField.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+TextField.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+TextField.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+TextField.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+TextField.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+TextField.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+TextField.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+TextField.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+TextField.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+TextField.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+TextField.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+TextField.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+TextField.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+TextField.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+TextField.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+TextField.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+TextField.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+TextField.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+TextField.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+TextField.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+TextField.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+TextField.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+TextField.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+TextField.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+TextField.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+TextField.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+TextField.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+TextField.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+TextField.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+TextField.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+TextField.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+TextField.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+TextField.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+TextField.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+TextField.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+TextField.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+TextField.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+TextField.prototype.getAppearance = function () {
+	throw new Error('Ti.UI.TextField.getAppearance was deprecated, since 5.2.0');
+};
+TextField.prototype.setAppearance = function () {
+	throw new Error('Ti.UI.TextField.setAppearance was deprecated, since 5.2.0');
+};
+TextField.prototype.getKeyboardAppearance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardAppearance;
+};
+TextField.prototype.setKeyboardAppearance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardAppearance = __SLAG__PROPERTY;
+};
+TextField.prototype.getAttributedString = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributedString;
+};
+TextField.prototype.setAttributedString = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.attributedString = __SLAG__PROPERTY;
+};
+TextField.prototype.getAttributedHintText = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributedHintText;
+};
+TextField.prototype.setAttributedHintText = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.attributedHintText = __SLAG__PROPERTY;
+};
+TextField.prototype.getAutocapitalization = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autocapitalization;
+};
+TextField.prototype.setAutocapitalization = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autocapitalization = __SLAG__PROPERTY;
+};
+TextField.prototype.getAutocorrect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autocorrect;
+};
+TextField.prototype.setAutocorrect = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autocorrect = __SLAG__PROPERTY;
+};
+TextField.prototype.getAutoLink = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoLink;
+};
+TextField.prototype.setAutoLink = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoLink = __SLAG__PROPERTY;
+};
+TextField.prototype.getBorderStyle = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderStyle;
+};
+TextField.prototype.setBorderStyle = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderStyle = __SLAG__PROPERTY;
+};
+TextField.prototype.getClearButtonMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clearButtonMode;
+};
+TextField.prototype.setClearButtonMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clearButtonMode = __SLAG__PROPERTY;
+};
+TextField.prototype.getClearOnEdit = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clearOnEdit;
+};
+TextField.prototype.setClearOnEdit = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clearOnEdit = __SLAG__PROPERTY;
+};
+TextField.prototype.getColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.color;
+};
+TextField.prototype.setColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.color = __SLAG__PROPERTY;
+};
+TextField.prototype.getEditable = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.editable;
+};
+TextField.prototype.setEditable = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.editable = __SLAG__PROPERTY;
+};
+TextField.prototype.getEllipsize = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ellipsize;
+};
+TextField.prototype.setEllipsize = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ellipsize = __SLAG__PROPERTY;
+};
+TextField.prototype.getEnableReturnKey = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enableReturnKey;
+};
+TextField.prototype.setEnableReturnKey = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enableReturnKey = __SLAG__PROPERTY;
+};
+TextField.prototype.getFont = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.font;
+};
+TextField.prototype.setFont = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.font = __SLAG__PROPERTY;
+};
+TextField.prototype.getHintText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hintText;
+};
+TextField.prototype.setHintText = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hintText = __SLAG__PROPERTY;
+};
+TextField.prototype.getHintTextColor = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hintTextColor;
+};
+TextField.prototype.setHintTextColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hintTextColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getInputType = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.inputType;
+};
+TextField.prototype.setInputType = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.inputType = __SLAG__PROPERTY;
+};
+TextField.prototype.getKeyboardToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardToolbar;
+};
+TextField.prototype.setKeyboardToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardToolbar = __SLAG__PROPERTY;
+};
+TextField.prototype.getKeyboardToolbarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardToolbarColor;
+};
+TextField.prototype.setKeyboardToolbarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardToolbarColor = __SLAG__PROPERTY;
+};
+TextField.prototype.getKeyboardToolbarHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardToolbarHeight;
+};
+TextField.prototype.setKeyboardToolbarHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardToolbarHeight = __SLAG__PROPERTY;
+};
+TextField.prototype.getKeyboardType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keyboardType;
+};
+TextField.prototype.setKeyboardType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keyboardType = __SLAG__PROPERTY;
+};
+TextField.prototype.getLeftButton = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftButton;
+};
+TextField.prototype.setLeftButton = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftButton = __SLAG__PROPERTY;
+};
+TextField.prototype.getLeftButtonMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftButtonMode;
+};
+TextField.prototype.setLeftButtonMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftButtonMode = __SLAG__PROPERTY;
+};
+TextField.prototype.getLeftButtonPadding = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftButtonPadding;
+};
+TextField.prototype.setLeftButtonPadding = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftButtonPadding = __SLAG__PROPERTY;
+};
+TextField.prototype.getMinimumFontSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minimumFontSize;
+};
+TextField.prototype.setMinimumFontSize = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minimumFontSize = __SLAG__PROPERTY;
+};
+TextField.prototype.getPadding = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.padding;
+};
+TextField.prototype.setPadding = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.padding = __SLAG__PROPERTY;
+};
+TextField.prototype.getPaddingLeft = function () {
+	throw new Error('Ti.UI.TextField.getPaddingLeft was deprecated, since 6.0.0');
+};
+TextField.prototype.setPaddingLeft = function () {
+	throw new Error('Ti.UI.TextField.setPaddingLeft was deprecated, since 6.0.0');
+};
+TextField.prototype.getPaddingRight = function () {
+	throw new Error('Ti.UI.TextField.getPaddingRight was deprecated, since 6.0.0');
+};
+TextField.prototype.setPaddingRight = function () {
+	throw new Error('Ti.UI.TextField.setPaddingRight was deprecated, since 6.0.0');
+};
+TextField.prototype.getPasswordMask = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.passwordMask;
+};
+TextField.prototype.setPasswordMask = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.passwordMask = __SLAG__PROPERTY;
+};
+TextField.prototype.getReturnKeyType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.returnKeyType;
+};
+TextField.prototype.setReturnKeyType = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.returnKeyType = __SLAG__PROPERTY;
+};
+TextField.prototype.getRightButton = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightButton;
+};
+TextField.prototype.setRightButton = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightButton = __SLAG__PROPERTY;
+};
+TextField.prototype.getRightButtonMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightButtonMode;
+};
+TextField.prototype.setRightButtonMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightButtonMode = __SLAG__PROPERTY;
+};
+TextField.prototype.getRightButtonPadding = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightButtonPadding;
+};
+TextField.prototype.setRightButtonPadding = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightButtonPadding = __SLAG__PROPERTY;
+};
+TextField.prototype.getSuppressReturn = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.suppressReturn;
+};
+TextField.prototype.setSuppressReturn = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.suppressReturn = __SLAG__PROPERTY;
+};
+TextField.prototype.getSelection = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selection;
+};
+TextField.prototype.getShowUndoRedoActions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showUndoRedoActions;
+};
+TextField.prototype.setShowUndoRedoActions = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showUndoRedoActions = __SLAG__PROPERTY;
+};
+TextField.prototype.getTextAlign = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textAlign;
+};
+TextField.prototype.setTextAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.textAlign = __SLAG__PROPERTY;
+};
+TextField.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+TextField.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+TextField.prototype.getVerticalAlign = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.verticalAlign;
+};
+TextField.prototype.setVerticalAlign = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.verticalAlign = __SLAG__PROPERTY;
+};
+TextField.prototype.getMaxLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maxLength;
+};
+TextField.prototype.setMaxLength = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maxLength = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TextField(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Toolbar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Toolbar.js
@@ -1,0 +1,857 @@
+var crypto = require('crypto');
+function Toolbar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundGradient',
+			'backgroundImage',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'barColor',
+			'items',
+			'borderTop',
+			'borderBottom',
+			'translucent',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Toolbar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Toolbar';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.Toolbar.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Toolbar.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Toolbar.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Toolbar.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = __SLAG_PROPERTIES.items || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderTop = undefined;
+	} else {
+		this.borderTop = __SLAG_PROPERTIES.borderTop || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderBottom = undefined;
+	} else {
+		this.borderBottom = __SLAG_PROPERTIES.borderBottom || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translucent = undefined;
+	} else {
+		this.translucent = __SLAG_PROPERTIES.translucent || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Toolbar.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Toolbar.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Toolbar.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Toolbar.finishLayout was deprecated, since 3.0.0');
+};
+Toolbar.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Toolbar.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Toolbar.startLayout was deprecated, since 3.0.0');
+};
+Toolbar.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Toolbar.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Toolbar.updateLayout was deprecated, since 3.0.0');
+};
+Toolbar.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Toolbar.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Toolbar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Toolbar.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Toolbar.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Toolbar.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Toolbar.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Toolbar.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Toolbar.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Toolbar.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Toolbar.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Toolbar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Toolbar.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Toolbar.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Toolbar.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Toolbar.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Toolbar.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Toolbar.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Toolbar.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Toolbar.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Toolbar.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Toolbar.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Toolbar.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Toolbar.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Toolbar.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Toolbar.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Toolbar.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Toolbar.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Toolbar.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Toolbar.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Toolbar.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Toolbar.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Toolbar.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Toolbar.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Toolbar.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Toolbar.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Toolbar.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Toolbar.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Toolbar.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+Toolbar.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+Toolbar.prototype.setItems = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.items = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderTop;
+};
+Toolbar.prototype.setBorderTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderTop = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderBottom;
+};
+Toolbar.prototype.setBorderBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderBottom = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTranslucent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translucent;
+};
+Toolbar.prototype.setTranslucent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translucent = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Toolbar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/View.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/View.js
@@ -1,0 +1,1616 @@
+var crypto = require('crypto');
+function View(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.View.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.View';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.View.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.View.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.View.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.View.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+View.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+View.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+View.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.View.finishLayout was deprecated, since 3.0.0');
+};
+View.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+View.prototype.removeAllChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+View.prototype.startLayout = function () {
+	throw new Error('Ti.UI.View.startLayout was deprecated, since 3.0.0');
+};
+View.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+View.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.View.updateLayout was deprecated, since 3.0.0');
+};
+View.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+View.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+View.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+View.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+View.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+View.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+View.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+View.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+View.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+View.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+View.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+View.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+View.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+View.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+View.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+View.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+View.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+View.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+View.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+View.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+View.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+View.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+View.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+View.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+View.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+View.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+View.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+View.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+View.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+View.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+View.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+View.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+View.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+View.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+View.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+View.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+View.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+View.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+View.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+View.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+View.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+View.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+View.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+View.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+View.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+View.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+View.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+View.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+View.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+View.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+View.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+View.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+View.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+View.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+View.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+View.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+View.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+View.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+View.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+View.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+View.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+View.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+View.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+View.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+View.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+View.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+View.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+View.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+View.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+View.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+View.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+View.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+View.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+View.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+View.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+View.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+View.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+View.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+View.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+View.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+View.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+View.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+View.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+View.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+View.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+View.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+View.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+View.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+View.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+View.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+View.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+View.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+View.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+View.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+View.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+View.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+View.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+View.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+View.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+View.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+View.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+View.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+View.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+View.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+View.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+View.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+View.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+View.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new View(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/WebView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/WebView.js
@@ -1,0 +1,2169 @@
+var crypto = require('crypto');
+function WebView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'allowsLinkPreview',
+			'blacklistedURLs',
+			'data',
+			'disableBounce',
+			'enableJavascriptInterface',
+			'handlePlatformUrl',
+			'hideLoadIndicator',
+			'html',
+			'ignoreSslError',
+			'loading',
+			'onCreateWindow',
+			'overScrollMode',
+			'cacheMode',
+			'pluginState',
+			'scrollsToTop',
+			'showScrollbars',
+			'enableZoomControls',
+			'scalesPageToFit',
+			'url',
+			'userAgent',
+			'willHandleTouches',
+			'lightTouchEnabled',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.WebView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.WebView';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.WebView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.WebView.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.WebView.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.WebView.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsLinkPreview = undefined;
+	} else {
+		this.allowsLinkPreview = __SLAG_PROPERTIES.allowsLinkPreview || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.blacklistedURLs = undefined;
+	} else {
+		this.blacklistedURLs = __SLAG_PROPERTIES.blacklistedURLs || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.disableBounce = undefined;
+	} else {
+		this.disableBounce = __SLAG_PROPERTIES.disableBounce || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enableJavascriptInterface = undefined;
+	} else {
+		this.enableJavascriptInterface = __SLAG_PROPERTIES.enableJavascriptInterface || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.handlePlatformUrl = undefined;
+	} else {
+		this.handlePlatformUrl = __SLAG_PROPERTIES.handlePlatformUrl || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hideLoadIndicator = undefined;
+	} else {
+		this.hideLoadIndicator = __SLAG_PROPERTIES.hideLoadIndicator || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.html = undefined;
+	} else {
+		this.html = __SLAG_PROPERTIES.html || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ignoreSslError = undefined;
+	} else {
+		this.ignoreSslError = __SLAG_PROPERTIES.ignoreSslError || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.loading = undefined;
+	} else {
+		this.loading = __SLAG_PROPERTIES.loading || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onCreateWindow = undefined;
+	} else {
+		this.onCreateWindow = __SLAG_PROPERTIES.onCreateWindow || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overScrollMode = undefined;
+	} else {
+		this.overScrollMode = __SLAG_PROPERTIES.overScrollMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cacheMode = undefined;
+	} else {
+		this.cacheMode = __SLAG_PROPERTIES.cacheMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pluginState = undefined;
+	} else {
+		this.pluginState = __SLAG_PROPERTIES.pluginState || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scrollsToTop = undefined;
+	} else {
+		this.scrollsToTop = __SLAG_PROPERTIES.scrollsToTop || true;
+	}
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showScrollbars = undefined;
+	} else {
+		this.showScrollbars = __SLAG_PROPERTIES.showScrollbars || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enableZoomControls = undefined;
+	} else {
+		this.enableZoomControls = __SLAG_PROPERTIES.enableZoomControls || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scalesPageToFit = undefined;
+	} else {
+		this.scalesPageToFit = __SLAG_PROPERTIES.scalesPageToFit || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.userAgent = undefined;
+	} else {
+		this.userAgent = __SLAG_PROPERTIES.userAgent || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.willHandleTouches = undefined;
+	} else {
+		this.willHandleTouches = __SLAG_PROPERTIES.willHandleTouches || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lightTouchEnabled = undefined;
+	} else {
+		this.lightTouchEnabled = __SLAG_PROPERTIES.lightTouchEnabled || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+WebView.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+WebView.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.WebView.finishLayout was deprecated, since 3.0.0');
+};
+WebView.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+WebView.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.WebView.startLayout was deprecated, since 3.0.0');
+};
+WebView.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+WebView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.WebView.updateLayout was deprecated, since 3.0.0');
+};
+WebView.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+WebView.prototype.setHtml = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.html = __SLAG__PROPERTY;
+};
+WebView.prototype.canGoBack = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+WebView.prototype.canGoForward = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+WebView.prototype.evalJS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+WebView.prototype.goBack = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.goForward = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.pause = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.reload = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.repaint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.release = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.resume = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.setBasicAuthentication = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.stopLoading = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WebView.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+WebView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+WebView.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+WebView.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+WebView.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+WebView.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+WebView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+WebView.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+WebView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+WebView.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+WebView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+WebView.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+WebView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+WebView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+WebView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+WebView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+WebView.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+WebView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+WebView.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+WebView.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+WebView.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+WebView.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+WebView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+WebView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+WebView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+WebView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+WebView.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+WebView.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+WebView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+WebView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+WebView.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+WebView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+WebView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+WebView.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+WebView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+WebView.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+WebView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+WebView.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+WebView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+WebView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+WebView.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+WebView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+WebView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+WebView.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+WebView.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+WebView.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+WebView.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+WebView.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+WebView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+WebView.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+WebView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+WebView.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+WebView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+WebView.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+WebView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+WebView.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+WebView.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+WebView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+WebView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+WebView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+WebView.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+WebView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+WebView.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+WebView.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+WebView.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+WebView.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+WebView.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+WebView.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+WebView.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+WebView.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+WebView.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+WebView.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+WebView.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+WebView.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+WebView.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+WebView.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+WebView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+WebView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+WebView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+WebView.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+WebView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+WebView.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+WebView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+WebView.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+WebView.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+WebView.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+WebView.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+WebView.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+WebView.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+WebView.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+WebView.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+WebView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+WebView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+WebView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+WebView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+WebView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+WebView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+WebView.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+WebView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+WebView.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+WebView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+WebView.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+WebView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+WebView.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+WebView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+WebView.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+WebView.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+WebView.prototype.getAllowsLinkPreview = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsLinkPreview;
+};
+WebView.prototype.setAllowsLinkPreview = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsLinkPreview = __SLAG__PROPERTY;
+};
+WebView.prototype.getBlacklistedURLs = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.blacklistedURLs;
+};
+WebView.prototype.setBlacklistedURLs = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.blacklistedURLs = __SLAG__PROPERTY;
+};
+WebView.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+WebView.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+WebView.prototype.getDisableBounce = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.disableBounce;
+};
+WebView.prototype.setDisableBounce = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.disableBounce = __SLAG__PROPERTY;
+};
+WebView.prototype.getEnableJavascriptInterface = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enableJavascriptInterface;
+};
+WebView.prototype.setEnableJavascriptInterface = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enableJavascriptInterface = __SLAG__PROPERTY;
+};
+WebView.prototype.getHandlePlatformUrl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.handlePlatformUrl;
+};
+WebView.prototype.setHandlePlatformUrl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.handlePlatformUrl = __SLAG__PROPERTY;
+};
+WebView.prototype.getHideLoadIndicator = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hideLoadIndicator;
+};
+WebView.prototype.setHideLoadIndicator = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hideLoadIndicator = __SLAG__PROPERTY;
+};
+WebView.prototype.getHtml = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.html;
+};
+WebView.prototype.setHtml = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.html = __SLAG__PROPERTY;
+};
+WebView.prototype.getIgnoreSslError = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ignoreSslError;
+};
+WebView.prototype.setIgnoreSslError = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.ignoreSslError = __SLAG__PROPERTY;
+};
+WebView.prototype.getLoading = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.loading;
+};
+WebView.prototype.setLoading = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.loading = __SLAG__PROPERTY;
+};
+WebView.prototype.getOnCreateWindow = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onCreateWindow;
+};
+WebView.prototype.setOnCreateWindow = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onCreateWindow = __SLAG__PROPERTY;
+};
+WebView.prototype.getOverScrollMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overScrollMode;
+};
+WebView.prototype.setOverScrollMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overScrollMode = __SLAG__PROPERTY;
+};
+WebView.prototype.getCacheMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.cacheMode;
+};
+WebView.prototype.setCacheMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.cacheMode = __SLAG__PROPERTY;
+};
+WebView.prototype.getPluginState = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pluginState;
+};
+WebView.prototype.setPluginState = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pluginState = __SLAG__PROPERTY;
+};
+WebView.prototype.getScrollsToTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scrollsToTop;
+};
+WebView.prototype.setScrollsToTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scrollsToTop = __SLAG__PROPERTY;
+};
+WebView.prototype.getShowScrollbars = function () {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showScrollbars;
+};
+WebView.prototype.setShowScrollbars = function (__SLAG__PROPERTY) {
+	if (['mobileweb'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showScrollbars = __SLAG__PROPERTY;
+};
+WebView.prototype.getEnableZoomControls = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enableZoomControls;
+};
+WebView.prototype.setEnableZoomControls = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enableZoomControls = __SLAG__PROPERTY;
+};
+WebView.prototype.getScalesPageToFit = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scalesPageToFit;
+};
+WebView.prototype.setScalesPageToFit = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scalesPageToFit = __SLAG__PROPERTY;
+};
+WebView.prototype.getUrl = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+WebView.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+WebView.prototype.getUserAgent = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.userAgent;
+};
+WebView.prototype.setUserAgent = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.userAgent = __SLAG__PROPERTY;
+};
+WebView.prototype.getWillHandleTouches = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.willHandleTouches;
+};
+WebView.prototype.setWillHandleTouches = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.willHandleTouches = __SLAG__PROPERTY;
+};
+WebView.prototype.getLightTouchEnabled = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lightTouchEnabled;
+};
+WebView.prototype.setLightTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lightTouchEnabled = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new WebView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/Window.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/Window.js
@@ -1,0 +1,2753 @@
+var crypto = require('crypto');
+function Window(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundDisabledColor',
+			'backgroundDisabledImage',
+			'backgroundFocusedColor',
+			'backgroundFocusedImage',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundSelectedColor',
+			'backgroundSelectedImage',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'elevation',
+			'focusable',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'overrideCurrentAnimation',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'rotation',
+			'rotationX',
+			'rotationY',
+			'scaleX',
+			'scaleY',
+			'size',
+			'softKeyboardOnFocus',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'translationX',
+			'translationY',
+			'translationZ',
+			'transitionName',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'keepScreenOn',
+			'activity',
+			'backButtonTitle',
+			'backButtonTitleImage',
+			'barColor',
+			'barImage',
+			'exitOnClose',
+			'extendEdges',
+			'flagSecure',
+			'includeOpaqueBars',
+			'autoAdjustScrollViewInsets',
+			'fullscreen',
+			'hideShadow',
+			'hidesBarsOnSwipe',
+			'hidesBarsOnTap',
+			'hidesBarsWhenKeyboardAppears',
+			'leftNavButton',
+			'leftNavButtons',
+			'modal',
+			'navBarHidden',
+			'navTintColor',
+			'onBack',
+			'orientationModes',
+			'orientation',
+			'rightNavButton',
+			'rightNavButtons',
+			'shadowImage',
+			'splitActionBar',
+			'statusBarStyle',
+			'swipeToClose',
+			'tabBarHidden',
+			'theme',
+			'title',
+			'titleAttributes',
+			'titleControl',
+			'titleImage',
+			'titlePrompt',
+			'titleid',
+			'titlepromptid',
+			'toolbar',
+			'transitionAnimation',
+			'translucent',
+			'url',
+			'windowFlags',
+			'windowSoftInputMode',
+			'windowPixelFormat',
+			'activityExitTransition',
+			'activityEnterTransition',
+			'activityReturnTransition',
+			'activityReenterTransition',
+			'activitySharedElementExitTransition',
+			'activitySharedElementEnterTransition',
+			'activitySharedElementReturnTransition',
+			'activitySharedElementReenterTransition',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.Window.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.Window';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.Window.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledColor = undefined;
+	} else {
+		this.backgroundDisabledColor = __SLAG_PROPERTIES.backgroundDisabledColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundDisabledImage = undefined;
+	} else {
+		this.backgroundDisabledImage = __SLAG_PROPERTIES.backgroundDisabledImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedColor = undefined;
+	} else {
+		this.backgroundFocusedColor = __SLAG_PROPERTIES.backgroundFocusedColor || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundFocusedImage = undefined;
+	} else {
+		this.backgroundFocusedImage = __SLAG_PROPERTIES.backgroundFocusedImage || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedColor = undefined;
+	} else {
+		this.backgroundSelectedColor = __SLAG_PROPERTIES.backgroundSelectedColor || '';
+	}
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundSelectedImage = undefined;
+	} else {
+		this.backgroundSelectedImage = __SLAG_PROPERTIES.backgroundSelectedImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.Window.children is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elevation = undefined;
+	} else {
+		this.elevation = __SLAG_PROPERTIES.elevation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.focusable = undefined;
+	} else {
+		this.focusable = __SLAG_PROPERTIES.focusable || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.overrideCurrentAnimation = undefined;
+	} else {
+		this.overrideCurrentAnimation = __SLAG_PROPERTIES.overrideCurrentAnimation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.Window.rect is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotation = undefined;
+	} else {
+		this.rotation = __SLAG_PROPERTIES.rotation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationX = undefined;
+	} else {
+		this.rotationX = __SLAG_PROPERTIES.rotationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rotationY = undefined;
+	} else {
+		this.rotationY = __SLAG_PROPERTIES.rotationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleX = undefined;
+	} else {
+		this.scaleX = __SLAG_PROPERTIES.scaleX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.scaleY = undefined;
+	} else {
+		this.scaleY = __SLAG_PROPERTIES.scaleY || 0;
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.Window.size is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.softKeyboardOnFocus = undefined;
+	} else {
+		this.softKeyboardOnFocus = __SLAG_PROPERTIES.softKeyboardOnFocus || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationX = undefined;
+	} else {
+		this.translationX = __SLAG_PROPERTIES.translationX || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationY = undefined;
+	} else {
+		this.translationY = __SLAG_PROPERTIES.translationY || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translationZ = undefined;
+	} else {
+		this.translationZ = __SLAG_PROPERTIES.translationZ || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionName = undefined;
+	} else {
+		this.transitionName = __SLAG_PROPERTIES.transitionName || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.keepScreenOn = undefined;
+	} else {
+		this.keepScreenOn = __SLAG_PROPERTIES.keepScreenOn || true;
+	}
+	if (__SLAG_PROPERTIES.activity) {
+		throw new Error('Ti.UI.Window.activity is read only property');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activity = undefined;
+	} else {
+		this.activity = {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backButtonTitle = undefined;
+	} else {
+		this.backButtonTitle = __SLAG_PROPERTIES.backButtonTitle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backButtonTitleImage = undefined;
+	} else {
+		this.backButtonTitleImage = __SLAG_PROPERTIES.backButtonTitleImage || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barImage = undefined;
+	} else {
+		this.barImage = __SLAG_PROPERTIES.barImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.exitOnClose = undefined;
+	} else {
+		this.exitOnClose = __SLAG_PROPERTIES.exitOnClose || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.extendEdges = undefined;
+	} else {
+		this.extendEdges = __SLAG_PROPERTIES.extendEdges || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.flagSecure = undefined;
+	} else {
+		this.flagSecure = __SLAG_PROPERTIES.flagSecure || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.includeOpaqueBars = undefined;
+	} else {
+		this.includeOpaqueBars = __SLAG_PROPERTIES.includeOpaqueBars || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoAdjustScrollViewInsets = undefined;
+	} else {
+		this.autoAdjustScrollViewInsets = __SLAG_PROPERTIES.autoAdjustScrollViewInsets || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullscreen = undefined;
+	} else {
+		this.fullscreen = __SLAG_PROPERTIES.fullscreen || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hideShadow = undefined;
+	} else {
+		this.hideShadow = __SLAG_PROPERTIES.hideShadow || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnSwipe = undefined;
+	} else {
+		this.hidesBarsOnSwipe = __SLAG_PROPERTIES.hidesBarsOnSwipe || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnTap = undefined;
+	} else {
+		this.hidesBarsOnTap = __SLAG_PROPERTIES.hidesBarsOnTap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsWhenKeyboardAppears = undefined;
+	} else {
+		this.hidesBarsWhenKeyboardAppears = __SLAG_PROPERTIES.hidesBarsWhenKeyboardAppears || true;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftNavButton = undefined;
+	} else {
+		this.leftNavButton = __SLAG_PROPERTIES.leftNavButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftNavButtons = undefined;
+	} else {
+		this.leftNavButtons = __SLAG_PROPERTIES.leftNavButtons || [];
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modal = undefined;
+	} else {
+		this.modal = __SLAG_PROPERTIES.modal || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navBarHidden = undefined;
+	} else {
+		this.navBarHidden = __SLAG_PROPERTIES.navBarHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navTintColor = undefined;
+	} else {
+		this.navTintColor = __SLAG_PROPERTIES.navTintColor || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onBack = undefined;
+	} else {
+		this.onBack = __SLAG_PROPERTIES.onBack || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientationModes = undefined;
+	} else {
+		this.orientationModes = __SLAG_PROPERTIES.orientationModes || 0;
+	}
+	if (__SLAG_PROPERTIES.orientation) {
+		throw new Error('Ti.UI.Window.orientation is read only property');
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientation = undefined;
+	} else {
+		this.orientation = 0;
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightNavButton = undefined;
+	} else {
+		this.rightNavButton = __SLAG_PROPERTIES.rightNavButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightNavButtons = undefined;
+	} else {
+		this.rightNavButtons = __SLAG_PROPERTIES.rightNavButtons || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowImage = undefined;
+	} else {
+		this.shadowImage = __SLAG_PROPERTIES.shadowImage || '';
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.splitActionBar = undefined;
+	} else {
+		this.splitActionBar = __SLAG_PROPERTIES.splitActionBar || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.statusBarStyle = undefined;
+	} else {
+		this.statusBarStyle = __SLAG_PROPERTIES.statusBarStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.swipeToClose = undefined;
+	} else {
+		this.swipeToClose = __SLAG_PROPERTIES.swipeToClose || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabBarHidden = undefined;
+	} else {
+		this.tabBarHidden = __SLAG_PROPERTIES.tabBarHidden || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.theme = undefined;
+	} else {
+		this.theme = __SLAG_PROPERTIES.theme || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleAttributes = undefined;
+	} else {
+		this.titleAttributes = __SLAG_PROPERTIES.titleAttributes || {};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleControl = undefined;
+	} else {
+		this.titleControl = __SLAG_PROPERTIES.titleControl || {};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleImage = undefined;
+	} else {
+		this.titleImage = __SLAG_PROPERTIES.titleImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titlePrompt = undefined;
+	} else {
+		this.titlePrompt = __SLAG_PROPERTIES.titlePrompt || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titlepromptid = undefined;
+	} else {
+		this.titlepromptid = __SLAG_PROPERTIES.titlepromptid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.toolbar = undefined;
+	} else {
+		this.toolbar = __SLAG_PROPERTIES.toolbar || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionAnimation = undefined;
+	} else {
+		this.transitionAnimation = __SLAG_PROPERTIES.transitionAnimation || {};
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translucent = undefined;
+	} else {
+		this.translucent = __SLAG_PROPERTIES.translucent || true;
+	}
+	if (__SLAG_PROPERTIES.url) {
+		throw new Error('Ti.UI.Window.url was deprecated, since 3.5.0');
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.windowFlags = undefined;
+	} else {
+		this.windowFlags = __SLAG_PROPERTIES.windowFlags || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.windowSoftInputMode = undefined;
+	} else {
+		this.windowSoftInputMode = __SLAG_PROPERTIES.windowSoftInputMode || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.windowPixelFormat = undefined;
+	} else {
+		this.windowPixelFormat = __SLAG_PROPERTIES.windowPixelFormat || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityExitTransition = undefined;
+	} else {
+		this.activityExitTransition = __SLAG_PROPERTIES.activityExitTransition || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityEnterTransition = undefined;
+	} else {
+		this.activityEnterTransition = __SLAG_PROPERTIES.activityEnterTransition || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityReturnTransition = undefined;
+	} else {
+		this.activityReturnTransition = __SLAG_PROPERTIES.activityReturnTransition || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityReenterTransition = undefined;
+	} else {
+		this.activityReenterTransition = __SLAG_PROPERTIES.activityReenterTransition || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activitySharedElementExitTransition = undefined;
+	} else {
+		this.activitySharedElementExitTransition = __SLAG_PROPERTIES.activitySharedElementExitTransition || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activitySharedElementEnterTransition = undefined;
+	} else {
+		this.activitySharedElementEnterTransition = __SLAG_PROPERTIES.activitySharedElementEnterTransition || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activitySharedElementReturnTransition = undefined;
+	} else {
+		this.activitySharedElementReturnTransition = __SLAG_PROPERTIES.activitySharedElementReturnTransition || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activitySharedElementReenterTransition = undefined;
+	} else {
+		this.activitySharedElementReenterTransition = __SLAG_PROPERTIES.activitySharedElementReenterTransition || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Window.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Window.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Window.prototype.animate = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.Window.finishLayout was deprecated, since 3.0.0');
+};
+Window.prototype.hide = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.insertAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Window.prototype.replaceAt = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.show = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.startLayout = function () {
+	throw new Error('Ti.UI.Window.startLayout was deprecated, since 3.0.0');
+};
+Window.prototype.toImage = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Window.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.Window.updateLayout was deprecated, since 3.0.0');
+};
+Window.prototype.convertPointToView = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Window.prototype.addSharedElement = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.close = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.hideNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.hideTabBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.open = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.removeAllSharedElements = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.setToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.toolbar = __SLAG__PROPERTY;
+};
+Window.prototype.showNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.showToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.hideToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Window.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Window.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Window.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Window.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Window.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Window.prototype.getAccessibilityHidden = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Window.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Window.prototype.getAccessibilityHint = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Window.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Window.prototype.getAccessibilityLabel = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Window.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Window.prototype.getAccessibilityValue = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Window.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Window.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Window.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Window.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Window.prototype.getBackgroundColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Window.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundDisabledColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledColor;
+};
+Window.prototype.setBackgroundDisabledColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledColor = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundDisabledImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundDisabledImage;
+};
+Window.prototype.setBackgroundDisabledImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundDisabledImage = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundFocusedColor = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedColor;
+};
+Window.prototype.setBackgroundFocusedColor = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedColor = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundFocusedImage = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundFocusedImage;
+};
+Window.prototype.setBackgroundFocusedImage = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundFocusedImage = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundGradient = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Window.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundImage = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Window.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundRepeat = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+Window.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+Window.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundSelectedColor = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedColor;
+};
+Window.prototype.setBackgroundSelectedColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedColor = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundSelectedImage = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundSelectedImage;
+};
+Window.prototype.setBackgroundSelectedImage = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundSelectedImage = __SLAG__PROPERTY;
+};
+Window.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+Window.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+Window.prototype.getBorderColor = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Window.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Window.prototype.getBorderRadius = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Window.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Window.prototype.getBorderWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Window.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Window.prototype.getBottom = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Window.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Window.prototype.getCenter = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Window.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Window.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Window.prototype.getChildren = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Window.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Window.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Window.prototype.getElevation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elevation;
+};
+Window.prototype.setElevation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elevation = __SLAG__PROPERTY;
+};
+Window.prototype.getFocusable = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.focusable;
+};
+Window.prototype.setFocusable = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.focusable = __SLAG__PROPERTY;
+};
+Window.prototype.getHeight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Window.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Window.prototype.getLeft = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Window.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Window.prototype.getLayout = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+Window.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+Window.prototype.getOpacity = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Window.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Window.prototype.getOverrideCurrentAnimation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.overrideCurrentAnimation;
+};
+Window.prototype.setOverrideCurrentAnimation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.overrideCurrentAnimation = __SLAG__PROPERTY;
+};
+Window.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Window.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Window.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Window.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Window.prototype.getRight = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Window.prototype.setRight = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Window.prototype.getRect = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Window.prototype.getRotation = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotation;
+};
+Window.prototype.setRotation = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotation = __SLAG__PROPERTY;
+};
+Window.prototype.getRotationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationX;
+};
+Window.prototype.setRotationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationX = __SLAG__PROPERTY;
+};
+Window.prototype.getRotationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rotationY;
+};
+Window.prototype.setRotationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rotationY = __SLAG__PROPERTY;
+};
+Window.prototype.getScaleX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleX;
+};
+Window.prototype.setScaleX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleX = __SLAG__PROPERTY;
+};
+Window.prototype.getScaleY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.scaleY;
+};
+Window.prototype.setScaleY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.scaleY = __SLAG__PROPERTY;
+};
+Window.prototype.getSize = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Window.prototype.getSoftKeyboardOnFocus = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.softKeyboardOnFocus;
+};
+Window.prototype.setSoftKeyboardOnFocus = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.softKeyboardOnFocus = __SLAG__PROPERTY;
+};
+Window.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Window.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Window.prototype.getTop = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Window.prototype.setTop = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Window.prototype.getTouchEnabled = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Window.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Window.prototype.getTransform = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Window.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Window.prototype.getTranslationX = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationX;
+};
+Window.prototype.setTranslationX = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationX = __SLAG__PROPERTY;
+};
+Window.prototype.getTranslationY = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationY;
+};
+Window.prototype.setTranslationY = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationY = __SLAG__PROPERTY;
+};
+Window.prototype.getTranslationZ = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translationZ;
+};
+Window.prototype.setTranslationZ = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translationZ = __SLAG__PROPERTY;
+};
+Window.prototype.getTransitionName = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionName;
+};
+Window.prototype.setTransitionName = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionName = __SLAG__PROPERTY;
+};
+Window.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Window.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Window.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Window.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Window.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Window.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Window.prototype.getVisible = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Window.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Window.prototype.getWidth = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Window.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Window.prototype.getHorizontalWrap = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Window.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Window.prototype.getZIndex = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Window.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Window.prototype.getKeepScreenOn = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.keepScreenOn;
+};
+Window.prototype.setKeepScreenOn = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.keepScreenOn = __SLAG__PROPERTY;
+};
+Window.prototype.getActivity = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activity;
+};
+Window.prototype.getBackButtonTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backButtonTitle;
+};
+Window.prototype.setBackButtonTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backButtonTitle = __SLAG__PROPERTY;
+};
+Window.prototype.getBackButtonTitleImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backButtonTitleImage;
+};
+Window.prototype.setBackButtonTitleImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backButtonTitleImage = __SLAG__PROPERTY;
+};
+Window.prototype.getBarColor = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+Window.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+Window.prototype.getBarImage = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barImage;
+};
+Window.prototype.setBarImage = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barImage = __SLAG__PROPERTY;
+};
+Window.prototype.getExitOnClose = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.exitOnClose;
+};
+Window.prototype.setExitOnClose = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.exitOnClose = __SLAG__PROPERTY;
+};
+Window.prototype.getExtendEdges = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.extendEdges;
+};
+Window.prototype.setExtendEdges = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.extendEdges = __SLAG__PROPERTY;
+};
+Window.prototype.getFlagSecure = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.flagSecure;
+};
+Window.prototype.setFlagSecure = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.flagSecure = __SLAG__PROPERTY;
+};
+Window.prototype.getIncludeOpaqueBars = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.includeOpaqueBars;
+};
+Window.prototype.setIncludeOpaqueBars = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.includeOpaqueBars = __SLAG__PROPERTY;
+};
+Window.prototype.getAutoAdjustScrollViewInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoAdjustScrollViewInsets;
+};
+Window.prototype.setAutoAdjustScrollViewInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoAdjustScrollViewInsets = __SLAG__PROPERTY;
+};
+Window.prototype.getFullscreen = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fullscreen;
+};
+Window.prototype.setFullscreen = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fullscreen = __SLAG__PROPERTY;
+};
+Window.prototype.getHideShadow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hideShadow;
+};
+Window.prototype.setHideShadow = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hideShadow = __SLAG__PROPERTY;
+};
+Window.prototype.getHidesBarsOnSwipe = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnSwipe;
+};
+Window.prototype.setHidesBarsOnSwipe = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnSwipe = __SLAG__PROPERTY;
+};
+Window.prototype.getHidesBarsOnTap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnTap;
+};
+Window.prototype.setHidesBarsOnTap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnTap = __SLAG__PROPERTY;
+};
+Window.prototype.getHidesBarsWhenKeyboardAppears = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsWhenKeyboardAppears;
+};
+Window.prototype.setHidesBarsWhenKeyboardAppears = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsWhenKeyboardAppears = __SLAG__PROPERTY;
+};
+Window.prototype.getLeftNavButton = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftNavButton;
+};
+Window.prototype.setLeftNavButton = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftNavButton = __SLAG__PROPERTY;
+};
+Window.prototype.getLeftNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftNavButtons;
+};
+Window.prototype.setLeftNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftNavButtons = __SLAG__PROPERTY;
+};
+Window.prototype.getModal = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.modal;
+};
+Window.prototype.setModal = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.modal = __SLAG__PROPERTY;
+};
+Window.prototype.getNavBarHidden = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navBarHidden;
+};
+Window.prototype.setNavBarHidden = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navBarHidden = __SLAG__PROPERTY;
+};
+Window.prototype.getNavTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navTintColor;
+};
+Window.prototype.setNavTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navTintColor = __SLAG__PROPERTY;
+};
+Window.prototype.getOnBack = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onBack;
+};
+Window.prototype.setOnBack = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onBack = __SLAG__PROPERTY;
+};
+Window.prototype.getOrientationModes = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientationModes;
+};
+Window.prototype.setOrientationModes = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.orientationModes = __SLAG__PROPERTY;
+};
+Window.prototype.getOrientation = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientation;
+};
+Window.prototype.getRightNavButton = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightNavButton;
+};
+Window.prototype.setRightNavButton = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightNavButton = __SLAG__PROPERTY;
+};
+Window.prototype.getRightNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightNavButtons;
+};
+Window.prototype.setRightNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightNavButtons = __SLAG__PROPERTY;
+};
+Window.prototype.getShadowImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowImage;
+};
+Window.prototype.setShadowImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowImage = __SLAG__PROPERTY;
+};
+Window.prototype.getSplitActionBar = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.splitActionBar;
+};
+Window.prototype.setSplitActionBar = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.splitActionBar = __SLAG__PROPERTY;
+};
+Window.prototype.getStatusBarStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.statusBarStyle;
+};
+Window.prototype.setStatusBarStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.statusBarStyle = __SLAG__PROPERTY;
+};
+Window.prototype.getSwipeToClose = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.swipeToClose;
+};
+Window.prototype.setSwipeToClose = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.swipeToClose = __SLAG__PROPERTY;
+};
+Window.prototype.getTabBarHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabBarHidden;
+};
+Window.prototype.setTabBarHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabBarHidden = __SLAG__PROPERTY;
+};
+Window.prototype.getTheme = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.theme;
+};
+Window.prototype.setTheme = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.theme = __SLAG__PROPERTY;
+};
+Window.prototype.getTitle = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+Window.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+Window.prototype.getTitleAttributes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleAttributes;
+};
+Window.prototype.setTitleAttributes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleAttributes = __SLAG__PROPERTY;
+};
+Window.prototype.getTitleControl = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleControl;
+};
+Window.prototype.setTitleControl = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleControl = __SLAG__PROPERTY;
+};
+Window.prototype.getTitleImage = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleImage;
+};
+Window.prototype.setTitleImage = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleImage = __SLAG__PROPERTY;
+};
+Window.prototype.getTitlePrompt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titlePrompt;
+};
+Window.prototype.setTitlePrompt = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titlePrompt = __SLAG__PROPERTY;
+};
+Window.prototype.getTitleid = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+Window.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+Window.prototype.getTitlepromptid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titlepromptid;
+};
+Window.prototype.setTitlepromptid = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titlepromptid = __SLAG__PROPERTY;
+};
+Window.prototype.getToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.toolbar;
+};
+Window.prototype.setToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.toolbar = __SLAG__PROPERTY;
+};
+Window.prototype.getTransitionAnimation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transitionAnimation;
+};
+Window.prototype.setTransitionAnimation = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transitionAnimation = __SLAG__PROPERTY;
+};
+Window.prototype.getTranslucent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translucent;
+};
+Window.prototype.setTranslucent = function (__SLAG__PROPERTY) {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translucent = __SLAG__PROPERTY;
+};
+Window.prototype.getUrl = function () {
+	throw new Error('Ti.UI.Window.getUrl was deprecated, since 3.5.0');
+};
+Window.prototype.setUrl = function () {
+	throw new Error('Ti.UI.Window.setUrl was deprecated, since 3.5.0');
+};
+Window.prototype.getWindowFlags = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.windowFlags;
+};
+Window.prototype.setWindowFlags = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.windowFlags = __SLAG__PROPERTY;
+};
+Window.prototype.getWindowSoftInputMode = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.windowSoftInputMode;
+};
+Window.prototype.setWindowSoftInputMode = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.windowSoftInputMode = __SLAG__PROPERTY;
+};
+Window.prototype.getWindowPixelFormat = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.windowPixelFormat;
+};
+Window.prototype.setWindowPixelFormat = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.windowPixelFormat = __SLAG__PROPERTY;
+};
+Window.prototype.getActivityExitTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activityExitTransition;
+};
+Window.prototype.setActivityExitTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activityExitTransition = __SLAG__PROPERTY;
+};
+Window.prototype.getActivityEnterTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activityEnterTransition;
+};
+Window.prototype.setActivityEnterTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activityEnterTransition = __SLAG__PROPERTY;
+};
+Window.prototype.getActivityReturnTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activityReturnTransition;
+};
+Window.prototype.setActivityReturnTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activityReturnTransition = __SLAG__PROPERTY;
+};
+Window.prototype.getActivityReenterTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activityReenterTransition;
+};
+Window.prototype.setActivityReenterTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activityReenterTransition = __SLAG__PROPERTY;
+};
+Window.prototype.getActivitySharedElementExitTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activitySharedElementExitTransition;
+};
+Window.prototype.setActivitySharedElementExitTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activitySharedElementExitTransition = __SLAG__PROPERTY;
+};
+Window.prototype.getActivitySharedElementEnterTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activitySharedElementEnterTransition;
+};
+Window.prototype.setActivitySharedElementEnterTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activitySharedElementEnterTransition = __SLAG__PROPERTY;
+};
+Window.prototype.getActivitySharedElementReturnTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activitySharedElementReturnTransition;
+};
+Window.prototype.setActivitySharedElementReturnTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activitySharedElementReturnTransition = __SLAG__PROPERTY;
+};
+Window.prototype.getActivitySharedElementReenterTransition = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activitySharedElementReenterTransition;
+};
+Window.prototype.setActivitySharedElementReenterTransition = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.activitySharedElementReenterTransition = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Window(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS.js
@@ -1,0 +1,1497 @@
+var crypto = require('crypto');
+function iOS(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'ANIMATION_CURVE_EASE_IN',
+			'ANIMATION_CURVE_EASE_IN_OUT',
+			'ANIMATION_CURVE_EASE_OUT',
+			'ANIMATION_CURVE_LINEAR',
+			'ATTRIBUTE_FONT',
+			'ATTRIBUTE_FOREGROUND_COLOR',
+			'ATTRIBUTE_BACKGROUND_COLOR',
+			'ATTRIBUTE_LIGATURE',
+			'ATTRIBUTE_LETTERPRESS_STYLE',
+			'ATTRIBUTE_KERN',
+			'ATTRIBUTE_STRIKETHROUGH_STYLE',
+			'ATTRIBUTE_UNDERLINES_STYLE',
+			'ATTRIBUTE_STROKE_COLOR',
+			'ATTRIBUTE_STROKE_WIDTH',
+			'ATTRIBUTE_SHADOW',
+			'ATTRIBUTE_WRITING_DIRECTION',
+			'ATTRIBUTE_TEXT_EFFECT',
+			'ATTRIBUTE_LINK',
+			'ATTRIBUTE_BASELINE_OFFSET',
+			'ATTRIBUTE_UNDERLINE_COLOR',
+			'ATTRIBUTE_STRIKETHROUGH_COLOR',
+			'ATTRIBUTE_OBLIQUENESS',
+			'ATTRIBUTE_EXPANSION',
+			'ATTRIBUTE_UNDERLINE_STYLE_NONE',
+			'ATTRIBUTE_UNDERLINE_STYLE_SINGLE',
+			'ATTRIBUTE_UNDERLINE_STYLE_THICK',
+			'ATTRIBUTE_UNDERLINE_STYLE_DOUBLE',
+			'ATTRIBUTE_UNDERLINE_PATTERN_SOLID',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DOT',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DASH',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT',
+			'ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT',
+			'ATTRIBUTE_UNDERLINE_BY_WORD',
+			'ATTRIBUTE_WRITING_DIRECTION_EMBEDDING',
+			'ATTRIBUTE_WRITING_DIRECTION_OVERRIDE',
+			'ATTRIBUTE_WRITING_DIRECTION_NATURAL',
+			'ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT',
+			'ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT',
+			'AUTODETECT_ADDRESS',
+			'AUTODETECT_ALL',
+			'AUTODETECT_CALENDAR',
+			'AUTODETECT_LINK',
+			'AUTODETECT_NONE',
+			'AUTODETECT_PHONE',
+			'BLEND_MODE_CLEAR',
+			'BLEND_MODE_COLOR',
+			'BLEND_MODE_COLOR_BURN',
+			'BLEND_MODE_COLOR_DODGE',
+			'BLEND_MODE_COPY',
+			'BLEND_MODE_DARKEN',
+			'BLEND_MODE_DESTINATION_ATOP',
+			'BLEND_MODE_DESTINATION_IN',
+			'BLEND_MODE_DESTINATION_OUT',
+			'BLEND_MODE_DESTINATION_OVER',
+			'BLEND_MODE_DIFFERENCE',
+			'BLEND_MODE_EXCLUSION',
+			'BLEND_MODE_HARD_LIGHT',
+			'BLEND_MODE_HUE',
+			'BLEND_MODE_LIGHTEN',
+			'BLEND_MODE_LUMINOSITY',
+			'BLEND_MODE_MULTIPLY',
+			'BLEND_MODE_NORMAL',
+			'BLEND_MODE_OVERLAY',
+			'BLEND_MODE_PLUS_DARKER',
+			'BLEND_MODE_PLUS_LIGHTER',
+			'BLEND_MODE_SATURATION',
+			'BLEND_MODE_SCREEN',
+			'BLEND_MODE_SOFT_LIGHT',
+			'BLEND_MODE_SOURCE_ATOP',
+			'BLEND_MODE_SOURCE_IN',
+			'BLEND_MODE_SOURCE_OUT',
+			'BLEND_MODE_XOR',
+			'BLUR_EFFECT_STYLE_EXTRA_LIGHT',
+			'BLUR_EFFECT_STYLE_LIGHT',
+			'BLUR_EFFECT_STYLE_DARK',
+			'BLUR_EFFECT_STYLE_REGULAR',
+			'BLUR_EFFECT_STYLE_PROMINENT',
+			'AD_SIZE_PORTRAIT',
+			'AD_SIZE_LANDSCAPE',
+			'CLIP_MODE_DEFAULT',
+			'CLIP_MODE_DISABLED',
+			'CLIP_MODE_ENABLED',
+			'COLLISION_MODE_ALL',
+			'COLLISION_MODE_BOUNDARY',
+			'COLLISION_MODE_ITEM',
+			'COLOR_GROUP_TABLEVIEW_BACKGROUND',
+			'COLOR_SCROLLVIEW_BACKGROUND',
+			'COLOR_VIEW_FLIPSIDE_BACKGROUND',
+			'COLOR_UNDER_PAGE_BACKGROUND',
+			'forceTouchSupported',
+			'FEEDBACK_GENERATOR_TYPE_SELECTION',
+			'FEEDBACK_GENERATOR_TYPE_IMPACT',
+			'FEEDBACK_GENERATOR_TYPE_NOTIFICATION',
+			'FEEDBACK_GENERATOR_NOTIFICATION_TYPE_SUCCESS',
+			'FEEDBACK_GENERATOR_NOTIFICATION_TYPE_WARNING',
+			'FEEDBACK_GENERATOR_NOTIFICATION_TYPE_ERROR',
+			'FEEDBACK_GENERATOR_IMPACT_STYLE_LIGHT',
+			'FEEDBACK_GENERATOR_IMPACT_STYLE_MEDIUM',
+			'FEEDBACK_GENERATOR_IMPACT_STYLE_HEAVY',
+			'LIVEPHOTO_PLAYBACK_STYLE_FULL',
+			'LIVEPHOTO_PLAYBACK_STYLE_HINT',
+			'MENU_POPUP_ARROW_DIRECTION_UP',
+			'MENU_POPUP_ARROW_DIRECTION_DOWN',
+			'MENU_POPUP_ARROW_DIRECTION_LEFT',
+			'MENU_POPUP_ARROW_DIRECTION_RIGHT',
+			'MENU_POPUP_ARROW_DIRECTION_DEFAULT',
+			'PUSH_MODE_CONTINUOUS',
+			'PUSH_MODE_INSTANTANEOUS',
+			'PREVIEW_ACTION_STYLE_DEFAULT',
+			'PREVIEW_ACTION_STYLE_SELECTED',
+			'PREVIEW_ACTION_STYLE_DESTRUCTIVE',
+			'ROW_ACTION_STYLE_DEFAULT',
+			'ROW_ACTION_STYLE_DESTRUCTIVE',
+			'ROW_ACTION_STYLE_NORMAL',
+			'SCROLL_DECELERATION_RATE_FAST',
+			'SCROLL_DECELERATION_RATE_NORMAL',
+			'KEYBOARD_DISMISS_MODE_NONE',
+			'KEYBOARD_DISMISS_MODE_ON_DRAG',
+			'KEYBOARD_DISMISS_MODE_INTERACTIVE',
+			'SEARCH_BAR_STYLE_PROMINENT',
+			'SEARCH_BAR_STYLE_MINIMAL',
+			'WEBVIEW_NAVIGATIONTYPE_LINK_CLICKED',
+			'WEBVIEW_NAVIGATIONTYPE_FORM_SUBMITTED',
+			'WEBVIEW_NAVIGATIONTYPE_BACK_FORWARD',
+			'WEBVIEW_NAVIGATIONTYPE_RELOAD',
+			'WEBVIEW_NAVIGATIONTYPE_FORM_RESUBMITTED',
+			'WEBVIEW_NAVIGATIONTYPE_OTHER',
+			'TABLEVIEW_INDEX_SEARCH',
+			'SHORTCUT_ICON_TYPE_COMPOSE',
+			'SHORTCUT_ICON_TYPE_PLAY',
+			'SHORTCUT_ICON_TYPE_PAUSE',
+			'SHORTCUT_ICON_TYPE_ADD',
+			'SHORTCUT_ICON_TYPE_LOCATION',
+			'SHORTCUT_ICON_TYPE_SEARCH',
+			'SHORTCUT_ICON_TYPE_SHARE',
+			'SHORTCUT_ICON_TYPE_PROHIBIT',
+			'SHORTCUT_ICON_TYPE_CONTACT',
+			'SHORTCUT_ICON_TYPE_HOME',
+			'SHORTCUT_ICON_TYPE_MARK_LOCATION',
+			'SHORTCUT_ICON_TYPE_FAVORITE',
+			'SHORTCUT_ICON_TYPE_LOVE',
+			'SHORTCUT_ICON_TYPE_CLOUD',
+			'SHORTCUT_ICON_TYPE_INVITATION',
+			'SHORTCUT_ICON_TYPE_CONFIRMATION',
+			'SHORTCUT_ICON_TYPE_MAIL',
+			'SHORTCUT_ICON_TYPE_MESSAGE',
+			'SHORTCUT_ICON_TYPE_DATE',
+			'SHORTCUT_ICON_TYPE_TIME',
+			'SHORTCUT_ICON_TYPE_CAPTURE_PHOTO',
+			'SHORTCUT_ICON_TYPE_CAPTURE_VIDEO',
+			'SHORTCUT_ICON_TYPE_TASK',
+			'SHORTCUT_ICON_TYPE_TASK_COMPLETED',
+			'SHORTCUT_ICON_TYPE_ALARM',
+			'SHORTCUT_ICON_TYPE_BOOKMARK',
+			'SHORTCUT_ICON_TYPE_SHUFFLE',
+			'SHORTCUT_ICON_TYPE_AUDIO',
+			'SHORTCUT_ICON_TYPE_UPDATE',
+			'appBadge',
+			'appSupportsShakeToEdit',
+			'statusBarBackgroundColor',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS';
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_EASE_IN) {
+		throw new Error('Ti.UI.iOS.ANIMATION_CURVE_EASE_IN was deprecated, since 2.1.0');
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_EASE_IN_OUT) {
+		throw new Error('Ti.UI.iOS.ANIMATION_CURVE_EASE_IN_OUT was deprecated, since 2.1.0');
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_EASE_OUT) {
+		throw new Error('Ti.UI.iOS.ANIMATION_CURVE_EASE_OUT was deprecated, since 2.1.0');
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_CURVE_LINEAR) {
+		throw new Error('Ti.UI.iOS.ANIMATION_CURVE_LINEAR was deprecated, since 2.1.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_FONT) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_FONT was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_FOREGROUND_COLOR) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_FOREGROUND_COLOR was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_BACKGROUND_COLOR) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_BACKGROUND_COLOR was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LIGATURE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_LIGATURE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LETTERPRESS_STYLE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_LETTERPRESS_STYLE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_KERN) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_KERN was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STRIKETHROUGH_STYLE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_STRIKETHROUGH_STYLE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINES_STYLE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINES_STYLE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STROKE_COLOR) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_STROKE_COLOR was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STROKE_WIDTH) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_STROKE_WIDTH was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_SHADOW) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_SHADOW was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_WRITING_DIRECTION was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_TEXT_EFFECT) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_TEXT_EFFECT was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_LINK) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_LINK was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_BASELINE_OFFSET) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_BASELINE_OFFSET was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_COLOR) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_COLOR was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_STRIKETHROUGH_COLOR) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_STRIKETHROUGH_COLOR was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_OBLIQUENESS) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_OBLIQUENESS was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_EXPANSION) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_EXPANSION was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_NONE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_STYLE_NONE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_SINGLE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_STYLE_SINGLE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_THICK) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_STYLE_THICK was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_STYLE_DOUBLE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_STYLE_DOUBLE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_SOLID) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_PATTERN_SOLID was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DOT) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_PATTERN_DOT was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DASH) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_PATTERN_DASH was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_PATTERN_DASH_DOT_DOT was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_UNDERLINE_BY_WORD) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_UNDERLINE_BY_WORD was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_EMBEDDING) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_WRITING_DIRECTION_EMBEDDING was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_OVERRIDE) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_WRITING_DIRECTION_OVERRIDE was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_NATURAL) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_WRITING_DIRECTION_NATURAL was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_WRITING_DIRECTION_LEFT_TO_RIGHT was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT) {
+		throw new Error('Ti.UI.iOS.ATTRIBUTE_WRITING_DIRECTION_RIGHT_TO_LEFT was deprecated, since 3.6.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_ADDRESS) {
+		throw new Error('Ti.UI.iOS.AUTODETECT_ADDRESS was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_ALL) {
+		throw new Error('Ti.UI.iOS.AUTODETECT_ALL was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_CALENDAR) {
+		throw new Error('Ti.UI.iOS.AUTODETECT_CALENDAR was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_LINK) {
+		throw new Error('Ti.UI.iOS.AUTODETECT_LINK was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_NONE) {
+		throw new Error('Ti.UI.iOS.AUTODETECT_NONE was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.AUTODETECT_PHONE) {
+		throw new Error('Ti.UI.iOS.AUTODETECT_PHONE was deprecated, since 3.0.0');
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_CLEAR) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_CLEAR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_CLEAR = undefined;
+	} else {
+		this.BLEND_MODE_CLEAR = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COLOR) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_COLOR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_COLOR = undefined;
+	} else {
+		this.BLEND_MODE_COLOR = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COLOR_BURN) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_COLOR_BURN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_COLOR_BURN = undefined;
+	} else {
+		this.BLEND_MODE_COLOR_BURN = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COLOR_DODGE) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_COLOR_DODGE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_COLOR_DODGE = undefined;
+	} else {
+		this.BLEND_MODE_COLOR_DODGE = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_COPY) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_COPY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_COPY = undefined;
+	} else {
+		this.BLEND_MODE_COPY = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DARKEN) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_DARKEN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_DARKEN = undefined;
+	} else {
+		this.BLEND_MODE_DARKEN = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_ATOP) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_DESTINATION_ATOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_DESTINATION_ATOP = undefined;
+	} else {
+		this.BLEND_MODE_DESTINATION_ATOP = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_IN) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_DESTINATION_IN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_DESTINATION_IN = undefined;
+	} else {
+		this.BLEND_MODE_DESTINATION_IN = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_OUT) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_DESTINATION_OUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_DESTINATION_OUT = undefined;
+	} else {
+		this.BLEND_MODE_DESTINATION_OUT = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DESTINATION_OVER) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_DESTINATION_OVER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_DESTINATION_OVER = undefined;
+	} else {
+		this.BLEND_MODE_DESTINATION_OVER = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_DIFFERENCE) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_DIFFERENCE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_DIFFERENCE = undefined;
+	} else {
+		this.BLEND_MODE_DIFFERENCE = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_EXCLUSION) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_EXCLUSION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_EXCLUSION = undefined;
+	} else {
+		this.BLEND_MODE_EXCLUSION = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_HARD_LIGHT) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_HARD_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_HARD_LIGHT = undefined;
+	} else {
+		this.BLEND_MODE_HARD_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_HUE) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_HUE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_HUE = undefined;
+	} else {
+		this.BLEND_MODE_HUE = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_LIGHTEN) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_LIGHTEN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_LIGHTEN = undefined;
+	} else {
+		this.BLEND_MODE_LIGHTEN = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_LUMINOSITY) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_LUMINOSITY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_LUMINOSITY = undefined;
+	} else {
+		this.BLEND_MODE_LUMINOSITY = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_MULTIPLY) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_MULTIPLY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_MULTIPLY = undefined;
+	} else {
+		this.BLEND_MODE_MULTIPLY = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_NORMAL) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_NORMAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_NORMAL = undefined;
+	} else {
+		this.BLEND_MODE_NORMAL = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_OVERLAY) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_OVERLAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_OVERLAY = undefined;
+	} else {
+		this.BLEND_MODE_OVERLAY = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_PLUS_DARKER) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_PLUS_DARKER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_PLUS_DARKER = undefined;
+	} else {
+		this.BLEND_MODE_PLUS_DARKER = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_PLUS_LIGHTER) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_PLUS_LIGHTER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_PLUS_LIGHTER = undefined;
+	} else {
+		this.BLEND_MODE_PLUS_LIGHTER = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SATURATION) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_SATURATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_SATURATION = undefined;
+	} else {
+		this.BLEND_MODE_SATURATION = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SCREEN) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_SCREEN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_SCREEN = undefined;
+	} else {
+		this.BLEND_MODE_SCREEN = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOFT_LIGHT) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_SOFT_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_SOFT_LIGHT = undefined;
+	} else {
+		this.BLEND_MODE_SOFT_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOURCE_ATOP) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_SOURCE_ATOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_SOURCE_ATOP = undefined;
+	} else {
+		this.BLEND_MODE_SOURCE_ATOP = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOURCE_IN) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_SOURCE_IN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_SOURCE_IN = undefined;
+	} else {
+		this.BLEND_MODE_SOURCE_IN = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_SOURCE_OUT) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_SOURCE_OUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_SOURCE_OUT = undefined;
+	} else {
+		this.BLEND_MODE_SOURCE_OUT = 0;
+	}
+	if (__SLAG_PROPERTIES.BLEND_MODE_XOR) {
+		throw new Error('Ti.UI.iOS.BLEND_MODE_XOR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLEND_MODE_XOR = undefined;
+	} else {
+		this.BLEND_MODE_XOR = 0;
+	}
+	if (__SLAG_PROPERTIES.BLUR_EFFECT_STYLE_EXTRA_LIGHT) {
+		throw new Error('Ti.UI.iOS.BLUR_EFFECT_STYLE_EXTRA_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUR_EFFECT_STYLE_EXTRA_LIGHT = undefined;
+	} else {
+		this.BLUR_EFFECT_STYLE_EXTRA_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.BLUR_EFFECT_STYLE_LIGHT) {
+		throw new Error('Ti.UI.iOS.BLUR_EFFECT_STYLE_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUR_EFFECT_STYLE_LIGHT = undefined;
+	} else {
+		this.BLUR_EFFECT_STYLE_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.BLUR_EFFECT_STYLE_DARK) {
+		throw new Error('Ti.UI.iOS.BLUR_EFFECT_STYLE_DARK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUR_EFFECT_STYLE_DARK = undefined;
+	} else {
+		this.BLUR_EFFECT_STYLE_DARK = 0;
+	}
+	if (__SLAG_PROPERTIES.BLUR_EFFECT_STYLE_REGULAR) {
+		throw new Error('Ti.UI.iOS.BLUR_EFFECT_STYLE_REGULAR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUR_EFFECT_STYLE_REGULAR = undefined;
+	} else {
+		this.BLUR_EFFECT_STYLE_REGULAR = 0;
+	}
+	if (__SLAG_PROPERTIES.BLUR_EFFECT_STYLE_PROMINENT) {
+		throw new Error('Ti.UI.iOS.BLUR_EFFECT_STYLE_PROMINENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUR_EFFECT_STYLE_PROMINENT = undefined;
+	} else {
+		this.BLUR_EFFECT_STYLE_PROMINENT = 0;
+	}
+	if (__SLAG_PROPERTIES.AD_SIZE_PORTRAIT) {
+		throw new Error('Ti.UI.iOS.AD_SIZE_PORTRAIT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AD_SIZE_PORTRAIT = undefined;
+	} else {
+		this.AD_SIZE_PORTRAIT = '';
+	}
+	if (__SLAG_PROPERTIES.AD_SIZE_LANDSCAPE) {
+		throw new Error('Ti.UI.iOS.AD_SIZE_LANDSCAPE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.AD_SIZE_LANDSCAPE = undefined;
+	} else {
+		this.AD_SIZE_LANDSCAPE = '';
+	}
+	if (__SLAG_PROPERTIES.CLIP_MODE_DEFAULT) {
+		throw new Error('Ti.UI.iOS.CLIP_MODE_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CLIP_MODE_DEFAULT = undefined;
+	} else {
+		this.CLIP_MODE_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.CLIP_MODE_DISABLED) {
+		throw new Error('Ti.UI.iOS.CLIP_MODE_DISABLED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CLIP_MODE_DISABLED = undefined;
+	} else {
+		this.CLIP_MODE_DISABLED = 0;
+	}
+	if (__SLAG_PROPERTIES.CLIP_MODE_ENABLED) {
+		throw new Error('Ti.UI.iOS.CLIP_MODE_ENABLED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CLIP_MODE_ENABLED = undefined;
+	} else {
+		this.CLIP_MODE_ENABLED = 0;
+	}
+	if (__SLAG_PROPERTIES.COLLISION_MODE_ALL) {
+		throw new Error('Ti.UI.iOS.COLLISION_MODE_ALL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COLLISION_MODE_ALL = undefined;
+	} else {
+		this.COLLISION_MODE_ALL = 0;
+	}
+	if (__SLAG_PROPERTIES.COLLISION_MODE_BOUNDARY) {
+		throw new Error('Ti.UI.iOS.COLLISION_MODE_BOUNDARY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COLLISION_MODE_BOUNDARY = undefined;
+	} else {
+		this.COLLISION_MODE_BOUNDARY = 0;
+	}
+	if (__SLAG_PROPERTIES.COLLISION_MODE_ITEM) {
+		throw new Error('Ti.UI.iOS.COLLISION_MODE_ITEM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COLLISION_MODE_ITEM = undefined;
+	} else {
+		this.COLLISION_MODE_ITEM = 0;
+	}
+	if (__SLAG_PROPERTIES.COLOR_GROUP_TABLEVIEW_BACKGROUND) {
+		throw new Error('Ti.UI.iOS.COLOR_GROUP_TABLEVIEW_BACKGROUND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COLOR_GROUP_TABLEVIEW_BACKGROUND = undefined;
+	} else {
+		this.COLOR_GROUP_TABLEVIEW_BACKGROUND = '';
+	}
+	if (__SLAG_PROPERTIES.COLOR_SCROLLVIEW_BACKGROUND) {
+		throw new Error('Ti.UI.iOS.COLOR_SCROLLVIEW_BACKGROUND was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.COLOR_VIEW_FLIPSIDE_BACKGROUND) {
+		throw new Error('Ti.UI.iOS.COLOR_VIEW_FLIPSIDE_BACKGROUND was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.COLOR_UNDER_PAGE_BACKGROUND) {
+		throw new Error('Ti.UI.iOS.COLOR_UNDER_PAGE_BACKGROUND was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.forceTouchSupported) {
+		throw new Error('Ti.UI.iOS.forceTouchSupported is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.forceTouchSupported = undefined;
+	} else {
+		this.forceTouchSupported = true;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_TYPE_SELECTION) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_TYPE_SELECTION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_TYPE_SELECTION = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_TYPE_SELECTION = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_TYPE_IMPACT) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_TYPE_IMPACT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_TYPE_IMPACT = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_TYPE_IMPACT = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_TYPE_NOTIFICATION) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_TYPE_NOTIFICATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_TYPE_NOTIFICATION = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_TYPE_NOTIFICATION = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_SUCCESS) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_SUCCESS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_SUCCESS = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_SUCCESS = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_WARNING) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_WARNING is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_WARNING = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_WARNING = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_ERROR) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_ERROR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_ERROR = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_NOTIFICATION_TYPE_ERROR = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_IMPACT_STYLE_LIGHT) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_IMPACT_STYLE_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_IMPACT_STYLE_LIGHT = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_IMPACT_STYLE_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_IMPACT_STYLE_MEDIUM) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_IMPACT_STYLE_MEDIUM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_IMPACT_STYLE_MEDIUM = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_IMPACT_STYLE_MEDIUM = 0;
+	}
+	if (__SLAG_PROPERTIES.FEEDBACK_GENERATOR_IMPACT_STYLE_HEAVY) {
+		throw new Error('Ti.UI.iOS.FEEDBACK_GENERATOR_IMPACT_STYLE_HEAVY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEEDBACK_GENERATOR_IMPACT_STYLE_HEAVY = undefined;
+	} else {
+		this.FEEDBACK_GENERATOR_IMPACT_STYLE_HEAVY = 0;
+	}
+	if (__SLAG_PROPERTIES.LIVEPHOTO_PLAYBACK_STYLE_FULL) {
+		throw new Error('Ti.UI.iOS.LIVEPHOTO_PLAYBACK_STYLE_FULL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIVEPHOTO_PLAYBACK_STYLE_FULL = undefined;
+	} else {
+		this.LIVEPHOTO_PLAYBACK_STYLE_FULL = 0;
+	}
+	if (__SLAG_PROPERTIES.LIVEPHOTO_PLAYBACK_STYLE_HINT) {
+		throw new Error('Ti.UI.iOS.LIVEPHOTO_PLAYBACK_STYLE_HINT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIVEPHOTO_PLAYBACK_STYLE_HINT = undefined;
+	} else {
+		this.LIVEPHOTO_PLAYBACK_STYLE_HINT = 0;
+	}
+	if (__SLAG_PROPERTIES.MENU_POPUP_ARROW_DIRECTION_UP) {
+		throw new Error('Ti.UI.iOS.MENU_POPUP_ARROW_DIRECTION_UP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MENU_POPUP_ARROW_DIRECTION_UP = undefined;
+	} else {
+		this.MENU_POPUP_ARROW_DIRECTION_UP = 0;
+	}
+	if (__SLAG_PROPERTIES.MENU_POPUP_ARROW_DIRECTION_DOWN) {
+		throw new Error('Ti.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MENU_POPUP_ARROW_DIRECTION_DOWN = undefined;
+	} else {
+		this.MENU_POPUP_ARROW_DIRECTION_DOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.MENU_POPUP_ARROW_DIRECTION_LEFT) {
+		throw new Error('Ti.UI.iOS.MENU_POPUP_ARROW_DIRECTION_LEFT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MENU_POPUP_ARROW_DIRECTION_LEFT = undefined;
+	} else {
+		this.MENU_POPUP_ARROW_DIRECTION_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.MENU_POPUP_ARROW_DIRECTION_RIGHT) {
+		throw new Error('Ti.UI.iOS.MENU_POPUP_ARROW_DIRECTION_RIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MENU_POPUP_ARROW_DIRECTION_RIGHT = undefined;
+	} else {
+		this.MENU_POPUP_ARROW_DIRECTION_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.MENU_POPUP_ARROW_DIRECTION_DEFAULT) {
+		throw new Error('Ti.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MENU_POPUP_ARROW_DIRECTION_DEFAULT = undefined;
+	} else {
+		this.MENU_POPUP_ARROW_DIRECTION_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.PUSH_MODE_CONTINUOUS) {
+		throw new Error('Ti.UI.iOS.PUSH_MODE_CONTINUOUS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PUSH_MODE_CONTINUOUS = undefined;
+	} else {
+		this.PUSH_MODE_CONTINUOUS = 0;
+	}
+	if (__SLAG_PROPERTIES.PUSH_MODE_INSTANTANEOUS) {
+		throw new Error('Ti.UI.iOS.PUSH_MODE_INSTANTANEOUS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PUSH_MODE_INSTANTANEOUS = undefined;
+	} else {
+		this.PUSH_MODE_INSTANTANEOUS = 0;
+	}
+	if (__SLAG_PROPERTIES.PREVIEW_ACTION_STYLE_DEFAULT) {
+		throw new Error('Ti.UI.iOS.PREVIEW_ACTION_STYLE_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PREVIEW_ACTION_STYLE_DEFAULT = undefined;
+	} else {
+		this.PREVIEW_ACTION_STYLE_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.PREVIEW_ACTION_STYLE_SELECTED) {
+		throw new Error('Ti.UI.iOS.PREVIEW_ACTION_STYLE_SELECTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PREVIEW_ACTION_STYLE_SELECTED = undefined;
+	} else {
+		this.PREVIEW_ACTION_STYLE_SELECTED = 0;
+	}
+	if (__SLAG_PROPERTIES.PREVIEW_ACTION_STYLE_DESTRUCTIVE) {
+		throw new Error('Ti.UI.iOS.PREVIEW_ACTION_STYLE_DESTRUCTIVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PREVIEW_ACTION_STYLE_DESTRUCTIVE = undefined;
+	} else {
+		this.PREVIEW_ACTION_STYLE_DESTRUCTIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.ROW_ACTION_STYLE_DEFAULT) {
+		throw new Error('Ti.UI.iOS.ROW_ACTION_STYLE_DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ROW_ACTION_STYLE_DEFAULT = undefined;
+	} else {
+		this.ROW_ACTION_STYLE_DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.ROW_ACTION_STYLE_DESTRUCTIVE) {
+		throw new Error('Ti.UI.iOS.ROW_ACTION_STYLE_DESTRUCTIVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ROW_ACTION_STYLE_DESTRUCTIVE = undefined;
+	} else {
+		this.ROW_ACTION_STYLE_DESTRUCTIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.ROW_ACTION_STYLE_NORMAL) {
+		throw new Error('Ti.UI.iOS.ROW_ACTION_STYLE_NORMAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ROW_ACTION_STYLE_NORMAL = undefined;
+	} else {
+		this.ROW_ACTION_STYLE_NORMAL = 0;
+	}
+	if (__SLAG_PROPERTIES.SCROLL_DECELERATION_RATE_FAST) {
+		throw new Error('Ti.UI.iOS.SCROLL_DECELERATION_RATE_FAST is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCROLL_DECELERATION_RATE_FAST = undefined;
+	} else {
+		this.SCROLL_DECELERATION_RATE_FAST = 0;
+	}
+	if (__SLAG_PROPERTIES.SCROLL_DECELERATION_RATE_NORMAL) {
+		throw new Error('Ti.UI.iOS.SCROLL_DECELERATION_RATE_NORMAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SCROLL_DECELERATION_RATE_NORMAL = undefined;
+	} else {
+		this.SCROLL_DECELERATION_RATE_NORMAL = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_DISMISS_MODE_NONE) {
+		throw new Error('Ti.UI.iOS.KEYBOARD_DISMISS_MODE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_DISMISS_MODE_NONE = undefined;
+	} else {
+		this.KEYBOARD_DISMISS_MODE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_DISMISS_MODE_ON_DRAG) {
+		throw new Error('Ti.UI.iOS.KEYBOARD_DISMISS_MODE_ON_DRAG is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_DISMISS_MODE_ON_DRAG = undefined;
+	} else {
+		this.KEYBOARD_DISMISS_MODE_ON_DRAG = 0;
+	}
+	if (__SLAG_PROPERTIES.KEYBOARD_DISMISS_MODE_INTERACTIVE) {
+		throw new Error('Ti.UI.iOS.KEYBOARD_DISMISS_MODE_INTERACTIVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.KEYBOARD_DISMISS_MODE_INTERACTIVE = undefined;
+	} else {
+		this.KEYBOARD_DISMISS_MODE_INTERACTIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.SEARCH_BAR_STYLE_PROMINENT) {
+		throw new Error('Ti.UI.iOS.SEARCH_BAR_STYLE_PROMINENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SEARCH_BAR_STYLE_PROMINENT = undefined;
+	} else {
+		this.SEARCH_BAR_STYLE_PROMINENT = 0;
+	}
+	if (__SLAG_PROPERTIES.SEARCH_BAR_STYLE_MINIMAL) {
+		throw new Error('Ti.UI.iOS.SEARCH_BAR_STYLE_MINIMAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SEARCH_BAR_STYLE_MINIMAL = undefined;
+	} else {
+		this.SEARCH_BAR_STYLE_MINIMAL = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_NAVIGATIONTYPE_LINK_CLICKED) {
+		throw new Error('Ti.UI.iOS.WEBVIEW_NAVIGATIONTYPE_LINK_CLICKED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_NAVIGATIONTYPE_LINK_CLICKED = undefined;
+	} else {
+		this.WEBVIEW_NAVIGATIONTYPE_LINK_CLICKED = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_NAVIGATIONTYPE_FORM_SUBMITTED) {
+		throw new Error('Ti.UI.iOS.WEBVIEW_NAVIGATIONTYPE_FORM_SUBMITTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_NAVIGATIONTYPE_FORM_SUBMITTED = undefined;
+	} else {
+		this.WEBVIEW_NAVIGATIONTYPE_FORM_SUBMITTED = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_NAVIGATIONTYPE_BACK_FORWARD) {
+		throw new Error('Ti.UI.iOS.WEBVIEW_NAVIGATIONTYPE_BACK_FORWARD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_NAVIGATIONTYPE_BACK_FORWARD = undefined;
+	} else {
+		this.WEBVIEW_NAVIGATIONTYPE_BACK_FORWARD = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_NAVIGATIONTYPE_RELOAD) {
+		throw new Error('Ti.UI.iOS.WEBVIEW_NAVIGATIONTYPE_RELOAD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_NAVIGATIONTYPE_RELOAD = undefined;
+	} else {
+		this.WEBVIEW_NAVIGATIONTYPE_RELOAD = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_NAVIGATIONTYPE_FORM_RESUBMITTED) {
+		throw new Error('Ti.UI.iOS.WEBVIEW_NAVIGATIONTYPE_FORM_RESUBMITTED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_NAVIGATIONTYPE_FORM_RESUBMITTED = undefined;
+	} else {
+		this.WEBVIEW_NAVIGATIONTYPE_FORM_RESUBMITTED = 0;
+	}
+	if (__SLAG_PROPERTIES.WEBVIEW_NAVIGATIONTYPE_OTHER) {
+		throw new Error('Ti.UI.iOS.WEBVIEW_NAVIGATIONTYPE_OTHER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WEBVIEW_NAVIGATIONTYPE_OTHER = undefined;
+	} else {
+		this.WEBVIEW_NAVIGATIONTYPE_OTHER = 0;
+	}
+	if (__SLAG_PROPERTIES.TABLEVIEW_INDEX_SEARCH) {
+		throw new Error('Ti.UI.iOS.TABLEVIEW_INDEX_SEARCH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TABLEVIEW_INDEX_SEARCH = undefined;
+	} else {
+		this.TABLEVIEW_INDEX_SEARCH = '';
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_COMPOSE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_COMPOSE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_COMPOSE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_COMPOSE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_PLAY) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_PLAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_PLAY = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_PLAY = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_PAUSE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_PAUSE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_PAUSE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_PAUSE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_ADD) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_ADD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_ADD = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_ADD = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_LOCATION) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_LOCATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_LOCATION = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_LOCATION = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_SEARCH) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_SEARCH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_SEARCH = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_SEARCH = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_SHARE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_SHARE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_SHARE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_SHARE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_PROHIBIT) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_PROHIBIT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_PROHIBIT = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_PROHIBIT = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_CONTACT) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_CONTACT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_CONTACT = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_CONTACT = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_HOME) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_HOME is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_HOME = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_HOME = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_MARK_LOCATION) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_MARK_LOCATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_MARK_LOCATION = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_MARK_LOCATION = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_FAVORITE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_FAVORITE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_FAVORITE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_FAVORITE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_LOVE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_LOVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_LOVE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_LOVE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_CLOUD) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_CLOUD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_CLOUD = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_CLOUD = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_INVITATION) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_INVITATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_INVITATION = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_INVITATION = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_CONFIRMATION) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_CONFIRMATION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_CONFIRMATION = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_CONFIRMATION = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_MAIL) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_MAIL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_MAIL = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_MAIL = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_MESSAGE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_MESSAGE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_MESSAGE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_MESSAGE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_DATE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_DATE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_DATE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_DATE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_TIME) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_TIME is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_TIME = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_TIME = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_CAPTURE_PHOTO) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_CAPTURE_PHOTO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_CAPTURE_PHOTO = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_CAPTURE_PHOTO = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_CAPTURE_VIDEO) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_CAPTURE_VIDEO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_CAPTURE_VIDEO = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_CAPTURE_VIDEO = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_TASK) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_TASK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_TASK = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_TASK = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_TASK_COMPLETED) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_TASK_COMPLETED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_TASK_COMPLETED = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_TASK_COMPLETED = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_ALARM) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_ALARM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_ALARM = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_ALARM = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_BOOKMARK) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_BOOKMARK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_BOOKMARK = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_BOOKMARK = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_SHUFFLE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_SHUFFLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_SHUFFLE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_SHUFFLE = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_AUDIO) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_AUDIO is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_AUDIO = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_AUDIO = 0;
+	}
+	if (__SLAG_PROPERTIES.SHORTCUT_ICON_TYPE_UPDATE) {
+		throw new Error('Ti.UI.iOS.SHORTCUT_ICON_TYPE_UPDATE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SHORTCUT_ICON_TYPE_UPDATE = undefined;
+	} else {
+		this.SHORTCUT_ICON_TYPE_UPDATE = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.appBadge = undefined;
+	} else {
+		this.appBadge = __SLAG_PROPERTIES.appBadge || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.appSupportsShakeToEdit = undefined;
+	} else {
+		this.appSupportsShakeToEdit = __SLAG_PROPERTIES.appSupportsShakeToEdit || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.statusBarBackgroundColor = undefined;
+	} else {
+		this.statusBarBackgroundColor = __SLAG_PROPERTIES.statusBarBackgroundColor || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+iOS.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iOS.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+iOS.prototype.createTransitionAnimation = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TransitionAnimation = require('./iOS/TransitionAnimation');
+	return TransitionAnimation(__SLAG_PROPERTY);
+};
+iOS.prototype.create3DMatrix = function () {
+	throw new Error('Ti.UI.iOS.create3DMatrix was deprecated, since 2.1.0');
+};
+iOS.prototype.createAdView = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var AdView = require('./iOS/AdView');
+	return AdView(__SLAG_PROPERTY);
+};
+iOS.prototype.createAnchorAttachmentBehavior = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var AnchorAttachmentBehavior = require('./iOS/AnchorAttachmentBehavior');
+	return AnchorAttachmentBehavior(__SLAG_PROPERTY);
+};
+iOS.prototype.createAnimator = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Animator = require('./iOS/Animator');
+	return Animator(__SLAG_PROPERTY);
+};
+iOS.prototype.createApplicationShortcuts = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ApplicationShortcuts = require('./iOS/ApplicationShortcuts');
+	return ApplicationShortcuts(__SLAG_PROPERTY);
+};
+iOS.prototype.createAttribute = function () {
+	throw new Error('Ti.UI.iOS.createAttribute was deprecated, since 3.6.0');
+};
+iOS.prototype.createAttributedString = function () {
+	throw new Error('Ti.UI.iOS.createAttributedString was deprecated, since 3.6.0');
+};
+iOS.prototype.createBlurView = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var BlurView = require('./iOS/BlurView');
+	return BlurView(__SLAG_PROPERTY);
+};
+iOS.prototype.createCollisionBehavior = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var CollisionBehavior = require('./iOS/CollisionBehavior');
+	return CollisionBehavior(__SLAG_PROPERTY);
+};
+iOS.prototype.createCoverFlowView = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var CoverFlowView = require('./iOS/CoverFlowView');
+	return CoverFlowView(__SLAG_PROPERTY);
+};
+iOS.prototype.createDocumentViewer = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var DocumentViewer = require('./iOS/DocumentViewer');
+	return DocumentViewer(__SLAG_PROPERTY);
+};
+iOS.prototype.createDynamicItemBehavior = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var DynamicItemBehavior = require('./iOS/DynamicItemBehavior');
+	return DynamicItemBehavior(__SLAG_PROPERTY);
+};
+iOS.prototype.createFeedbackGenerator = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var FeedbackGenerator = require('./iOS/FeedbackGenerator');
+	return FeedbackGenerator(__SLAG_PROPERTY);
+};
+iOS.prototype.createGravityBehavior = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var GravityBehavior = require('./iOS/GravityBehavior');
+	return GravityBehavior(__SLAG_PROPERTY);
+};
+iOS.prototype.createLivePhotoView = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var LivePhotoView = require('./iOS/LivePhotoView');
+	return LivePhotoView(__SLAG_PROPERTY);
+};
+iOS.prototype.createNavigationWindow = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var NavigationWindow = require('./iOS/NavigationWindow');
+	return NavigationWindow(__SLAG_PROPERTY);
+};
+iOS.prototype.createPreviewAction = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var PreviewAction = require('./iOS/PreviewAction');
+	return PreviewAction(__SLAG_PROPERTY);
+};
+iOS.prototype.createPreviewActionGroup = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var PreviewActionGroup = require('./iOS/PreviewActionGroup');
+	return PreviewActionGroup(__SLAG_PROPERTY);
+};
+iOS.prototype.createPreviewContext = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var PreviewContext = require('./iOS/PreviewContext');
+	return PreviewContext(__SLAG_PROPERTY);
+};
+iOS.prototype.createPushBehavior = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var PushBehavior = require('./iOS/PushBehavior');
+	return PushBehavior(__SLAG_PROPERTY);
+};
+iOS.prototype.createSnapBehavior = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SnapBehavior = require('./iOS/SnapBehavior');
+	return SnapBehavior(__SLAG_PROPERTY);
+};
+iOS.prototype.createSplitWindow = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SplitWindow = require('./iOS/SplitWindow');
+	return SplitWindow(__SLAG_PROPERTY);
+};
+iOS.prototype.createStepper = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Stepper = require('./iOS/Stepper');
+	return Stepper(__SLAG_PROPERTY);
+};
+iOS.prototype.createSystemButton = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var SystemButton = require('./iOS/SystemButton');
+	return SystemButton(__SLAG_PROPERTY);
+};
+iOS.prototype.createTabbedBar = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TabbedBar = require('./iOS/TabbedBar');
+	return TabbedBar(__SLAG_PROPERTY);
+};
+iOS.prototype.createToolbar = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Toolbar = require('./iOS/Toolbar');
+	return Toolbar(__SLAG_PROPERTY);
+};
+iOS.prototype.createViewAttachmentBehavior = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ViewAttachmentBehavior = require('./iOS/ViewAttachmentBehavior');
+	return ViewAttachmentBehavior(__SLAG_PROPERTY);
+};
+iOS.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+iOS.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+iOS.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+iOS.prototype.getForceTouchSupported = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.forceTouchSupported;
+};
+iOS.prototype.getAppBadge = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.appBadge;
+};
+iOS.prototype.setAppBadge = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.appBadge = __SLAG__PROPERTY;
+};
+iOS.prototype.getAppSupportsShakeToEdit = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.appSupportsShakeToEdit;
+};
+iOS.prototype.setAppSupportsShakeToEdit = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.appSupportsShakeToEdit = __SLAG__PROPERTY;
+};
+iOS.prototype.getStatusBarBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.statusBarBackgroundColor;
+};
+iOS.prototype.setStatusBarBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.statusBarBackgroundColor = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new iOS(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/3DMatrix.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/3DMatrix.js
@@ -1,0 +1,393 @@
+var crypto = require('crypto');
+function ThreeDMatrix(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'm11',
+			'm12',
+			'm13',
+			'm14',
+			'm21',
+			'm22',
+			'm23',
+			'm24',
+			'm31',
+			'm32',
+			'm33',
+			'm34',
+			'm41',
+			'm42',
+			'm43',
+			'm44',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.3DMatrix.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.3DMatrix';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m11 = undefined;
+	} else {
+		this.m11 = __SLAG_PROPERTIES.m11 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m12 = undefined;
+	} else {
+		this.m12 = __SLAG_PROPERTIES.m12 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m13 = undefined;
+	} else {
+		this.m13 = __SLAG_PROPERTIES.m13 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m14 = undefined;
+	} else {
+		this.m14 = __SLAG_PROPERTIES.m14 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m21 = undefined;
+	} else {
+		this.m21 = __SLAG_PROPERTIES.m21 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m22 = undefined;
+	} else {
+		this.m22 = __SLAG_PROPERTIES.m22 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m23 = undefined;
+	} else {
+		this.m23 = __SLAG_PROPERTIES.m23 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m24 = undefined;
+	} else {
+		this.m24 = __SLAG_PROPERTIES.m24 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m31 = undefined;
+	} else {
+		this.m31 = __SLAG_PROPERTIES.m31 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m32 = undefined;
+	} else {
+		this.m32 = __SLAG_PROPERTIES.m32 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m33 = undefined;
+	} else {
+		this.m33 = __SLAG_PROPERTIES.m33 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m34 = undefined;
+	} else {
+		this.m34 = __SLAG_PROPERTIES.m34 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m41 = undefined;
+	} else {
+		this.m41 = __SLAG_PROPERTIES.m41 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m42 = undefined;
+	} else {
+		this.m42 = __SLAG_PROPERTIES.m42 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m43 = undefined;
+	} else {
+		this.m43 = __SLAG_PROPERTIES.m43 || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.m44 = undefined;
+	} else {
+		this.m44 = __SLAG_PROPERTIES.m44 || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ThreeDMatrix.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ThreeDMatrix.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ThreeDMatrix.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ThreeDMatrix.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ThreeDMatrix.prototype.invert = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.multiply = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.rotate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.scale = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.translate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+ThreeDMatrix.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ThreeDMatrix.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ThreeDMatrix.prototype.getM11 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m11;
+};
+ThreeDMatrix.prototype.setM11 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m11 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM12 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m12;
+};
+ThreeDMatrix.prototype.setM12 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m12 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM13 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m13;
+};
+ThreeDMatrix.prototype.setM13 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m13 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM14 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m14;
+};
+ThreeDMatrix.prototype.setM14 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m14 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM21 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m21;
+};
+ThreeDMatrix.prototype.setM21 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m21 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM22 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m22;
+};
+ThreeDMatrix.prototype.setM22 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m22 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM23 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m23;
+};
+ThreeDMatrix.prototype.setM23 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m23 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM24 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m24;
+};
+ThreeDMatrix.prototype.setM24 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m24 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM31 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m31;
+};
+ThreeDMatrix.prototype.setM31 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m31 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM32 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m32;
+};
+ThreeDMatrix.prototype.setM32 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m32 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM33 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m33;
+};
+ThreeDMatrix.prototype.setM33 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m33 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM34 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m34;
+};
+ThreeDMatrix.prototype.setM34 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m34 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM41 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m41;
+};
+ThreeDMatrix.prototype.setM41 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m41 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM42 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m42;
+};
+ThreeDMatrix.prototype.setM42 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m42 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM43 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m43;
+};
+ThreeDMatrix.prototype.setM43 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m43 = __SLAG__PROPERTY;
+};
+ThreeDMatrix.prototype.getM44 = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.m44;
+};
+ThreeDMatrix.prototype.setM44 = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.m44 = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ThreeDMatrix(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AdView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AdView.js
@@ -1,0 +1,880 @@
+var crypto = require('crypto');
+function AdView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'adSize',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.AdView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.AdView';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.AdView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.AdView.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.AdView.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.AdView.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.adSize = undefined;
+	} else {
+		this.adSize = __SLAG_PROPERTIES.adSize || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AdView.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AdView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+AdView.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.AdView.finishLayout was deprecated, since 3.0.0');
+};
+AdView.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+AdView.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.AdView.startLayout was deprecated, since 3.0.0');
+};
+AdView.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+AdView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.AdView.updateLayout was deprecated, since 3.0.0');
+};
+AdView.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+AdView.prototype.cancelAction = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AdView.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AdView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AdView.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+AdView.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+AdView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+AdView.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+AdView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+AdView.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+AdView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+AdView.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+AdView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+AdView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+AdView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+AdView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+AdView.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+AdView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+AdView.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+AdView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+AdView.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+AdView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+AdView.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+AdView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+AdView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+AdView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+AdView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+AdView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+AdView.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+AdView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+AdView.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+AdView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+AdView.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+AdView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+AdView.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+AdView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+AdView.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+AdView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+AdView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+AdView.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+AdView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+AdView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+AdView.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+AdView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+AdView.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+AdView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+AdView.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+AdView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+AdView.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+AdView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+AdView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+AdView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+AdView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+AdView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+AdView.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+AdView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+AdView.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+AdView.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+AdView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+AdView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+AdView.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+AdView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+AdView.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+AdView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+AdView.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+AdView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+AdView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+AdView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+AdView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+AdView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+AdView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+AdView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+AdView.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+AdView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+AdView.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+AdView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+AdView.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+AdView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+AdView.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+AdView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+AdView.prototype.getAdSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.adSize;
+};
+AdView.prototype.setAdSize = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.adSize = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new AdView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AlertDialogStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AlertDialogStyle.js
@@ -1,0 +1,111 @@
+var crypto = require('crypto');
+function AlertDialogStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'DEFAULT',
+			'PLAIN_TEXT_INPUT',
+			'SECURE_TEXT_INPUT',
+			'LOGIN_AND_PASSWORD_INPUT',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.AlertDialogStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.AlertDialogStyle';
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iOS.AlertDialogStyle.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN_TEXT_INPUT) {
+		throw new Error('Ti.UI.iOS.AlertDialogStyle.PLAIN_TEXT_INPUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN_TEXT_INPUT = undefined;
+	} else {
+		this.PLAIN_TEXT_INPUT = 0;
+	}
+	if (__SLAG_PROPERTIES.SECURE_TEXT_INPUT) {
+		throw new Error('Ti.UI.iOS.AlertDialogStyle.SECURE_TEXT_INPUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SECURE_TEXT_INPUT = undefined;
+	} else {
+		this.SECURE_TEXT_INPUT = 0;
+	}
+	if (__SLAG_PROPERTIES.LOGIN_AND_PASSWORD_INPUT) {
+		throw new Error('Ti.UI.iOS.AlertDialogStyle.LOGIN_AND_PASSWORD_INPUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LOGIN_AND_PASSWORD_INPUT = undefined;
+	} else {
+		this.LOGIN_AND_PASSWORD_INPUT = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AlertDialogStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialogStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialogStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialogStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AlertDialogStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AlertDialogStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AlertDialogStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new AlertDialogStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AnchorAttachmentBehavior.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AnchorAttachmentBehavior.js
@@ -1,0 +1,189 @@
+var crypto = require('crypto');
+function AnchorAttachmentBehavior(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'anchor',
+			'damping',
+			'distance',
+			'frequency',
+			'item',
+			'offset',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.AnchorAttachmentBehavior.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.AnchorAttachmentBehavior';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchor = undefined;
+	} else {
+		this.anchor = __SLAG_PROPERTIES.anchor || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.damping = undefined;
+	} else {
+		this.damping = __SLAG_PROPERTIES.damping || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.distance = undefined;
+	} else {
+		this.distance = __SLAG_PROPERTIES.distance || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.frequency = undefined;
+	} else {
+		this.frequency = __SLAG_PROPERTIES.frequency || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.item = undefined;
+	} else {
+		this.item = __SLAG_PROPERTIES.item || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.offset = undefined;
+	} else {
+		this.offset = __SLAG_PROPERTIES.offset || {
+			x: 0,
+			y: 0
+		};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AnchorAttachmentBehavior.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnchorAttachmentBehavior.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnchorAttachmentBehavior.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnchorAttachmentBehavior.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AnchorAttachmentBehavior.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AnchorAttachmentBehavior.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AnchorAttachmentBehavior.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+AnchorAttachmentBehavior.prototype.getAnchor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchor;
+};
+AnchorAttachmentBehavior.prototype.setAnchor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchor = __SLAG__PROPERTY;
+};
+AnchorAttachmentBehavior.prototype.getDamping = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.damping;
+};
+AnchorAttachmentBehavior.prototype.setDamping = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.damping = __SLAG__PROPERTY;
+};
+AnchorAttachmentBehavior.prototype.getDistance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.distance;
+};
+AnchorAttachmentBehavior.prototype.setDistance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.distance = __SLAG__PROPERTY;
+};
+AnchorAttachmentBehavior.prototype.getFrequency = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.frequency;
+};
+AnchorAttachmentBehavior.prototype.setFrequency = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.frequency = __SLAG__PROPERTY;
+};
+AnchorAttachmentBehavior.prototype.getItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.item;
+};
+AnchorAttachmentBehavior.prototype.setItem = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.item = __SLAG__PROPERTY;
+};
+AnchorAttachmentBehavior.prototype.getOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.offset;
+};
+AnchorAttachmentBehavior.prototype.setOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.offset = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new AnchorAttachmentBehavior(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AnimationStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AnimationStyle.js
@@ -1,0 +1,120 @@
+var crypto = require('crypto');
+function AnimationStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'CURL_DOWN',
+			'CURL_UP',
+			'FLIP_FROM_LEFT',
+			'FLIP_FROM_RIGHT',
+			'NONE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.AnimationStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.AnimationStyle';
+	if (__SLAG_PROPERTIES.CURL_DOWN) {
+		throw new Error('Ti.UI.iOS.AnimationStyle.CURL_DOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CURL_DOWN = undefined;
+	} else {
+		this.CURL_DOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.CURL_UP) {
+		throw new Error('Ti.UI.iOS.AnimationStyle.CURL_UP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CURL_UP = undefined;
+	} else {
+		this.CURL_UP = 0;
+	}
+	if (__SLAG_PROPERTIES.FLIP_FROM_LEFT) {
+		throw new Error('Ti.UI.iOS.AnimationStyle.FLIP_FROM_LEFT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLIP_FROM_LEFT = undefined;
+	} else {
+		this.FLIP_FROM_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.FLIP_FROM_RIGHT) {
+		throw new Error('Ti.UI.iOS.AnimationStyle.FLIP_FROM_RIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLIP_FROM_RIGHT = undefined;
+	} else {
+		this.FLIP_FROM_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iOS.AnimationStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AnimationStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnimationStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnimationStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnimationStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AnimationStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AnimationStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AnimationStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new AnimationStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Animator.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Animator.js
@@ -1,0 +1,156 @@
+var crypto = require('crypto');
+function Animator(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'behaviors',
+			'referenceView',
+			'running',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.Animator.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.Animator';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.behaviors = undefined;
+	} else {
+		this.behaviors = __SLAG_PROPERTIES.behaviors || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.referenceView = undefined;
+	} else {
+		this.referenceView = __SLAG_PROPERTIES.referenceView || {};
+	}
+	if (__SLAG_PROPERTIES.running) {
+		throw new Error('Ti.UI.iOS.Animator.running is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.running = undefined;
+	} else {
+		this.running = true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Animator.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Animator.prototype.addBehavior = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.removeAllBehaviors = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.removeBehavior = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.startAnimator = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.stopAnimator = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.updateItemUsingCurrentState = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Animator.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Animator.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Animator.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Animator.prototype.getBehaviors = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.behaviors;
+};
+Animator.prototype.setBehaviors = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.behaviors = __SLAG__PROPERTY;
+};
+Animator.prototype.getReferenceView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.referenceView;
+};
+Animator.prototype.setReferenceView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.referenceView = __SLAG__PROPERTY;
+};
+Animator.prototype.getRunning = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.running;
+};
+module.exports = function (properties) {
+	return new Animator(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ApplicationShortcuts.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ApplicationShortcuts.js
@@ -1,0 +1,113 @@
+var crypto = require('crypto');
+function ApplicationShortcuts(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.ApplicationShortcuts.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.ApplicationShortcuts';
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ApplicationShortcuts.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ApplicationShortcuts.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ApplicationShortcuts.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ApplicationShortcuts.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ApplicationShortcuts.prototype.listDynamicShortcuts = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+ApplicationShortcuts.prototype.listStaticShortcuts = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return [];
+};
+ApplicationShortcuts.prototype.removeAllDynamicShortcuts = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ApplicationShortcuts.prototype.dynamicShortcutExists = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+ApplicationShortcuts.prototype.addDynamicShortcut = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ApplicationShortcuts.prototype.removeDynamicShortcut = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ApplicationShortcuts.prototype.getDynamicShortcut = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ApplicationShortcuts.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ApplicationShortcuts.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ApplicationShortcuts.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ApplicationShortcuts(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Attribute.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Attribute.js
@@ -1,0 +1,129 @@
+var crypto = require('crypto');
+function Attribute(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'type',
+			'value',
+			'range',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.Attribute.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.Attribute';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.range = undefined;
+	} else {
+		this.range = __SLAG_PROPERTIES.range || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Attribute.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attribute.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attribute.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attribute.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Attribute.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Attribute.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Attribute.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Attribute.prototype.getType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+Attribute.prototype.setType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.type = __SLAG__PROPERTY;
+};
+Attribute.prototype.getValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+Attribute.prototype.setValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Attribute.prototype.getRange = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.range;
+};
+Attribute.prototype.setRange = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.range = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Attribute(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AttributedString.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/AttributedString.js
@@ -1,0 +1,116 @@
+var crypto = require('crypto');
+function AttributedString(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'text',
+			'attributes',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.AttributedString.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.AttributedString';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.text = undefined;
+	} else {
+		this.text = __SLAG_PROPERTIES.text || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = __SLAG_PROPERTIES.attributes || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AttributedString.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AttributedString.prototype.addAttribute = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AttributedString.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AttributedString.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AttributedString.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+AttributedString.prototype.getText = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.text;
+};
+AttributedString.prototype.setText = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.text = __SLAG__PROPERTY;
+};
+AttributedString.prototype.getAttributes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+AttributedString.prototype.setAttributes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.attributes = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new AttributedString(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/BlurView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/BlurView.js
@@ -1,0 +1,875 @@
+var crypto = require('crypto');
+function BlurView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'effect',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.BlurView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.BlurView';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.BlurView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.BlurView.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.BlurView.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.BlurView.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.effect = undefined;
+	} else {
+		this.effect = __SLAG_PROPERTIES.effect || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+BlurView.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+BlurView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+BlurView.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.BlurView.finishLayout was deprecated, since 3.0.0');
+};
+BlurView.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+BlurView.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+BlurView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.BlurView.startLayout was deprecated, since 3.0.0');
+};
+BlurView.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+BlurView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.BlurView.updateLayout was deprecated, since 3.0.0');
+};
+BlurView.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+BlurView.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+BlurView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+BlurView.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+BlurView.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+BlurView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+BlurView.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+BlurView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+BlurView.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+BlurView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+BlurView.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+BlurView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+BlurView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+BlurView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+BlurView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+BlurView.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+BlurView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+BlurView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+BlurView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+BlurView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+BlurView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+BlurView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+BlurView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+BlurView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+BlurView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+BlurView.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+BlurView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+BlurView.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+BlurView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+BlurView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+BlurView.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+BlurView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+BlurView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+BlurView.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+BlurView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+BlurView.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+BlurView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+BlurView.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+BlurView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+BlurView.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+BlurView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+BlurView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+BlurView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+BlurView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+BlurView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+BlurView.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+BlurView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+BlurView.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+BlurView.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+BlurView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+BlurView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+BlurView.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+BlurView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+BlurView.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+BlurView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+BlurView.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+BlurView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+BlurView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+BlurView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+BlurView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+BlurView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+BlurView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+BlurView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+BlurView.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+BlurView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+BlurView.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+BlurView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+BlurView.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+BlurView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+BlurView.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+BlurView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+BlurView.prototype.getEffect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.effect;
+};
+BlurView.prototype.setEffect = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.effect = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new BlurView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/CollisionBehavior.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/CollisionBehavior.js
@@ -1,0 +1,184 @@
+var crypto = require('crypto');
+function CollisionBehavior(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'boundaryIdentifiers',
+			'collisionMode',
+			'items',
+			'referenceInsets',
+			'treatReferenceAsBoundary',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.CollisionBehavior.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.CollisionBehavior';
+	if (__SLAG_PROPERTIES.boundaryIdentifiers) {
+		throw new Error('Ti.UI.iOS.CollisionBehavior.boundaryIdentifiers is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.boundaryIdentifiers = undefined;
+	} else {
+		this.boundaryIdentifiers = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.collisionMode = undefined;
+	} else {
+		this.collisionMode = __SLAG_PROPERTIES.collisionMode || 0;
+	}
+	if (__SLAG_PROPERTIES.items) {
+		throw new Error('Ti.UI.iOS.CollisionBehavior.items is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.referenceInsets = undefined;
+	} else {
+		this.referenceInsets = __SLAG_PROPERTIES.referenceInsets || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.treatReferenceAsBoundary = undefined;
+	} else {
+		this.treatReferenceAsBoundary = __SLAG_PROPERTIES.treatReferenceAsBoundary || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+CollisionBehavior.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+CollisionBehavior.prototype.addBoundary = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.addItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.removeAllBoundaries = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.removeBoundary = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.removeItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CollisionBehavior.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+CollisionBehavior.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+CollisionBehavior.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+CollisionBehavior.prototype.getBoundaryIdentifiers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.boundaryIdentifiers;
+};
+CollisionBehavior.prototype.getCollisionMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.collisionMode;
+};
+CollisionBehavior.prototype.setCollisionMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.collisionMode = __SLAG__PROPERTY;
+};
+CollisionBehavior.prototype.getItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+CollisionBehavior.prototype.getReferenceInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.referenceInsets;
+};
+CollisionBehavior.prototype.setReferenceInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.referenceInsets = __SLAG__PROPERTY;
+};
+CollisionBehavior.prototype.getTreatReferenceAsBoundary = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.treatReferenceAsBoundary;
+};
+CollisionBehavior.prototype.setTreatReferenceAsBoundary = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.treatReferenceAsBoundary = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new CollisionBehavior(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/CoverFlowView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/CoverFlowView.js
@@ -1,0 +1,898 @@
+var crypto = require('crypto');
+function CoverFlowView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'images',
+			'selected',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.CoverFlowView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.CoverFlowView';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.CoverFlowView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.CoverFlowView.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.CoverFlowView.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.CoverFlowView.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.images = undefined;
+	} else {
+		this.images = __SLAG_PROPERTIES.images || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selected = undefined;
+	} else {
+		this.selected = __SLAG_PROPERTIES.selected || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+CoverFlowView.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+CoverFlowView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+CoverFlowView.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.CoverFlowView.finishLayout was deprecated, since 3.0.0');
+};
+CoverFlowView.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+CoverFlowView.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.CoverFlowView.startLayout was deprecated, since 3.0.0');
+};
+CoverFlowView.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CoverFlowView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.CoverFlowView.updateLayout was deprecated, since 3.0.0');
+};
+CoverFlowView.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+CoverFlowView.prototype.setImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CoverFlowView.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+CoverFlowView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+CoverFlowView.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+CoverFlowView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+CoverFlowView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+CoverFlowView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+CoverFlowView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+CoverFlowView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+CoverFlowView.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+CoverFlowView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+CoverFlowView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+CoverFlowView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+CoverFlowView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+CoverFlowView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+CoverFlowView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+CoverFlowView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+CoverFlowView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+CoverFlowView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+CoverFlowView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+CoverFlowView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+CoverFlowView.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+CoverFlowView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+CoverFlowView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+CoverFlowView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+CoverFlowView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+CoverFlowView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+CoverFlowView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+CoverFlowView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+CoverFlowView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+CoverFlowView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+CoverFlowView.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+CoverFlowView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+CoverFlowView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+CoverFlowView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+CoverFlowView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+CoverFlowView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+CoverFlowView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+CoverFlowView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+CoverFlowView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+CoverFlowView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+CoverFlowView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+CoverFlowView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+CoverFlowView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getImages = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.images;
+};
+CoverFlowView.prototype.setImages = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.images = __SLAG__PROPERTY;
+};
+CoverFlowView.prototype.getSelected = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.selected;
+};
+CoverFlowView.prototype.setSelected = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.selected = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new CoverFlowView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/DocumentViewer.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/DocumentViewer.js
@@ -1,0 +1,890 @@
+var crypto = require('crypto');
+function DocumentViewer(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'name',
+			'url',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.DocumentViewer.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.DocumentViewer';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.DocumentViewer.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.DocumentViewer.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.DocumentViewer.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.DocumentViewer.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.UI.iOS.DocumentViewer.name is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DocumentViewer.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DocumentViewer.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+DocumentViewer.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.DocumentViewer.finishLayout was deprecated, since 3.0.0');
+};
+DocumentViewer.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+DocumentViewer.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.DocumentViewer.startLayout was deprecated, since 3.0.0');
+};
+DocumentViewer.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentViewer.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.DocumentViewer.updateLayout was deprecated, since 3.0.0');
+};
+DocumentViewer.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+DocumentViewer.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DocumentViewer.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DocumentViewer.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+DocumentViewer.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+DocumentViewer.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+DocumentViewer.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+DocumentViewer.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+DocumentViewer.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+DocumentViewer.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+DocumentViewer.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+DocumentViewer.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+DocumentViewer.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+DocumentViewer.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+DocumentViewer.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+DocumentViewer.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+DocumentViewer.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+DocumentViewer.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+DocumentViewer.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+DocumentViewer.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+DocumentViewer.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+DocumentViewer.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+DocumentViewer.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+DocumentViewer.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+DocumentViewer.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+DocumentViewer.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+DocumentViewer.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+DocumentViewer.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+DocumentViewer.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+DocumentViewer.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+DocumentViewer.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+DocumentViewer.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+DocumentViewer.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+DocumentViewer.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+DocumentViewer.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+DocumentViewer.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+DocumentViewer.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+DocumentViewer.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+DocumentViewer.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+DocumentViewer.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+DocumentViewer.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+DocumentViewer.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+DocumentViewer.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+DocumentViewer.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+DocumentViewer.prototype.getUrl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.url;
+};
+DocumentViewer.prototype.setUrl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.url = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DocumentViewer(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/DynamicItemBehavior.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/DynamicItemBehavior.js
@@ -1,0 +1,233 @@
+var crypto = require('crypto');
+function DynamicItemBehavior(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'allowsRotation',
+			'angularResistance',
+			'density',
+			'elasticity',
+			'friction',
+			'items',
+			'resistance',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.DynamicItemBehavior.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.DynamicItemBehavior';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.allowsRotation = undefined;
+	} else {
+		this.allowsRotation = __SLAG_PROPERTIES.allowsRotation || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.angularResistance = undefined;
+	} else {
+		this.angularResistance = __SLAG_PROPERTIES.angularResistance || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.density = undefined;
+	} else {
+		this.density = __SLAG_PROPERTIES.density || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.elasticity = undefined;
+	} else {
+		this.elasticity = __SLAG_PROPERTIES.elasticity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.friction = undefined;
+	} else {
+		this.friction = __SLAG_PROPERTIES.friction || 0;
+	}
+	if (__SLAG_PROPERTIES.items) {
+		throw new Error('Ti.UI.iOS.DynamicItemBehavior.items is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.resistance = undefined;
+	} else {
+		this.resistance = __SLAG_PROPERTIES.resistance || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DynamicItemBehavior.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DynamicItemBehavior.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DynamicItemBehavior.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DynamicItemBehavior.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DynamicItemBehavior.prototype.addAngularVelocityForItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DynamicItemBehavior.prototype.addItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DynamicItemBehavior.prototype.addLinearVelocityForItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DynamicItemBehavior.prototype.angularVelocityForItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return 0;
+};
+DynamicItemBehavior.prototype.linearVelocityForItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+DynamicItemBehavior.prototype.removeItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DynamicItemBehavior.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DynamicItemBehavior.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DynamicItemBehavior.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DynamicItemBehavior.prototype.getAllowsRotation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.allowsRotation;
+};
+DynamicItemBehavior.prototype.setAllowsRotation = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.allowsRotation = __SLAG__PROPERTY;
+};
+DynamicItemBehavior.prototype.getAngularResistance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.angularResistance;
+};
+DynamicItemBehavior.prototype.setAngularResistance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.angularResistance = __SLAG__PROPERTY;
+};
+DynamicItemBehavior.prototype.getDensity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.density;
+};
+DynamicItemBehavior.prototype.setDensity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.density = __SLAG__PROPERTY;
+};
+DynamicItemBehavior.prototype.getElasticity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.elasticity;
+};
+DynamicItemBehavior.prototype.setElasticity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.elasticity = __SLAG__PROPERTY;
+};
+DynamicItemBehavior.prototype.getFriction = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.friction;
+};
+DynamicItemBehavior.prototype.setFriction = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.friction = __SLAG__PROPERTY;
+};
+DynamicItemBehavior.prototype.getItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+DynamicItemBehavior.prototype.getResistance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.resistance;
+};
+DynamicItemBehavior.prototype.setResistance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.resistance = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DynamicItemBehavior(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/FeedbackGenerator.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/FeedbackGenerator.js
@@ -1,0 +1,113 @@
+var crypto = require('crypto');
+function FeedbackGenerator(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'type',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.FeedbackGenerator.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.FeedbackGenerator';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+FeedbackGenerator.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FeedbackGenerator.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FeedbackGenerator.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FeedbackGenerator.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+FeedbackGenerator.prototype.prepare = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FeedbackGenerator.prototype.selectionChanged = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FeedbackGenerator.prototype.impactOccurred = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FeedbackGenerator.prototype.notificationOccurred = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+FeedbackGenerator.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+FeedbackGenerator.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+FeedbackGenerator.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+FeedbackGenerator.prototype.getType = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.type;
+};
+FeedbackGenerator.prototype.setType = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.type = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new FeedbackGenerator(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/GravityBehavior.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/GravityBehavior.js
@@ -1,0 +1,157 @@
+var crypto = require('crypto');
+function GravityBehavior(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'angle',
+			'gravityDirection',
+			'items',
+			'magnitude',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.GravityBehavior.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.GravityBehavior';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.angle = undefined;
+	} else {
+		this.angle = __SLAG_PROPERTIES.angle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.gravityDirection = undefined;
+	} else {
+		this.gravityDirection = __SLAG_PROPERTIES.gravityDirection || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.items) {
+		throw new Error('Ti.UI.iOS.GravityBehavior.items is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.magnitude = undefined;
+	} else {
+		this.magnitude = __SLAG_PROPERTIES.magnitude || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+GravityBehavior.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GravityBehavior.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GravityBehavior.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GravityBehavior.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+GravityBehavior.prototype.addItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GravityBehavior.prototype.removeItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+GravityBehavior.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+GravityBehavior.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+GravityBehavior.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+GravityBehavior.prototype.getAngle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.angle;
+};
+GravityBehavior.prototype.setAngle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.angle = __SLAG__PROPERTY;
+};
+GravityBehavior.prototype.getGravityDirection = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.gravityDirection;
+};
+GravityBehavior.prototype.setGravityDirection = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.gravityDirection = __SLAG__PROPERTY;
+};
+GravityBehavior.prototype.getItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+GravityBehavior.prototype.getMagnitude = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.magnitude;
+};
+GravityBehavior.prototype.setMagnitude = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.magnitude = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new GravityBehavior(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ListViewCellSelectionStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ListViewCellSelectionStyle.js
@@ -1,0 +1,64 @@
+var crypto = require('crypto');
+function ListViewCellSelectionStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'BLUE',
+			'GRAY',
+			'NONE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.ListViewCellSelectionStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.ListViewCellSelectionStyle';
+	if (__SLAG_PROPERTIES.BLUE) {
+		throw new Error('Ti.UI.iOS.ListViewCellSelectionStyle.BLUE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUE = undefined;
+	} else {
+		this.BLUE = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAY) {
+		throw new Error('Ti.UI.iOS.ListViewCellSelectionStyle.GRAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAY = undefined;
+	} else {
+		this.GRAY = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iOS.ListViewCellSelectionStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListViewCellSelectionStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ListViewCellSelectionStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ListViewScrollPosition.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ListViewScrollPosition.js
@@ -1,0 +1,73 @@
+var crypto = require('crypto');
+function ListViewScrollPosition(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'BOTTOM',
+			'MIDDLE',
+			'NONE',
+			'TOP',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.ListViewScrollPosition.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.ListViewScrollPosition';
+	if (__SLAG_PROPERTIES.BOTTOM) {
+		throw new Error('Ti.UI.iOS.ListViewScrollPosition.BOTTOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOTTOM = undefined;
+	} else {
+		this.BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.MIDDLE) {
+		throw new Error('Ti.UI.iOS.ListViewScrollPosition.MIDDLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MIDDLE = undefined;
+	} else {
+		this.MIDDLE = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iOS.ListViewScrollPosition.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.TOP) {
+		throw new Error('Ti.UI.iOS.ListViewScrollPosition.TOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TOP = undefined;
+	} else {
+		this.TOP = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListViewScrollPosition.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ListViewScrollPosition(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ListViewStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ListViewStyle.js
@@ -1,0 +1,55 @@
+var crypto = require('crypto');
+function ListViewStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'GROUPED',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.ListViewStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.ListViewStyle';
+	if (__SLAG_PROPERTIES.GROUPED) {
+		throw new Error('Ti.UI.iOS.ListViewStyle.GROUPED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GROUPED = undefined;
+	} else {
+		this.GROUPED = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iOS.ListViewStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListViewStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ListViewStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/LivePhoto.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/LivePhoto.js
@@ -1,0 +1,24 @@
+var crypto = require('crypto');
+function LivePhoto(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = ['id'];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new LivePhoto(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/LivePhotoView.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/LivePhotoView.js
@@ -1,0 +1,903 @@
+var crypto = require('crypto');
+function LivePhotoView(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'livePhoto',
+			'muted',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.LivePhotoView.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.LivePhotoView';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.LivePhotoView.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.LivePhotoView.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.LivePhotoView.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.LivePhotoView.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.livePhoto = undefined;
+	} else {
+		this.livePhoto = __SLAG_PROPERTIES.livePhoto || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.muted = undefined;
+	} else {
+		this.muted = __SLAG_PROPERTIES.muted || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+LivePhotoView.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+LivePhotoView.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+LivePhotoView.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.LivePhotoView.finishLayout was deprecated, since 3.0.0');
+};
+LivePhotoView.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+LivePhotoView.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.LivePhotoView.startLayout was deprecated, since 3.0.0');
+};
+LivePhotoView.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+LivePhotoView.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.LivePhotoView.updateLayout was deprecated, since 3.0.0');
+};
+LivePhotoView.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+LivePhotoView.prototype.startPlaybackWithStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.stopPlayback = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+LivePhotoView.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+LivePhotoView.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+LivePhotoView.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+LivePhotoView.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+LivePhotoView.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+LivePhotoView.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+LivePhotoView.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+LivePhotoView.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+LivePhotoView.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+LivePhotoView.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+LivePhotoView.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+LivePhotoView.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+LivePhotoView.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+LivePhotoView.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+LivePhotoView.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+LivePhotoView.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+LivePhotoView.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+LivePhotoView.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+LivePhotoView.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+LivePhotoView.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+LivePhotoView.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+LivePhotoView.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+LivePhotoView.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+LivePhotoView.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+LivePhotoView.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+LivePhotoView.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+LivePhotoView.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+LivePhotoView.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+LivePhotoView.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+LivePhotoView.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+LivePhotoView.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+LivePhotoView.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+LivePhotoView.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+LivePhotoView.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+LivePhotoView.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+LivePhotoView.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+LivePhotoView.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+LivePhotoView.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+LivePhotoView.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+LivePhotoView.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+LivePhotoView.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+LivePhotoView.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+LivePhotoView.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getLivePhoto = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.livePhoto;
+};
+LivePhotoView.prototype.setLivePhoto = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.livePhoto = __SLAG__PROPERTY;
+};
+LivePhotoView.prototype.getMuted = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.muted;
+};
+LivePhotoView.prototype.setMuted = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.muted = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new LivePhotoView(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/MenuPopup.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/MenuPopup.js
@@ -1,0 +1,47 @@
+var crypto = require('crypto');
+function MenuPopup(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'items',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = __SLAG_PROPERTIES.items || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+MenuPopup.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MenuPopup.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+MenuPopup.prototype.isVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+module.exports = function (properties) {
+	return new MenuPopup(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/NavigationWindow.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/NavigationWindow.js
@@ -1,0 +1,1182 @@
+var crypto = require('crypto');
+function NavigationWindow(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'extendEdges',
+			'includeOpaqueBars',
+			'autoAdjustScrollViewInsets',
+			'fullscreen',
+			'hidesBarsOnSwipe',
+			'hidesBarsOnTap',
+			'hidesBarsWhenKeyboardAppears',
+			'leftNavButtons',
+			'modal',
+			'onBack',
+			'orientationModes',
+			'orientation',
+			'rightNavButtons',
+			'statusBarStyle',
+			'titleAttributes',
+			'window',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.NavigationWindow.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.NavigationWindow';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.NavigationWindow.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.NavigationWindow.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.NavigationWindow.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.NavigationWindow.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.extendEdges = undefined;
+	} else {
+		this.extendEdges = __SLAG_PROPERTIES.extendEdges || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.includeOpaqueBars = undefined;
+	} else {
+		this.includeOpaqueBars = __SLAG_PROPERTIES.includeOpaqueBars || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoAdjustScrollViewInsets = undefined;
+	} else {
+		this.autoAdjustScrollViewInsets = __SLAG_PROPERTIES.autoAdjustScrollViewInsets || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullscreen = undefined;
+	} else {
+		this.fullscreen = __SLAG_PROPERTIES.fullscreen || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnSwipe = undefined;
+	} else {
+		this.hidesBarsOnSwipe = __SLAG_PROPERTIES.hidesBarsOnSwipe || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnTap = undefined;
+	} else {
+		this.hidesBarsOnTap = __SLAG_PROPERTIES.hidesBarsOnTap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsWhenKeyboardAppears = undefined;
+	} else {
+		this.hidesBarsWhenKeyboardAppears = __SLAG_PROPERTIES.hidesBarsWhenKeyboardAppears || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftNavButtons = undefined;
+	} else {
+		this.leftNavButtons = __SLAG_PROPERTIES.leftNavButtons || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modal = undefined;
+	} else {
+		this.modal = __SLAG_PROPERTIES.modal || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onBack = undefined;
+	} else {
+		this.onBack = __SLAG_PROPERTIES.onBack || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientationModes = undefined;
+	} else {
+		this.orientationModes = __SLAG_PROPERTIES.orientationModes || 0;
+	}
+	if (__SLAG_PROPERTIES.orientation) {
+		throw new Error('Ti.UI.iOS.NavigationWindow.orientation is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientation = undefined;
+	} else {
+		this.orientation = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightNavButtons = undefined;
+	} else {
+		this.rightNavButtons = __SLAG_PROPERTIES.rightNavButtons || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.statusBarStyle = undefined;
+	} else {
+		this.statusBarStyle = __SLAG_PROPERTIES.statusBarStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleAttributes = undefined;
+	} else {
+		this.titleAttributes = __SLAG_PROPERTIES.titleAttributes || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.window = undefined;
+	} else {
+		this.window = __SLAG_PROPERTIES.window || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+NavigationWindow.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+NavigationWindow.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+NavigationWindow.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.NavigationWindow.finishLayout was deprecated, since 3.0.0');
+};
+NavigationWindow.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+NavigationWindow.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.NavigationWindow.startLayout was deprecated, since 3.0.0');
+};
+NavigationWindow.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NavigationWindow.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.NavigationWindow.updateLayout was deprecated, since 3.0.0');
+};
+NavigationWindow.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+NavigationWindow.prototype.close = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.hideNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.open = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.showNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.showToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.hideToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.closeWindow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.openWindow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.popToRootWindow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationWindow.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+NavigationWindow.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+NavigationWindow.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+NavigationWindow.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+NavigationWindow.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+NavigationWindow.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+NavigationWindow.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+NavigationWindow.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+NavigationWindow.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+NavigationWindow.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+NavigationWindow.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+NavigationWindow.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+NavigationWindow.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+NavigationWindow.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+NavigationWindow.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+NavigationWindow.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+NavigationWindow.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+NavigationWindow.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+NavigationWindow.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+NavigationWindow.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+NavigationWindow.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+NavigationWindow.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+NavigationWindow.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+NavigationWindow.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+NavigationWindow.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+NavigationWindow.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+NavigationWindow.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+NavigationWindow.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+NavigationWindow.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+NavigationWindow.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+NavigationWindow.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+NavigationWindow.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+NavigationWindow.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+NavigationWindow.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+NavigationWindow.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+NavigationWindow.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+NavigationWindow.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+NavigationWindow.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+NavigationWindow.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+NavigationWindow.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+NavigationWindow.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+NavigationWindow.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+NavigationWindow.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getExtendEdges = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.extendEdges;
+};
+NavigationWindow.prototype.setExtendEdges = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.extendEdges = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getIncludeOpaqueBars = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.includeOpaqueBars;
+};
+NavigationWindow.prototype.setIncludeOpaqueBars = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.includeOpaqueBars = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getAutoAdjustScrollViewInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoAdjustScrollViewInsets;
+};
+NavigationWindow.prototype.setAutoAdjustScrollViewInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoAdjustScrollViewInsets = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getFullscreen = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fullscreen;
+};
+NavigationWindow.prototype.setFullscreen = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fullscreen = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getHidesBarsOnSwipe = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnSwipe;
+};
+NavigationWindow.prototype.setHidesBarsOnSwipe = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnSwipe = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getHidesBarsOnTap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnTap;
+};
+NavigationWindow.prototype.setHidesBarsOnTap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnTap = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getHidesBarsWhenKeyboardAppears = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsWhenKeyboardAppears;
+};
+NavigationWindow.prototype.setHidesBarsWhenKeyboardAppears = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsWhenKeyboardAppears = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getLeftNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftNavButtons;
+};
+NavigationWindow.prototype.setLeftNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftNavButtons = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getModal = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.modal;
+};
+NavigationWindow.prototype.setModal = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.modal = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getOnBack = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onBack;
+};
+NavigationWindow.prototype.setOnBack = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onBack = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getOrientationModes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientationModes;
+};
+NavigationWindow.prototype.setOrientationModes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.orientationModes = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getOrientation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientation;
+};
+NavigationWindow.prototype.getRightNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightNavButtons;
+};
+NavigationWindow.prototype.setRightNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightNavButtons = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getStatusBarStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.statusBarStyle;
+};
+NavigationWindow.prototype.setStatusBarStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.statusBarStyle = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getTitleAttributes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleAttributes;
+};
+NavigationWindow.prototype.setTitleAttributes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleAttributes = __SLAG__PROPERTY;
+};
+NavigationWindow.prototype.getWindow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.window;
+};
+NavigationWindow.prototype.setWindow = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.window = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new NavigationWindow(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PreviewAction.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PreviewAction.js
@@ -1,0 +1,111 @@
+var crypto = require('crypto');
+function PreviewAction(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'title',
+			'style',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.PreviewAction.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.PreviewAction';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PreviewAction.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewAction.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewAction.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewAction.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PreviewAction.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PreviewAction.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PreviewAction.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PreviewAction.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+PreviewAction.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+PreviewAction.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+PreviewAction.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PreviewAction(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PreviewActionGroup.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PreviewActionGroup.js
@@ -1,0 +1,129 @@
+var crypto = require('crypto');
+function PreviewActionGroup(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'title',
+			'style',
+			'actions',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.PreviewActionGroup.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.PreviewActionGroup';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.actions = undefined;
+	} else {
+		this.actions = __SLAG_PROPERTIES.actions || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PreviewActionGroup.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewActionGroup.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewActionGroup.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewActionGroup.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PreviewActionGroup.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PreviewActionGroup.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PreviewActionGroup.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PreviewActionGroup.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+PreviewActionGroup.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+PreviewActionGroup.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+PreviewActionGroup.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+PreviewActionGroup.prototype.getActions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.actions;
+};
+PreviewActionGroup.prototype.setActions = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.actions = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PreviewActionGroup(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PreviewContext.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PreviewContext.js
@@ -1,0 +1,129 @@
+var crypto = require('crypto');
+function PreviewContext(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'actions',
+			'contentHeight',
+			'preview',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.PreviewContext.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.PreviewContext';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.actions = undefined;
+	} else {
+		this.actions = __SLAG_PROPERTIES.actions || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentHeight = undefined;
+	} else {
+		this.contentHeight = __SLAG_PROPERTIES.contentHeight || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.preview = undefined;
+	} else {
+		this.preview = __SLAG_PROPERTIES.preview || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PreviewContext.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewContext.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewContext.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PreviewContext.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PreviewContext.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PreviewContext.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PreviewContext.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PreviewContext.prototype.getActions = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.actions;
+};
+PreviewContext.prototype.setActions = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.actions = __SLAG__PROPERTY;
+};
+PreviewContext.prototype.getContentHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentHeight;
+};
+PreviewContext.prototype.setContentHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentHeight = __SLAG__PROPERTY;
+};
+PreviewContext.prototype.getPreview = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.preview;
+};
+PreviewContext.prototype.setPreview = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.preview = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PreviewContext(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ProgressBarStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ProgressBarStyle.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function ProgressBarStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BAR',
+			'DEFAULT',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.ProgressBarStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.ProgressBarStyle';
+	if (__SLAG_PROPERTIES.BAR) {
+		throw new Error('Ti.UI.iOS.ProgressBarStyle.BAR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BAR = undefined;
+	} else {
+		this.BAR = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iOS.ProgressBarStyle.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iOS.ProgressBarStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ProgressBarStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBarStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBarStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBarStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ProgressBarStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ProgressBarStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ProgressBarStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ProgressBarStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PushBehavior.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/PushBehavior.js
@@ -1,0 +1,193 @@
+var crypto = require('crypto');
+function PushBehavior(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'active',
+			'angle',
+			'items',
+			'magnitude',
+			'pushDirection',
+			'pushMode',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.PushBehavior.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.PushBehavior';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.active = undefined;
+	} else {
+		this.active = __SLAG_PROPERTIES.active || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.angle = undefined;
+	} else {
+		this.angle = __SLAG_PROPERTIES.angle || 0;
+	}
+	if (__SLAG_PROPERTIES.items) {
+		throw new Error('Ti.UI.iOS.PushBehavior.items is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.magnitude = undefined;
+	} else {
+		this.magnitude = __SLAG_PROPERTIES.magnitude || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pushDirection = undefined;
+	} else {
+		this.pushDirection = __SLAG_PROPERTIES.pushDirection || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pushMode = undefined;
+	} else {
+		this.pushMode = __SLAG_PROPERTIES.pushMode || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+PushBehavior.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushBehavior.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushBehavior.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushBehavior.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+PushBehavior.prototype.addItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushBehavior.prototype.removeItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+PushBehavior.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+PushBehavior.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+PushBehavior.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+PushBehavior.prototype.getActive = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.active;
+};
+PushBehavior.prototype.setActive = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.active = __SLAG__PROPERTY;
+};
+PushBehavior.prototype.getAngle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.angle;
+};
+PushBehavior.prototype.setAngle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.angle = __SLAG__PROPERTY;
+};
+PushBehavior.prototype.getItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+PushBehavior.prototype.getMagnitude = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.magnitude;
+};
+PushBehavior.prototype.setMagnitude = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.magnitude = __SLAG__PROPERTY;
+};
+PushBehavior.prototype.getPushDirection = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pushDirection;
+};
+PushBehavior.prototype.setPushDirection = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pushDirection = __SLAG__PROPERTY;
+};
+PushBehavior.prototype.getPushMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pushMode;
+};
+PushBehavior.prototype.setPushMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pushMode = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new PushBehavior(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/RowAnimationStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/RowAnimationStyle.js
@@ -1,0 +1,129 @@
+var crypto = require('crypto');
+function RowAnimationStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BOTTOM',
+			'FADE',
+			'LEFT',
+			'NONE',
+			'RIGHT',
+			'TOP',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.RowAnimationStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.RowAnimationStyle';
+	if (__SLAG_PROPERTIES.BOTTOM) {
+		throw new Error('Ti.UI.iOS.RowAnimationStyle.BOTTOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOTTOM = undefined;
+	} else {
+		this.BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.FADE) {
+		throw new Error('Ti.UI.iOS.RowAnimationStyle.FADE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FADE = undefined;
+	} else {
+		this.FADE = 0;
+	}
+	if (__SLAG_PROPERTIES.LEFT) {
+		throw new Error('Ti.UI.iOS.RowAnimationStyle.LEFT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LEFT = undefined;
+	} else {
+		this.LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iOS.RowAnimationStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.RIGHT) {
+		throw new Error('Ti.UI.iOS.RowAnimationStyle.RIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RIGHT = undefined;
+	} else {
+		this.RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.TOP) {
+		throw new Error('Ti.UI.iOS.RowAnimationStyle.TOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TOP = undefined;
+	} else {
+		this.TOP = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+RowAnimationStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RowAnimationStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RowAnimationStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RowAnimationStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+RowAnimationStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+RowAnimationStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+RowAnimationStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new RowAnimationStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ScrollIndicatorStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ScrollIndicatorStyle.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function ScrollIndicatorStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BLACK',
+			'DEFAULT',
+			'WHITE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.ScrollIndicatorStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.ScrollIndicatorStyle';
+	if (__SLAG_PROPERTIES.BLACK) {
+		throw new Error('Ti.UI.iOS.ScrollIndicatorStyle.BLACK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLACK = undefined;
+	} else {
+		this.BLACK = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iOS.ScrollIndicatorStyle.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.WHITE) {
+		throw new Error('Ti.UI.iOS.ScrollIndicatorStyle.WHITE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WHITE = undefined;
+	} else {
+		this.WHITE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ScrollIndicatorStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollIndicatorStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollIndicatorStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollIndicatorStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ScrollIndicatorStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ScrollIndicatorStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ScrollIndicatorStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ScrollIndicatorStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SnapBehavior.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SnapBehavior.js
@@ -1,0 +1,132 @@
+var crypto = require('crypto');
+function SnapBehavior(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'damping',
+			'item',
+			'snapPoint',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.SnapBehavior.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.SnapBehavior';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.damping = undefined;
+	} else {
+		this.damping = __SLAG_PROPERTIES.damping || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.item = undefined;
+	} else {
+		this.item = __SLAG_PROPERTIES.item || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.snapPoint = undefined;
+	} else {
+		this.snapPoint = __SLAG_PROPERTIES.snapPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SnapBehavior.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SnapBehavior.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SnapBehavior.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SnapBehavior.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SnapBehavior.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SnapBehavior.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SnapBehavior.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SnapBehavior.prototype.getDamping = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.damping;
+};
+SnapBehavior.prototype.setDamping = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.damping = __SLAG__PROPERTY;
+};
+SnapBehavior.prototype.getItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.item;
+};
+SnapBehavior.prototype.setItem = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.item = __SLAG__PROPERTY;
+};
+SnapBehavior.prototype.getSnapPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.snapPoint;
+};
+SnapBehavior.prototype.setSnapPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.snapPoint = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SnapBehavior(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SplitWindow.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SplitWindow.js
@@ -1,0 +1,1632 @@
+var crypto = require('crypto');
+function SplitWindow(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'backButtonTitle',
+			'backButtonTitleImage',
+			'barColor',
+			'barImage',
+			'extendEdges',
+			'includeOpaqueBars',
+			'autoAdjustScrollViewInsets',
+			'fullscreen',
+			'hideShadow',
+			'hidesBarsOnSwipe',
+			'hidesBarsOnTap',
+			'hidesBarsWhenKeyboardAppears',
+			'leftNavButton',
+			'leftNavButtons',
+			'modal',
+			'navBarHidden',
+			'navTintColor',
+			'onBack',
+			'orientationModes',
+			'orientation',
+			'rightNavButton',
+			'rightNavButtons',
+			'shadowImage',
+			'statusBarStyle',
+			'tabBarHidden',
+			'title',
+			'titleAttributes',
+			'titleControl',
+			'titleImage',
+			'titlePrompt',
+			'titleid',
+			'titlepromptid',
+			'toolbar',
+			'translucent',
+			'url',
+			'detailView',
+			'masterView',
+			'showMasterInPortrait',
+			'masterIsOverlayed',
+			'portraitSplit',
+			'landscapeSplit',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.SplitWindow.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.SplitWindow';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.SplitWindow.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.SplitWindow.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.SplitWindow.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.SplitWindow.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backButtonTitle = undefined;
+	} else {
+		this.backButtonTitle = __SLAG_PROPERTIES.backButtonTitle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backButtonTitleImage = undefined;
+	} else {
+		this.backButtonTitleImage = __SLAG_PROPERTIES.backButtonTitleImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barImage = undefined;
+	} else {
+		this.barImage = __SLAG_PROPERTIES.barImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.extendEdges = undefined;
+	} else {
+		this.extendEdges = __SLAG_PROPERTIES.extendEdges || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.includeOpaqueBars = undefined;
+	} else {
+		this.includeOpaqueBars = __SLAG_PROPERTIES.includeOpaqueBars || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoAdjustScrollViewInsets = undefined;
+	} else {
+		this.autoAdjustScrollViewInsets = __SLAG_PROPERTIES.autoAdjustScrollViewInsets || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullscreen = undefined;
+	} else {
+		this.fullscreen = __SLAG_PROPERTIES.fullscreen || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hideShadow = undefined;
+	} else {
+		this.hideShadow = __SLAG_PROPERTIES.hideShadow || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnSwipe = undefined;
+	} else {
+		this.hidesBarsOnSwipe = __SLAG_PROPERTIES.hidesBarsOnSwipe || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnTap = undefined;
+	} else {
+		this.hidesBarsOnTap = __SLAG_PROPERTIES.hidesBarsOnTap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsWhenKeyboardAppears = undefined;
+	} else {
+		this.hidesBarsWhenKeyboardAppears = __SLAG_PROPERTIES.hidesBarsWhenKeyboardAppears || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftNavButton = undefined;
+	} else {
+		this.leftNavButton = __SLAG_PROPERTIES.leftNavButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftNavButtons = undefined;
+	} else {
+		this.leftNavButtons = __SLAG_PROPERTIES.leftNavButtons || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modal = undefined;
+	} else {
+		this.modal = __SLAG_PROPERTIES.modal || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navBarHidden = undefined;
+	} else {
+		this.navBarHidden = __SLAG_PROPERTIES.navBarHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navTintColor = undefined;
+	} else {
+		this.navTintColor = __SLAG_PROPERTIES.navTintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onBack = undefined;
+	} else {
+		this.onBack = __SLAG_PROPERTIES.onBack || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientationModes = undefined;
+	} else {
+		this.orientationModes = __SLAG_PROPERTIES.orientationModes || 0;
+	}
+	if (__SLAG_PROPERTIES.orientation) {
+		throw new Error('Ti.UI.iOS.SplitWindow.orientation is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientation = undefined;
+	} else {
+		this.orientation = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightNavButton = undefined;
+	} else {
+		this.rightNavButton = __SLAG_PROPERTIES.rightNavButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightNavButtons = undefined;
+	} else {
+		this.rightNavButtons = __SLAG_PROPERTIES.rightNavButtons || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowImage = undefined;
+	} else {
+		this.shadowImage = __SLAG_PROPERTIES.shadowImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.statusBarStyle = undefined;
+	} else {
+		this.statusBarStyle = __SLAG_PROPERTIES.statusBarStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabBarHidden = undefined;
+	} else {
+		this.tabBarHidden = __SLAG_PROPERTIES.tabBarHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleAttributes = undefined;
+	} else {
+		this.titleAttributes = __SLAG_PROPERTIES.titleAttributes || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleControl = undefined;
+	} else {
+		this.titleControl = __SLAG_PROPERTIES.titleControl || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleImage = undefined;
+	} else {
+		this.titleImage = __SLAG_PROPERTIES.titleImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titlePrompt = undefined;
+	} else {
+		this.titlePrompt = __SLAG_PROPERTIES.titlePrompt || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titlepromptid = undefined;
+	} else {
+		this.titlepromptid = __SLAG_PROPERTIES.titlepromptid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.toolbar = undefined;
+	} else {
+		this.toolbar = __SLAG_PROPERTIES.toolbar || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translucent = undefined;
+	} else {
+		this.translucent = __SLAG_PROPERTIES.translucent || true;
+	}
+	if (__SLAG_PROPERTIES.url) {
+		throw new Error('Ti.UI.iOS.SplitWindow.url was deprecated, since 3.5.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.detailView = undefined;
+	} else {
+		this.detailView = __SLAG_PROPERTIES.detailView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.masterView = undefined;
+	} else {
+		this.masterView = __SLAG_PROPERTIES.masterView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showMasterInPortrait = undefined;
+	} else {
+		this.showMasterInPortrait = __SLAG_PROPERTIES.showMasterInPortrait || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.masterIsOverlayed = undefined;
+	} else {
+		this.masterIsOverlayed = __SLAG_PROPERTIES.masterIsOverlayed || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.portraitSplit = undefined;
+	} else {
+		this.portraitSplit = __SLAG_PROPERTIES.portraitSplit || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.landscapeSplit = undefined;
+	} else {
+		this.landscapeSplit = __SLAG_PROPERTIES.landscapeSplit || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SplitWindow.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SplitWindow.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+SplitWindow.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.SplitWindow.finishLayout was deprecated, since 3.0.0');
+};
+SplitWindow.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+SplitWindow.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.SplitWindow.startLayout was deprecated, since 3.0.0');
+};
+SplitWindow.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+SplitWindow.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.SplitWindow.updateLayout was deprecated, since 3.0.0');
+};
+SplitWindow.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+SplitWindow.prototype.close = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.hideNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.hideTabBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.open = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.setToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.toolbar = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.showNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.showToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.hideToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.setShowMasterInPortrait = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showMasterInPortrait = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.setMasterIsOverlayed = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.masterIsOverlayed = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SplitWindow.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SplitWindow.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+SplitWindow.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+SplitWindow.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+SplitWindow.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+SplitWindow.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+SplitWindow.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+SplitWindow.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+SplitWindow.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+SplitWindow.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+SplitWindow.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+SplitWindow.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+SplitWindow.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+SplitWindow.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+SplitWindow.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+SplitWindow.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+SplitWindow.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+SplitWindow.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+SplitWindow.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+SplitWindow.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+SplitWindow.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+SplitWindow.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+SplitWindow.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+SplitWindow.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+SplitWindow.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+SplitWindow.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+SplitWindow.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+SplitWindow.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+SplitWindow.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+SplitWindow.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+SplitWindow.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+SplitWindow.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+SplitWindow.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+SplitWindow.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+SplitWindow.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+SplitWindow.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+SplitWindow.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+SplitWindow.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+SplitWindow.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+SplitWindow.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+SplitWindow.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+SplitWindow.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackButtonTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backButtonTitle;
+};
+SplitWindow.prototype.setBackButtonTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backButtonTitle = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackButtonTitleImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backButtonTitleImage;
+};
+SplitWindow.prototype.setBackButtonTitleImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backButtonTitleImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+SplitWindow.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBarImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barImage;
+};
+SplitWindow.prototype.setBarImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getExtendEdges = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.extendEdges;
+};
+SplitWindow.prototype.setExtendEdges = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.extendEdges = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getIncludeOpaqueBars = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.includeOpaqueBars;
+};
+SplitWindow.prototype.setIncludeOpaqueBars = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.includeOpaqueBars = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAutoAdjustScrollViewInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoAdjustScrollViewInsets;
+};
+SplitWindow.prototype.setAutoAdjustScrollViewInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoAdjustScrollViewInsets = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getFullscreen = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fullscreen;
+};
+SplitWindow.prototype.setFullscreen = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fullscreen = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHideShadow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hideShadow;
+};
+SplitWindow.prototype.setHideShadow = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hideShadow = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHidesBarsOnSwipe = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnSwipe;
+};
+SplitWindow.prototype.setHidesBarsOnSwipe = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnSwipe = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHidesBarsOnTap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnTap;
+};
+SplitWindow.prototype.setHidesBarsOnTap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnTap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHidesBarsWhenKeyboardAppears = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsWhenKeyboardAppears;
+};
+SplitWindow.prototype.setHidesBarsWhenKeyboardAppears = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsWhenKeyboardAppears = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLeftNavButton = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftNavButton;
+};
+SplitWindow.prototype.setLeftNavButton = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftNavButton = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLeftNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftNavButtons;
+};
+SplitWindow.prototype.setLeftNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftNavButtons = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getModal = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.modal;
+};
+SplitWindow.prototype.setModal = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.modal = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getNavBarHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navBarHidden;
+};
+SplitWindow.prototype.setNavBarHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navBarHidden = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getNavTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navTintColor;
+};
+SplitWindow.prototype.setNavTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navTintColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOnBack = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onBack;
+};
+SplitWindow.prototype.setOnBack = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onBack = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOrientationModes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientationModes;
+};
+SplitWindow.prototype.setOrientationModes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.orientationModes = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOrientation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientation;
+};
+SplitWindow.prototype.getRightNavButton = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightNavButton;
+};
+SplitWindow.prototype.setRightNavButton = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightNavButton = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getRightNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightNavButtons;
+};
+SplitWindow.prototype.setRightNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightNavButtons = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getShadowImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowImage;
+};
+SplitWindow.prototype.setShadowImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getStatusBarStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.statusBarStyle;
+};
+SplitWindow.prototype.setStatusBarStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.statusBarStyle = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTabBarHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabBarHidden;
+};
+SplitWindow.prototype.setTabBarHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabBarHidden = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+SplitWindow.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleAttributes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleAttributes;
+};
+SplitWindow.prototype.setTitleAttributes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleAttributes = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleControl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleControl;
+};
+SplitWindow.prototype.setTitleControl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleControl = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleImage;
+};
+SplitWindow.prototype.setTitleImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitlePrompt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titlePrompt;
+};
+SplitWindow.prototype.setTitlePrompt = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titlePrompt = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+SplitWindow.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitlepromptid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titlepromptid;
+};
+SplitWindow.prototype.setTitlepromptid = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titlepromptid = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.toolbar;
+};
+SplitWindow.prototype.setToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.toolbar = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTranslucent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translucent;
+};
+SplitWindow.prototype.setTranslucent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translucent = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getUrl = function () {
+	throw new Error('Ti.UI.iOS.SplitWindow.getUrl was deprecated, since 3.5.0');
+};
+SplitWindow.prototype.setUrl = function () {
+	throw new Error('Ti.UI.iOS.SplitWindow.setUrl was deprecated, since 3.5.0');
+};
+SplitWindow.prototype.getDetailView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.detailView;
+};
+SplitWindow.prototype.setDetailView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.detailView = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getMasterView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.masterView;
+};
+SplitWindow.prototype.setMasterView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.masterView = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getShowMasterInPortrait = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showMasterInPortrait;
+};
+SplitWindow.prototype.setShowMasterInPortrait = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showMasterInPortrait = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getMasterIsOverlayed = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.masterIsOverlayed;
+};
+SplitWindow.prototype.setMasterIsOverlayed = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.masterIsOverlayed = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getPortraitSplit = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.portraitSplit;
+};
+SplitWindow.prototype.setPortraitSplit = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.portraitSplit = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLandscapeSplit = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.landscapeSplit;
+};
+SplitWindow.prototype.setLandscapeSplit = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.landscapeSplit = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SplitWindow(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/StatusBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/StatusBar.js
@@ -1,0 +1,138 @@
+var crypto = require('crypto');
+function StatusBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'ANIMATION_STYLE_NONE',
+			'ANIMATION_STYLE_SLIDE',
+			'ANIMATION_STYLE_FADE',
+			'DEFAULT',
+			'GRAY',
+			'GREY',
+			'LIGHT_CONTENT',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.StatusBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.StatusBar';
+	if (__SLAG_PROPERTIES.ANIMATION_STYLE_NONE) {
+		throw new Error('Ti.UI.iOS.StatusBar.ANIMATION_STYLE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_STYLE_NONE = undefined;
+	} else {
+		this.ANIMATION_STYLE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_STYLE_SLIDE) {
+		throw new Error('Ti.UI.iOS.StatusBar.ANIMATION_STYLE_SLIDE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_STYLE_SLIDE = undefined;
+	} else {
+		this.ANIMATION_STYLE_SLIDE = 0;
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_STYLE_FADE) {
+		throw new Error('Ti.UI.iOS.StatusBar.ANIMATION_STYLE_FADE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_STYLE_FADE = undefined;
+	} else {
+		this.ANIMATION_STYLE_FADE = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iOS.StatusBar.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAY) {
+		throw new Error('Ti.UI.iOS.StatusBar.GRAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAY = undefined;
+	} else {
+		this.GRAY = 0;
+	}
+	if (__SLAG_PROPERTIES.GREY) {
+		throw new Error('Ti.UI.iOS.StatusBar.GREY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GREY = undefined;
+	} else {
+		this.GREY = 0;
+	}
+	if (__SLAG_PROPERTIES.LIGHT_CONTENT) {
+		throw new Error('Ti.UI.iOS.StatusBar.LIGHT_CONTENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIGHT_CONTENT = undefined;
+	} else {
+		this.LIGHT_CONTENT = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+StatusBar.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+StatusBar.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+StatusBar.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+StatusBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+StatusBar.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+StatusBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+StatusBar.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new StatusBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Stepper.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Stepper.js
@@ -1,0 +1,1073 @@
+var crypto = require('crypto');
+function Stepper(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'enabled',
+			'value',
+			'continuous',
+			'autorepeat',
+			'wraps',
+			'minimum',
+			'maximum',
+			'steps',
+			'decrementImage',
+			'decrementDisabledImage',
+			'incrementImage',
+			'incrementDisabledImage',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.Stepper.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.Stepper';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.Stepper.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.Stepper.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.Stepper.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.Stepper.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.enabled = undefined;
+	} else {
+		this.enabled = __SLAG_PROPERTIES.enabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.continuous = undefined;
+	} else {
+		this.continuous = __SLAG_PROPERTIES.continuous || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autorepeat = undefined;
+	} else {
+		this.autorepeat = __SLAG_PROPERTIES.autorepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.wraps = undefined;
+	} else {
+		this.wraps = __SLAG_PROPERTIES.wraps || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.minimum = undefined;
+	} else {
+		this.minimum = __SLAG_PROPERTIES.minimum || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.maximum = undefined;
+	} else {
+		this.maximum = __SLAG_PROPERTIES.maximum || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.steps = undefined;
+	} else {
+		this.steps = __SLAG_PROPERTIES.steps || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.decrementImage = undefined;
+	} else {
+		this.decrementImage = __SLAG_PROPERTIES.decrementImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.decrementDisabledImage = undefined;
+	} else {
+		this.decrementDisabledImage = __SLAG_PROPERTIES.decrementDisabledImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.incrementImage = undefined;
+	} else {
+		this.incrementImage = __SLAG_PROPERTIES.incrementImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.incrementDisabledImage = undefined;
+	} else {
+		this.incrementDisabledImage = __SLAG_PROPERTIES.incrementDisabledImage || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Stepper.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Stepper.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Stepper.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.Stepper.finishLayout was deprecated, since 3.0.0');
+};
+Stepper.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Stepper.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Stepper.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.Stepper.startLayout was deprecated, since 3.0.0');
+};
+Stepper.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Stepper.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.Stepper.updateLayout was deprecated, since 3.0.0');
+};
+Stepper.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Stepper.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Stepper.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Stepper.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Stepper.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Stepper.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Stepper.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Stepper.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Stepper.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Stepper.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Stepper.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Stepper.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Stepper.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Stepper.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Stepper.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Stepper.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Stepper.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Stepper.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Stepper.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+Stepper.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+Stepper.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+Stepper.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Stepper.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Stepper.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Stepper.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Stepper.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Stepper.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Stepper.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Stepper.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Stepper.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Stepper.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Stepper.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Stepper.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Stepper.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Stepper.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Stepper.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Stepper.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Stepper.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+Stepper.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+Stepper.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Stepper.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Stepper.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Stepper.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Stepper.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Stepper.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Stepper.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Stepper.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Stepper.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Stepper.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Stepper.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Stepper.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Stepper.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Stepper.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Stepper.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Stepper.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Stepper.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Stepper.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Stepper.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Stepper.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Stepper.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Stepper.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Stepper.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Stepper.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Stepper.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Stepper.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Stepper.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Stepper.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Stepper.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Stepper.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Stepper.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Stepper.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Stepper.prototype.getEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.enabled;
+};
+Stepper.prototype.setEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.enabled = __SLAG__PROPERTY;
+};
+Stepper.prototype.getValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+Stepper.prototype.setValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+Stepper.prototype.getContinuous = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.continuous;
+};
+Stepper.prototype.setContinuous = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.continuous = __SLAG__PROPERTY;
+};
+Stepper.prototype.getAutorepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autorepeat;
+};
+Stepper.prototype.setAutorepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autorepeat = __SLAG__PROPERTY;
+};
+Stepper.prototype.getWraps = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.wraps;
+};
+Stepper.prototype.setWraps = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.wraps = __SLAG__PROPERTY;
+};
+Stepper.prototype.getMinimum = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.minimum;
+};
+Stepper.prototype.setMinimum = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.minimum = __SLAG__PROPERTY;
+};
+Stepper.prototype.getMaximum = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.maximum;
+};
+Stepper.prototype.setMaximum = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.maximum = __SLAG__PROPERTY;
+};
+Stepper.prototype.getSteps = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.steps;
+};
+Stepper.prototype.setSteps = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.steps = __SLAG__PROPERTY;
+};
+Stepper.prototype.getDecrementImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.decrementImage;
+};
+Stepper.prototype.setDecrementImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.decrementImage = __SLAG__PROPERTY;
+};
+Stepper.prototype.getDecrementDisabledImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.decrementDisabledImage;
+};
+Stepper.prototype.setDecrementDisabledImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.decrementDisabledImage = __SLAG__PROPERTY;
+};
+Stepper.prototype.getIncrementImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.incrementImage;
+};
+Stepper.prototype.setIncrementImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.incrementImage = __SLAG__PROPERTY;
+};
+Stepper.prototype.getIncrementDisabledImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.incrementDisabledImage;
+};
+Stepper.prototype.setIncrementDisabledImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.incrementDisabledImage = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Stepper(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SystemButton.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SystemButton.js
@@ -1,0 +1,309 @@
+var crypto = require('crypto');
+function SystemButton(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'ACTION',
+			'ACTIVITY',
+			'ADD',
+			'BOOKMARKS',
+			'CAMERA',
+			'CANCEL',
+			'COMPOSE',
+			'CONTACT_ADD',
+			'DISCLOSURE',
+			'DONE',
+			'EDIT',
+			'FAST_FORWARD',
+			'FIXED_SPACE',
+			'FLEXIBLE_SPACE',
+			'INFO_DARK',
+			'INFO_LIGHT',
+			'ORGANIZE',
+			'PAUSE',
+			'PLAY',
+			'REFRESH',
+			'REPLY',
+			'REWIND',
+			'SAVE',
+			'SPINNER',
+			'STOP',
+			'TRASH',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.SystemButton.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.SystemButton';
+	if (__SLAG_PROPERTIES.ACTION) {
+		throw new Error('Ti.UI.iOS.SystemButton.ACTION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION = undefined;
+	} else {
+		this.ACTION = 0;
+	}
+	if (__SLAG_PROPERTIES.ACTIVITY) {
+		throw new Error('Ti.UI.iOS.SystemButton.ACTIVITY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVITY = undefined;
+	} else {
+		this.ACTIVITY = 0;
+	}
+	if (__SLAG_PROPERTIES.ADD) {
+		throw new Error('Ti.UI.iOS.SystemButton.ADD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ADD = undefined;
+	} else {
+		this.ADD = 0;
+	}
+	if (__SLAG_PROPERTIES.BOOKMARKS) {
+		throw new Error('Ti.UI.iOS.SystemButton.BOOKMARKS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOOKMARKS = undefined;
+	} else {
+		this.BOOKMARKS = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA) {
+		throw new Error('Ti.UI.iOS.SystemButton.CAMERA is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA = undefined;
+	} else {
+		this.CAMERA = 0;
+	}
+	if (__SLAG_PROPERTIES.CANCEL) {
+		throw new Error('Ti.UI.iOS.SystemButton.CANCEL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CANCEL = undefined;
+	} else {
+		this.CANCEL = 0;
+	}
+	if (__SLAG_PROPERTIES.COMPOSE) {
+		throw new Error('Ti.UI.iOS.SystemButton.COMPOSE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMPOSE = undefined;
+	} else {
+		this.COMPOSE = 0;
+	}
+	if (__SLAG_PROPERTIES.CONTACT_ADD) {
+		throw new Error('Ti.UI.iOS.SystemButton.CONTACT_ADD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONTACT_ADD = undefined;
+	} else {
+		this.CONTACT_ADD = 0;
+	}
+	if (__SLAG_PROPERTIES.DISCLOSURE) {
+		throw new Error('Ti.UI.iOS.SystemButton.DISCLOSURE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DISCLOSURE = undefined;
+	} else {
+		this.DISCLOSURE = 0;
+	}
+	if (__SLAG_PROPERTIES.DONE) {
+		throw new Error('Ti.UI.iOS.SystemButton.DONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DONE = undefined;
+	} else {
+		this.DONE = 0;
+	}
+	if (__SLAG_PROPERTIES.EDIT) {
+		throw new Error('Ti.UI.iOS.SystemButton.EDIT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EDIT = undefined;
+	} else {
+		this.EDIT = 0;
+	}
+	if (__SLAG_PROPERTIES.FAST_FORWARD) {
+		throw new Error('Ti.UI.iOS.SystemButton.FAST_FORWARD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FAST_FORWARD = undefined;
+	} else {
+		this.FAST_FORWARD = 0;
+	}
+	if (__SLAG_PROPERTIES.FIXED_SPACE) {
+		throw new Error('Ti.UI.iOS.SystemButton.FIXED_SPACE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FIXED_SPACE = undefined;
+	} else {
+		this.FIXED_SPACE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLEXIBLE_SPACE) {
+		throw new Error('Ti.UI.iOS.SystemButton.FLEXIBLE_SPACE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLEXIBLE_SPACE = undefined;
+	} else {
+		this.FLEXIBLE_SPACE = 0;
+	}
+	if (__SLAG_PROPERTIES.INFO_DARK) {
+		throw new Error('Ti.UI.iOS.SystemButton.INFO_DARK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INFO_DARK = undefined;
+	} else {
+		this.INFO_DARK = 0;
+	}
+	if (__SLAG_PROPERTIES.INFO_LIGHT) {
+		throw new Error('Ti.UI.iOS.SystemButton.INFO_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INFO_LIGHT = undefined;
+	} else {
+		this.INFO_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.ORGANIZE) {
+		throw new Error('Ti.UI.iOS.SystemButton.ORGANIZE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ORGANIZE = undefined;
+	} else {
+		this.ORGANIZE = 0;
+	}
+	if (__SLAG_PROPERTIES.PAUSE) {
+		throw new Error('Ti.UI.iOS.SystemButton.PAUSE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PAUSE = undefined;
+	} else {
+		this.PAUSE = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAY) {
+		throw new Error('Ti.UI.iOS.SystemButton.PLAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAY = undefined;
+	} else {
+		this.PLAY = 0;
+	}
+	if (__SLAG_PROPERTIES.REFRESH) {
+		throw new Error('Ti.UI.iOS.SystemButton.REFRESH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.REFRESH = undefined;
+	} else {
+		this.REFRESH = 0;
+	}
+	if (__SLAG_PROPERTIES.REPLY) {
+		throw new Error('Ti.UI.iOS.SystemButton.REPLY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.REPLY = undefined;
+	} else {
+		this.REPLY = 0;
+	}
+	if (__SLAG_PROPERTIES.REWIND) {
+		throw new Error('Ti.UI.iOS.SystemButton.REWIND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.REWIND = undefined;
+	} else {
+		this.REWIND = 0;
+	}
+	if (__SLAG_PROPERTIES.SAVE) {
+		throw new Error('Ti.UI.iOS.SystemButton.SAVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SAVE = undefined;
+	} else {
+		this.SAVE = 0;
+	}
+	if (__SLAG_PROPERTIES.SPINNER) {
+		throw new Error('Ti.UI.iOS.SystemButton.SPINNER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SPINNER = undefined;
+	} else {
+		this.SPINNER = 0;
+	}
+	if (__SLAG_PROPERTIES.STOP) {
+		throw new Error('Ti.UI.iOS.SystemButton.STOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STOP = undefined;
+	} else {
+		this.STOP = 0;
+	}
+	if (__SLAG_PROPERTIES.TRASH) {
+		throw new Error('Ti.UI.iOS.SystemButton.TRASH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRASH = undefined;
+	} else {
+		this.TRASH = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SystemButton.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButton.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButton.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButton.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SystemButton.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SystemButton.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SystemButton.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new SystemButton(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SystemButtonStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/SystemButtonStyle.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function SystemButtonStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BORDERED',
+			'DONE',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.SystemButtonStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.SystemButtonStyle';
+	if (__SLAG_PROPERTIES.BORDERED) {
+		throw new Error('Ti.UI.iOS.SystemButtonStyle.BORDERED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BORDERED = undefined;
+	} else {
+		this.BORDERED = 0;
+	}
+	if (__SLAG_PROPERTIES.DONE) {
+		throw new Error('Ti.UI.iOS.SystemButtonStyle.DONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DONE = undefined;
+	} else {
+		this.DONE = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iOS.SystemButtonStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SystemButtonStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButtonStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButtonStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButtonStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SystemButtonStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SystemButtonStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SystemButtonStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new SystemButtonStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TabbedBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TabbedBar.js
@@ -1,0 +1,911 @@
+var crypto = require('crypto');
+function TabbedBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'index',
+			'labels',
+			'style',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.TabbedBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.TabbedBar';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.TabbedBar.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.TabbedBar.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.TabbedBar.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.TabbedBar.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.index = undefined;
+	} else {
+		this.index = __SLAG_PROPERTIES.index || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.labels = undefined;
+	} else {
+		this.labels = __SLAG_PROPERTIES.labels || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.style = undefined;
+	} else {
+		this.style = __SLAG_PROPERTIES.style || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TabbedBar.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TabbedBar.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+TabbedBar.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.TabbedBar.finishLayout was deprecated, since 3.0.0');
+};
+TabbedBar.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+TabbedBar.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TabbedBar.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.TabbedBar.startLayout was deprecated, since 3.0.0');
+};
+TabbedBar.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+TabbedBar.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.TabbedBar.updateLayout was deprecated, since 3.0.0');
+};
+TabbedBar.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+TabbedBar.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TabbedBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+TabbedBar.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+TabbedBar.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+TabbedBar.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+TabbedBar.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+TabbedBar.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+TabbedBar.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+TabbedBar.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+TabbedBar.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+TabbedBar.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+TabbedBar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+TabbedBar.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+TabbedBar.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+TabbedBar.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+TabbedBar.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+TabbedBar.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+TabbedBar.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+TabbedBar.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+TabbedBar.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+TabbedBar.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+TabbedBar.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+TabbedBar.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+TabbedBar.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+TabbedBar.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+TabbedBar.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+TabbedBar.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+TabbedBar.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+TabbedBar.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+TabbedBar.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+TabbedBar.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+TabbedBar.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+TabbedBar.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+TabbedBar.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+TabbedBar.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+TabbedBar.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+TabbedBar.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+TabbedBar.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+TabbedBar.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+TabbedBar.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+TabbedBar.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+TabbedBar.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+TabbedBar.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.index;
+};
+TabbedBar.prototype.setIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.index = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getLabels = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.labels;
+};
+TabbedBar.prototype.setLabels = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.labels = __SLAG__PROPERTY;
+};
+TabbedBar.prototype.getStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.style;
+};
+TabbedBar.prototype.setStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.style = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new TabbedBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TableViewCellSelectionStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TableViewCellSelectionStyle.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function TableViewCellSelectionStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BLUE',
+			'GRAY',
+			'NONE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.TableViewCellSelectionStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.TableViewCellSelectionStyle';
+	if (__SLAG_PROPERTIES.BLUE) {
+		throw new Error('Ti.UI.iOS.TableViewCellSelectionStyle.BLUE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUE = undefined;
+	} else {
+		this.BLUE = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAY) {
+		throw new Error('Ti.UI.iOS.TableViewCellSelectionStyle.GRAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAY = undefined;
+	} else {
+		this.GRAY = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iOS.TableViewCellSelectionStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewCellSelectionStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewCellSelectionStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewCellSelectionStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewCellSelectionStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewCellSelectionStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewCellSelectionStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewCellSelectionStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewCellSelectionStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TableViewScrollPosition.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TableViewScrollPosition.js
@@ -1,0 +1,111 @@
+var crypto = require('crypto');
+function TableViewScrollPosition(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BOTTOM',
+			'MIDDLE',
+			'NONE',
+			'TOP',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.TableViewScrollPosition.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.TableViewScrollPosition';
+	if (__SLAG_PROPERTIES.BOTTOM) {
+		throw new Error('Ti.UI.iOS.TableViewScrollPosition.BOTTOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOTTOM = undefined;
+	} else {
+		this.BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.MIDDLE) {
+		throw new Error('Ti.UI.iOS.TableViewScrollPosition.MIDDLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MIDDLE = undefined;
+	} else {
+		this.MIDDLE = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iOS.TableViewScrollPosition.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.TOP) {
+		throw new Error('Ti.UI.iOS.TableViewScrollPosition.TOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TOP = undefined;
+	} else {
+		this.TOP = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewScrollPosition.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewScrollPosition.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewScrollPosition.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewScrollPosition.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewScrollPosition.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewScrollPosition.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewScrollPosition.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewScrollPosition(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TableViewStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/TableViewStyle.js
@@ -1,0 +1,93 @@
+var crypto = require('crypto');
+function TableViewStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'GROUPED',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.TableViewStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.TableViewStyle';
+	if (__SLAG_PROPERTIES.GROUPED) {
+		throw new Error('Ti.UI.iOS.TableViewStyle.GROUPED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GROUPED = undefined;
+	} else {
+		this.GROUPED = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iOS.TableViewStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Toolbar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/Toolbar.js
@@ -1,0 +1,875 @@
+var crypto = require('crypto');
+function Toolbar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundGradient',
+			'backgroundImage',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'barColor',
+			'items',
+			'borderTop',
+			'borderBottom',
+			'extendBackground',
+			'translucent',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.Toolbar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.Toolbar';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iOS.Toolbar.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iOS.Toolbar.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iOS.Toolbar.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iOS.Toolbar.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.items = undefined;
+	} else {
+		this.items = __SLAG_PROPERTIES.items || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderTop = undefined;
+	} else {
+		this.borderTop = __SLAG_PROPERTIES.borderTop || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderBottom = undefined;
+	} else {
+		this.borderBottom = __SLAG_PROPERTIES.borderBottom || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.extendBackground = undefined;
+	} else {
+		this.extendBackground = __SLAG_PROPERTIES.extendBackground || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translucent = undefined;
+	} else {
+		this.translucent = __SLAG_PROPERTIES.translucent || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Toolbar.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Toolbar.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+Toolbar.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iOS.Toolbar.finishLayout was deprecated, since 3.0.0');
+};
+Toolbar.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+Toolbar.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Toolbar.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iOS.Toolbar.startLayout was deprecated, since 3.0.0');
+};
+Toolbar.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Toolbar.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iOS.Toolbar.updateLayout was deprecated, since 3.0.0');
+};
+Toolbar.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+Toolbar.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Toolbar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Toolbar.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+Toolbar.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+Toolbar.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+Toolbar.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+Toolbar.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+Toolbar.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+Toolbar.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+Toolbar.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+Toolbar.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+Toolbar.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+Toolbar.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+Toolbar.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+Toolbar.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+Toolbar.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+Toolbar.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+Toolbar.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+Toolbar.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+Toolbar.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+Toolbar.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+Toolbar.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+Toolbar.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+Toolbar.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+Toolbar.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+Toolbar.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+Toolbar.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+Toolbar.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+Toolbar.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+Toolbar.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+Toolbar.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+Toolbar.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+Toolbar.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+Toolbar.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+Toolbar.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+Toolbar.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+Toolbar.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+Toolbar.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+Toolbar.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getItems = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.items;
+};
+Toolbar.prototype.setItems = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.items = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderTop;
+};
+Toolbar.prototype.setBorderTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderTop = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getBorderBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderBottom;
+};
+Toolbar.prototype.setBorderBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderBottom = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getExtendBackground = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.extendBackground;
+};
+Toolbar.prototype.setExtendBackground = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.extendBackground = __SLAG__PROPERTY;
+};
+Toolbar.prototype.getTranslucent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translucent;
+};
+Toolbar.prototype.setTranslucent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translucent = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Toolbar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ViewAttachmentBehavior.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iOS/ViewAttachmentBehavior.js
@@ -1,0 +1,207 @@
+var crypto = require('crypto');
+function ViewAttachmentBehavior(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'anchorItem',
+			'anchorOffset',
+			'damping',
+			'distance',
+			'frequency',
+			'item',
+			'itemOffset',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iOS.ViewAttachmentBehavior.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iOS.ViewAttachmentBehavior';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorItem = undefined;
+	} else {
+		this.anchorItem = __SLAG_PROPERTIES.anchorItem || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorOffset = undefined;
+	} else {
+		this.anchorOffset = __SLAG_PROPERTIES.anchorOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.damping = undefined;
+	} else {
+		this.damping = __SLAG_PROPERTIES.damping || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.distance = undefined;
+	} else {
+		this.distance = __SLAG_PROPERTIES.distance || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.frequency = undefined;
+	} else {
+		this.frequency = __SLAG_PROPERTIES.frequency || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.item = undefined;
+	} else {
+		this.item = __SLAG_PROPERTIES.item || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.itemOffset = undefined;
+	} else {
+		this.itemOffset = __SLAG_PROPERTIES.itemOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ViewAttachmentBehavior.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ViewAttachmentBehavior.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ViewAttachmentBehavior.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ViewAttachmentBehavior.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ViewAttachmentBehavior.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ViewAttachmentBehavior.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ViewAttachmentBehavior.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ViewAttachmentBehavior.prototype.getAnchorItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorItem;
+};
+ViewAttachmentBehavior.prototype.setAnchorItem = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorItem = __SLAG__PROPERTY;
+};
+ViewAttachmentBehavior.prototype.getAnchorOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorOffset;
+};
+ViewAttachmentBehavior.prototype.setAnchorOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorOffset = __SLAG__PROPERTY;
+};
+ViewAttachmentBehavior.prototype.getDamping = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.damping;
+};
+ViewAttachmentBehavior.prototype.setDamping = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.damping = __SLAG__PROPERTY;
+};
+ViewAttachmentBehavior.prototype.getDistance = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.distance;
+};
+ViewAttachmentBehavior.prototype.setDistance = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.distance = __SLAG__PROPERTY;
+};
+ViewAttachmentBehavior.prototype.getFrequency = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.frequency;
+};
+ViewAttachmentBehavior.prototype.setFrequency = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.frequency = __SLAG__PROPERTY;
+};
+ViewAttachmentBehavior.prototype.getItem = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.item;
+};
+ViewAttachmentBehavior.prototype.setItem = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.item = __SLAG__PROPERTY;
+};
+ViewAttachmentBehavior.prototype.getItemOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.itemOffset;
+};
+ViewAttachmentBehavior.prototype.setItemOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.itemOffset = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new ViewAttachmentBehavior(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPad.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPad.js
@@ -1,0 +1,142 @@
+var crypto = require('crypto');
+function iPad(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'POPOVER_ARROW_DIRECTION_ANY',
+			'POPOVER_ARROW_DIRECTION_DOWN',
+			'POPOVER_ARROW_DIRECTION_LEFT',
+			'POPOVER_ARROW_DIRECTION_RIGHT',
+			'POPOVER_ARROW_DIRECTION_UNKNOWN',
+			'POPOVER_ARROW_DIRECTION_UP',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPad.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPad';
+	if (__SLAG_PROPERTIES.POPOVER_ARROW_DIRECTION_ANY) {
+		throw new Error('Ti.UI.iPad.POPOVER_ARROW_DIRECTION_ANY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.POPOVER_ARROW_DIRECTION_ANY = undefined;
+	} else {
+		this.POPOVER_ARROW_DIRECTION_ANY = 0;
+	}
+	if (__SLAG_PROPERTIES.POPOVER_ARROW_DIRECTION_DOWN) {
+		throw new Error('Ti.UI.iPad.POPOVER_ARROW_DIRECTION_DOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.POPOVER_ARROW_DIRECTION_DOWN = undefined;
+	} else {
+		this.POPOVER_ARROW_DIRECTION_DOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.POPOVER_ARROW_DIRECTION_LEFT) {
+		throw new Error('Ti.UI.iPad.POPOVER_ARROW_DIRECTION_LEFT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.POPOVER_ARROW_DIRECTION_LEFT = undefined;
+	} else {
+		this.POPOVER_ARROW_DIRECTION_LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.POPOVER_ARROW_DIRECTION_RIGHT) {
+		throw new Error('Ti.UI.iPad.POPOVER_ARROW_DIRECTION_RIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.POPOVER_ARROW_DIRECTION_RIGHT = undefined;
+	} else {
+		this.POPOVER_ARROW_DIRECTION_RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.POPOVER_ARROW_DIRECTION_UNKNOWN) {
+		throw new Error('Ti.UI.iPad.POPOVER_ARROW_DIRECTION_UNKNOWN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.POPOVER_ARROW_DIRECTION_UNKNOWN = undefined;
+	} else {
+		this.POPOVER_ARROW_DIRECTION_UNKNOWN = 0;
+	}
+	if (__SLAG_PROPERTIES.POPOVER_ARROW_DIRECTION_UP) {
+		throw new Error('Ti.UI.iPad.POPOVER_ARROW_DIRECTION_UP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.POPOVER_ARROW_DIRECTION_UP = undefined;
+	} else {
+		this.POPOVER_ARROW_DIRECTION_UP = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+iPad.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iPad.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iPad.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iPad.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+iPad.prototype.createDocumentViewer = function () {
+	throw new Error('Ti.UI.iPad.createDocumentViewer was deprecated, since 3.0.0');
+};
+iPad.prototype.createPopover = function (__SLAG_PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Popover = require('./iPad/Popover');
+	return Popover(__SLAG_PROPERTY);
+};
+iPad.prototype.createSplitWindow = function () {
+	throw new Error('Ti.UI.iPad.createSplitWindow was deprecated, since 3.6.0');
+};
+iPad.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+iPad.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+iPad.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new iPad(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPad/DocumentViewer.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPad/DocumentViewer.js
@@ -1,0 +1,844 @@
+var crypto = require('crypto');
+function DocumentViewer(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPad.DocumentViewer.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPad.DocumentViewer';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iPad.DocumentViewer.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iPad.DocumentViewer.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iPad.DocumentViewer.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iPad.DocumentViewer.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DocumentViewer.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DocumentViewer.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+DocumentViewer.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iPad.DocumentViewer.finishLayout was deprecated, since 3.0.0');
+};
+DocumentViewer.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+DocumentViewer.prototype.removeAllChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iPad.DocumentViewer.startLayout was deprecated, since 3.0.0');
+};
+DocumentViewer.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentViewer.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iPad.DocumentViewer.updateLayout was deprecated, since 3.0.0');
+};
+DocumentViewer.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+DocumentViewer.prototype.setUrl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentViewer.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DocumentViewer.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DocumentViewer.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+DocumentViewer.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+DocumentViewer.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+DocumentViewer.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+DocumentViewer.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+DocumentViewer.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+DocumentViewer.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+DocumentViewer.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+DocumentViewer.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+DocumentViewer.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+DocumentViewer.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+DocumentViewer.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+DocumentViewer.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+DocumentViewer.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+DocumentViewer.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+DocumentViewer.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+DocumentViewer.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+DocumentViewer.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+DocumentViewer.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+DocumentViewer.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+DocumentViewer.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+DocumentViewer.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+DocumentViewer.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+DocumentViewer.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+DocumentViewer.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+DocumentViewer.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+DocumentViewer.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+DocumentViewer.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+DocumentViewer.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+DocumentViewer.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+DocumentViewer.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+DocumentViewer.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+DocumentViewer.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+DocumentViewer.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+DocumentViewer.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+DocumentViewer.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+DocumentViewer.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+DocumentViewer.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+DocumentViewer.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+DocumentViewer.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+DocumentViewer.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DocumentViewer(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPad/Popover.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPad/Popover.js
@@ -1,0 +1,232 @@
+var crypto = require('crypto');
+function Popover(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'backgroundColor',
+			'height',
+			'width',
+			'arrowDirection',
+			'contentView',
+			'leftNavButton',
+			'passthroughViews',
+			'rightNavButton',
+			'title',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPad.Popover.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPad.Popover';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (__SLAG_PROPERTIES.height) {
+		throw new Error('Ti.UI.iPad.Popover.height was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.width) {
+		throw new Error('Ti.UI.iPad.Popover.width was deprecated, since 3.4.2');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.arrowDirection = undefined;
+	} else {
+		this.arrowDirection = __SLAG_PROPERTIES.arrowDirection || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.contentView = undefined;
+	} else {
+		this.contentView = __SLAG_PROPERTIES.contentView || {};
+	}
+	if (__SLAG_PROPERTIES.leftNavButton) {
+		throw new Error('Ti.UI.iPad.Popover.leftNavButton was deprecated, since 3.4.2');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.passthroughViews = undefined;
+	} else {
+		this.passthroughViews = __SLAG_PROPERTIES.passthroughViews || [];
+	}
+	if (__SLAG_PROPERTIES.rightNavButton) {
+		throw new Error('Ti.UI.iPad.Popover.rightNavButton was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.title) {
+		throw new Error('Ti.UI.iPad.Popover.title was deprecated, since 3.4.2');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Popover.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Popover.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Popover.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Popover.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Popover.prototype.add = function () {
+	throw new Error('Ti.UI.iPad.Popover.add was deprecated, since 3.2.0');
+};
+Popover.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iPad.Popover.finishLayout was deprecated, since 3.0.0');
+};
+Popover.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Popover.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Popover.prototype.remove = function () {
+	throw new Error('Ti.UI.iPad.Popover.remove was deprecated, since 3.2.0');
+};
+Popover.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Popover.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Popover.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iPad.Popover.startLayout was deprecated, since 3.0.0');
+};
+Popover.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iPad.Popover.updateLayout was deprecated, since 3.0.0');
+};
+Popover.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Popover.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Popover.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Popover.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+Popover.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+Popover.prototype.getHeight = function () {
+	throw new Error('Ti.UI.iPad.Popover.getHeight was deprecated, since 3.4.2');
+};
+Popover.prototype.setHeight = function () {
+	throw new Error('Ti.UI.iPad.Popover.setHeight was deprecated, since 3.4.2');
+};
+Popover.prototype.getWidth = function () {
+	throw new Error('Ti.UI.iPad.Popover.getWidth was deprecated, since 3.4.2');
+};
+Popover.prototype.setWidth = function () {
+	throw new Error('Ti.UI.iPad.Popover.setWidth was deprecated, since 3.4.2');
+};
+Popover.prototype.getArrowDirection = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.arrowDirection;
+};
+Popover.prototype.setArrowDirection = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.arrowDirection = __SLAG__PROPERTY;
+};
+Popover.prototype.getContentView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.contentView;
+};
+Popover.prototype.setContentView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.contentView = __SLAG__PROPERTY;
+};
+Popover.prototype.getLeftNavButton = function () {
+	throw new Error('Ti.UI.iPad.Popover.getLeftNavButton was deprecated, since 3.4.2');
+};
+Popover.prototype.setLeftNavButton = function () {
+	throw new Error('Ti.UI.iPad.Popover.setLeftNavButton was deprecated, since 3.4.2');
+};
+Popover.prototype.getPassthroughViews = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.passthroughViews;
+};
+Popover.prototype.setPassthroughViews = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.passthroughViews = __SLAG__PROPERTY;
+};
+Popover.prototype.getRightNavButton = function () {
+	throw new Error('Ti.UI.iPad.Popover.getRightNavButton was deprecated, since 3.4.2');
+};
+Popover.prototype.setRightNavButton = function () {
+	throw new Error('Ti.UI.iPad.Popover.setRightNavButton was deprecated, since 3.4.2');
+};
+Popover.prototype.getTitle = function () {
+	throw new Error('Ti.UI.iPad.Popover.getTitle was deprecated, since 3.4.2');
+};
+Popover.prototype.setTitle = function () {
+	throw new Error('Ti.UI.iPad.Popover.setTitle was deprecated, since 3.4.2');
+};
+module.exports = function (properties) {
+	return new Popover(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPad/SplitWindow.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPad/SplitWindow.js
@@ -1,0 +1,1548 @@
+var crypto = require('crypto');
+function SplitWindow(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'backButtonTitle',
+			'backButtonTitleImage',
+			'barColor',
+			'barImage',
+			'extendEdges',
+			'includeOpaqueBars',
+			'autoAdjustScrollViewInsets',
+			'fullscreen',
+			'hideShadow',
+			'hidesBarsOnSwipe',
+			'hidesBarsOnTap',
+			'hidesBarsWhenKeyboardAppears',
+			'leftNavButton',
+			'leftNavButtons',
+			'modal',
+			'navBarHidden',
+			'navTintColor',
+			'onBack',
+			'orientationModes',
+			'orientation',
+			'rightNavButton',
+			'rightNavButtons',
+			'shadowImage',
+			'statusBarStyle',
+			'tabBarHidden',
+			'title',
+			'titleAttributes',
+			'titleControl',
+			'titleImage',
+			'titlePrompt',
+			'titleid',
+			'titlepromptid',
+			'toolbar',
+			'translucent',
+			'url',
+			'detailView',
+			'masterView',
+			'showMasterInPortrait',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPad.SplitWindow.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPad.SplitWindow';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iPad.SplitWindow.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iPad.SplitWindow.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iPad.SplitWindow.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iPad.SplitWindow.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backButtonTitle = undefined;
+	} else {
+		this.backButtonTitle = __SLAG_PROPERTIES.backButtonTitle || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backButtonTitleImage = undefined;
+	} else {
+		this.backButtonTitleImage = __SLAG_PROPERTIES.backButtonTitleImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barImage = undefined;
+	} else {
+		this.barImage = __SLAG_PROPERTIES.barImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.extendEdges = undefined;
+	} else {
+		this.extendEdges = __SLAG_PROPERTIES.extendEdges || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.includeOpaqueBars = undefined;
+	} else {
+		this.includeOpaqueBars = __SLAG_PROPERTIES.includeOpaqueBars || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.autoAdjustScrollViewInsets = undefined;
+	} else {
+		this.autoAdjustScrollViewInsets = __SLAG_PROPERTIES.autoAdjustScrollViewInsets || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullscreen = undefined;
+	} else {
+		this.fullscreen = __SLAG_PROPERTIES.fullscreen || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hideShadow = undefined;
+	} else {
+		this.hideShadow = __SLAG_PROPERTIES.hideShadow || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnSwipe = undefined;
+	} else {
+		this.hidesBarsOnSwipe = __SLAG_PROPERTIES.hidesBarsOnSwipe || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsOnTap = undefined;
+	} else {
+		this.hidesBarsOnTap = __SLAG_PROPERTIES.hidesBarsOnTap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hidesBarsWhenKeyboardAppears = undefined;
+	} else {
+		this.hidesBarsWhenKeyboardAppears = __SLAG_PROPERTIES.hidesBarsWhenKeyboardAppears || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftNavButton = undefined;
+	} else {
+		this.leftNavButton = __SLAG_PROPERTIES.leftNavButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.leftNavButtons = undefined;
+	} else {
+		this.leftNavButtons = __SLAG_PROPERTIES.leftNavButtons || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modal = undefined;
+	} else {
+		this.modal = __SLAG_PROPERTIES.modal || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navBarHidden = undefined;
+	} else {
+		this.navBarHidden = __SLAG_PROPERTIES.navBarHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navTintColor = undefined;
+	} else {
+		this.navTintColor = __SLAG_PROPERTIES.navTintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.onBack = undefined;
+	} else {
+		this.onBack = __SLAG_PROPERTIES.onBack || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientationModes = undefined;
+	} else {
+		this.orientationModes = __SLAG_PROPERTIES.orientationModes || 0;
+	}
+	if (__SLAG_PROPERTIES.orientation) {
+		throw new Error('Ti.UI.iPad.SplitWindow.orientation is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.orientation = undefined;
+	} else {
+		this.orientation = 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightNavButton = undefined;
+	} else {
+		this.rightNavButton = __SLAG_PROPERTIES.rightNavButton || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rightNavButtons = undefined;
+	} else {
+		this.rightNavButtons = __SLAG_PROPERTIES.rightNavButtons || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadowImage = undefined;
+	} else {
+		this.shadowImage = __SLAG_PROPERTIES.shadowImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.statusBarStyle = undefined;
+	} else {
+		this.statusBarStyle = __SLAG_PROPERTIES.statusBarStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tabBarHidden = undefined;
+	} else {
+		this.tabBarHidden = __SLAG_PROPERTIES.tabBarHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.title = undefined;
+	} else {
+		this.title = __SLAG_PROPERTIES.title || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleAttributes = undefined;
+	} else {
+		this.titleAttributes = __SLAG_PROPERTIES.titleAttributes || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleControl = undefined;
+	} else {
+		this.titleControl = __SLAG_PROPERTIES.titleControl || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleImage = undefined;
+	} else {
+		this.titleImage = __SLAG_PROPERTIES.titleImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titlePrompt = undefined;
+	} else {
+		this.titlePrompt = __SLAG_PROPERTIES.titlePrompt || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titleid = undefined;
+	} else {
+		this.titleid = __SLAG_PROPERTIES.titleid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.titlepromptid = undefined;
+	} else {
+		this.titlepromptid = __SLAG_PROPERTIES.titlepromptid || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.toolbar = undefined;
+	} else {
+		this.toolbar = __SLAG_PROPERTIES.toolbar || [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translucent = undefined;
+	} else {
+		this.translucent = __SLAG_PROPERTIES.translucent || true;
+	}
+	if (__SLAG_PROPERTIES.url) {
+		throw new Error('Ti.UI.iPad.SplitWindow.url was deprecated, since 3.5.0');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.detailView = undefined;
+	} else {
+		this.detailView = __SLAG_PROPERTIES.detailView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.masterView = undefined;
+	} else {
+		this.masterView = __SLAG_PROPERTIES.masterView || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.showMasterInPortrait = undefined;
+	} else {
+		this.showMasterInPortrait = __SLAG_PROPERTIES.showMasterInPortrait || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SplitWindow.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SplitWindow.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+SplitWindow.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iPad.SplitWindow.finishLayout was deprecated, since 3.0.0');
+};
+SplitWindow.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+SplitWindow.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iPad.SplitWindow.startLayout was deprecated, since 3.0.0');
+};
+SplitWindow.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+SplitWindow.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iPad.SplitWindow.updateLayout was deprecated, since 3.0.0');
+};
+SplitWindow.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+SplitWindow.prototype.close = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.hideNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.hideTabBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.open = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.setToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.toolbar = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.showNavBar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.showToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.hideToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SplitWindow.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SplitWindow.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+SplitWindow.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+SplitWindow.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+SplitWindow.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+SplitWindow.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+SplitWindow.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+SplitWindow.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+SplitWindow.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+SplitWindow.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+SplitWindow.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+SplitWindow.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+SplitWindow.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+SplitWindow.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+SplitWindow.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+SplitWindow.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+SplitWindow.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+SplitWindow.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+SplitWindow.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+SplitWindow.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+SplitWindow.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+SplitWindow.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+SplitWindow.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+SplitWindow.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+SplitWindow.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+SplitWindow.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+SplitWindow.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+SplitWindow.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+SplitWindow.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+SplitWindow.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+SplitWindow.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+SplitWindow.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+SplitWindow.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+SplitWindow.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+SplitWindow.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+SplitWindow.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+SplitWindow.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+SplitWindow.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+SplitWindow.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+SplitWindow.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+SplitWindow.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+SplitWindow.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackButtonTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backButtonTitle;
+};
+SplitWindow.prototype.setBackButtonTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backButtonTitle = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBackButtonTitleImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backButtonTitleImage;
+};
+SplitWindow.prototype.setBackButtonTitleImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backButtonTitleImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBarColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barColor;
+};
+SplitWindow.prototype.setBarColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getBarImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.barImage;
+};
+SplitWindow.prototype.setBarImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.barImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getExtendEdges = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.extendEdges;
+};
+SplitWindow.prototype.setExtendEdges = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.extendEdges = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getIncludeOpaqueBars = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.includeOpaqueBars;
+};
+SplitWindow.prototype.setIncludeOpaqueBars = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.includeOpaqueBars = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getAutoAdjustScrollViewInsets = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.autoAdjustScrollViewInsets;
+};
+SplitWindow.prototype.setAutoAdjustScrollViewInsets = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.autoAdjustScrollViewInsets = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getFullscreen = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.fullscreen;
+};
+SplitWindow.prototype.setFullscreen = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.fullscreen = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHideShadow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hideShadow;
+};
+SplitWindow.prototype.setHideShadow = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hideShadow = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHidesBarsOnSwipe = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnSwipe;
+};
+SplitWindow.prototype.setHidesBarsOnSwipe = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnSwipe = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHidesBarsOnTap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsOnTap;
+};
+SplitWindow.prototype.setHidesBarsOnTap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsOnTap = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getHidesBarsWhenKeyboardAppears = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hidesBarsWhenKeyboardAppears;
+};
+SplitWindow.prototype.setHidesBarsWhenKeyboardAppears = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.hidesBarsWhenKeyboardAppears = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLeftNavButton = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftNavButton;
+};
+SplitWindow.prototype.setLeftNavButton = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftNavButton = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getLeftNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.leftNavButtons;
+};
+SplitWindow.prototype.setLeftNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.leftNavButtons = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getModal = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.modal;
+};
+SplitWindow.prototype.setModal = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.modal = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getNavBarHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navBarHidden;
+};
+SplitWindow.prototype.setNavBarHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navBarHidden = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getNavTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.navTintColor;
+};
+SplitWindow.prototype.setNavTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.navTintColor = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOnBack = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.onBack;
+};
+SplitWindow.prototype.setOnBack = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.onBack = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOrientationModes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientationModes;
+};
+SplitWindow.prototype.setOrientationModes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.orientationModes = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getOrientation = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.orientation;
+};
+SplitWindow.prototype.getRightNavButton = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightNavButton;
+};
+SplitWindow.prototype.setRightNavButton = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightNavButton = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getRightNavButtons = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rightNavButtons;
+};
+SplitWindow.prototype.setRightNavButtons = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.rightNavButtons = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getShadowImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.shadowImage;
+};
+SplitWindow.prototype.setShadowImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.shadowImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getStatusBarStyle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.statusBarStyle;
+};
+SplitWindow.prototype.setStatusBarStyle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.statusBarStyle = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTabBarHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tabBarHidden;
+};
+SplitWindow.prototype.setTabBarHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tabBarHidden = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitle = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.title;
+};
+SplitWindow.prototype.setTitle = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.title = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleAttributes = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleAttributes;
+};
+SplitWindow.prototype.setTitleAttributes = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleAttributes = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleControl = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleControl;
+};
+SplitWindow.prototype.setTitleControl = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleControl = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleImage;
+};
+SplitWindow.prototype.setTitleImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleImage = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitlePrompt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titlePrompt;
+};
+SplitWindow.prototype.setTitlePrompt = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titlePrompt = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitleid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titleid;
+};
+SplitWindow.prototype.setTitleid = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titleid = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTitlepromptid = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.titlepromptid;
+};
+SplitWindow.prototype.setTitlepromptid = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.titlepromptid = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getToolbar = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.toolbar;
+};
+SplitWindow.prototype.setToolbar = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.toolbar = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getTranslucent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.translucent;
+};
+SplitWindow.prototype.setTranslucent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.translucent = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getUrl = function () {
+	throw new Error('Ti.UI.iPad.SplitWindow.getUrl was deprecated, since 3.5.0');
+};
+SplitWindow.prototype.setUrl = function () {
+	throw new Error('Ti.UI.iPad.SplitWindow.setUrl was deprecated, since 3.5.0');
+};
+SplitWindow.prototype.getDetailView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.detailView;
+};
+SplitWindow.prototype.setDetailView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.detailView = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getMasterView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.masterView;
+};
+SplitWindow.prototype.setMasterView = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.masterView = __SLAG__PROPERTY;
+};
+SplitWindow.prototype.getShowMasterInPortrait = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.showMasterInPortrait;
+};
+SplitWindow.prototype.setShowMasterInPortrait = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.showMasterInPortrait = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new SplitWindow(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone.js
@@ -1,0 +1,190 @@
+var crypto = require('crypto');
+function iPhone(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'MODAL_PRESENTATION_CURRENT_CONTEXT',
+			'MODAL_PRESENTATION_FORMSHEET',
+			'MODAL_PRESENTATION_FULLSCREEN',
+			'MODAL_PRESENTATION_PAGESHEET',
+			'MODAL_TRANSITION_STYLE_COVER_VERTICAL',
+			'MODAL_TRANSITION_STYLE_CROSS_DISSOLVE',
+			'MODAL_TRANSITION_STYLE_FLIP_HORIZONTAL',
+			'MODAL_TRANSITION_STYLE_PARTIAL_CURL',
+			'appBadge',
+			'appSupportsShakeToEdit',
+			'statusBarHidden',
+			'statusBarStyle',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone';
+	if (__SLAG_PROPERTIES.MODAL_PRESENTATION_CURRENT_CONTEXT) {
+		throw new Error('Ti.UI.iPhone.MODAL_PRESENTATION_CURRENT_CONTEXT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_PRESENTATION_CURRENT_CONTEXT = undefined;
+	} else {
+		this.MODAL_PRESENTATION_CURRENT_CONTEXT = 0;
+	}
+	if (__SLAG_PROPERTIES.MODAL_PRESENTATION_FORMSHEET) {
+		throw new Error('Ti.UI.iPhone.MODAL_PRESENTATION_FORMSHEET is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_PRESENTATION_FORMSHEET = undefined;
+	} else {
+		this.MODAL_PRESENTATION_FORMSHEET = 0;
+	}
+	if (__SLAG_PROPERTIES.MODAL_PRESENTATION_FULLSCREEN) {
+		throw new Error('Ti.UI.iPhone.MODAL_PRESENTATION_FULLSCREEN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_PRESENTATION_FULLSCREEN = undefined;
+	} else {
+		this.MODAL_PRESENTATION_FULLSCREEN = 0;
+	}
+	if (__SLAG_PROPERTIES.MODAL_PRESENTATION_PAGESHEET) {
+		throw new Error('Ti.UI.iPhone.MODAL_PRESENTATION_PAGESHEET is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_PRESENTATION_PAGESHEET = undefined;
+	} else {
+		this.MODAL_PRESENTATION_PAGESHEET = 0;
+	}
+	if (__SLAG_PROPERTIES.MODAL_TRANSITION_STYLE_COVER_VERTICAL) {
+		throw new Error('Ti.UI.iPhone.MODAL_TRANSITION_STYLE_COVER_VERTICAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_TRANSITION_STYLE_COVER_VERTICAL = undefined;
+	} else {
+		this.MODAL_TRANSITION_STYLE_COVER_VERTICAL = 0;
+	}
+	if (__SLAG_PROPERTIES.MODAL_TRANSITION_STYLE_CROSS_DISSOLVE) {
+		throw new Error('Ti.UI.iPhone.MODAL_TRANSITION_STYLE_CROSS_DISSOLVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_TRANSITION_STYLE_CROSS_DISSOLVE = undefined;
+	} else {
+		this.MODAL_TRANSITION_STYLE_CROSS_DISSOLVE = 0;
+	}
+	if (__SLAG_PROPERTIES.MODAL_TRANSITION_STYLE_FLIP_HORIZONTAL) {
+		throw new Error('Ti.UI.iPhone.MODAL_TRANSITION_STYLE_FLIP_HORIZONTAL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_TRANSITION_STYLE_FLIP_HORIZONTAL = undefined;
+	} else {
+		this.MODAL_TRANSITION_STYLE_FLIP_HORIZONTAL = 0;
+	}
+	if (__SLAG_PROPERTIES.MODAL_TRANSITION_STYLE_PARTIAL_CURL) {
+		throw new Error('Ti.UI.iPhone.MODAL_TRANSITION_STYLE_PARTIAL_CURL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MODAL_TRANSITION_STYLE_PARTIAL_CURL = undefined;
+	} else {
+		this.MODAL_TRANSITION_STYLE_PARTIAL_CURL = 0;
+	}
+	if (__SLAG_PROPERTIES.appBadge) {
+		throw new Error('Ti.UI.iPhone.appBadge was deprecated, since 5.4.0');
+	}
+	if (__SLAG_PROPERTIES.appSupportsShakeToEdit) {
+		throw new Error('Ti.UI.iPhone.appSupportsShakeToEdit was deprecated, since 5.4.0');
+	}
+	if (__SLAG_PROPERTIES.statusBarHidden) {
+		throw new Error('Ti.UI.iPhone.statusBarHidden was deprecated, since 3.1.3');
+	}
+	if (__SLAG_PROPERTIES.statusBarStyle) {
+		throw new Error('Ti.UI.iPhone.statusBarStyle was deprecated, since 3.1.3');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+iPhone.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iPhone.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iPhone.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+iPhone.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+iPhone.prototype.hideStatusBar = function () {
+	throw new Error('Ti.UI.iPhone.hideStatusBar was deprecated, since 3.1.3');
+};
+iPhone.prototype.showStatusBar = function () {
+	throw new Error('Ti.UI.iPhone.showStatusBar was deprecated, since 3.1.3');
+};
+iPhone.prototype.createNavigationGroup = function () {
+	throw new Error('Ti.UI.iPhone.createNavigationGroup was deprecated, since 3.1.3');
+};
+iPhone.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+iPhone.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+iPhone.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+iPhone.prototype.getAppBadge = function () {
+	throw new Error('Ti.UI.iPhone.getAppBadge was deprecated, since 5.4.0');
+};
+iPhone.prototype.setAppBadge = function () {
+	throw new Error('Ti.UI.iPhone.setAppBadge was deprecated, since 5.4.0');
+};
+iPhone.prototype.getAppSupportsShakeToEdit = function () {
+	throw new Error('Ti.UI.iPhone.getAppSupportsShakeToEdit was deprecated, since 5.4.0');
+};
+iPhone.prototype.setAppSupportsShakeToEdit = function () {
+	throw new Error('Ti.UI.iPhone.setAppSupportsShakeToEdit was deprecated, since 5.4.0');
+};
+iPhone.prototype.getStatusBarHidden = function () {
+	throw new Error('Ti.UI.iPhone.getStatusBarHidden was deprecated, since 3.1.3');
+};
+iPhone.prototype.getStatusBarStyle = function () {
+	throw new Error('Ti.UI.iPhone.getStatusBarStyle was deprecated, since 3.1.3');
+};
+module.exports = function (properties) {
+	return new iPhone(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ActivityIndicatorStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ActivityIndicatorStyle.js
@@ -1,0 +1,87 @@
+var crypto = require('crypto');
+function ActivityIndicatorStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BIG',
+			'DARK',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.ActivityIndicatorStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.ActivityIndicatorStyle';
+	if (__SLAG_PROPERTIES.BIG) {
+		throw new Error('Ti.UI.iPhone.ActivityIndicatorStyle.BIG was deprecated, since 5.1.0');
+	}
+	if (__SLAG_PROPERTIES.DARK) {
+		throw new Error('Ti.UI.iPhone.ActivityIndicatorStyle.DARK was deprecated, since 5.1.0');
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iPhone.ActivityIndicatorStyle.PLAIN was deprecated, since 5.1.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ActivityIndicatorStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicatorStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicatorStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ActivityIndicatorStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ActivityIndicatorStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ActivityIndicatorStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ActivityIndicatorStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ActivityIndicatorStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/AlertDialogStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/AlertDialogStyle.js
@@ -1,0 +1,111 @@
+var crypto = require('crypto');
+function AlertDialogStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'DEFAULT',
+			'PLAIN_TEXT_INPUT',
+			'SECURE_TEXT_INPUT',
+			'LOGIN_AND_PASSWORD_INPUT',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.AlertDialogStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.AlertDialogStyle';
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iPhone.AlertDialogStyle.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN_TEXT_INPUT) {
+		throw new Error('Ti.UI.iPhone.AlertDialogStyle.PLAIN_TEXT_INPUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN_TEXT_INPUT = undefined;
+	} else {
+		this.PLAIN_TEXT_INPUT = 0;
+	}
+	if (__SLAG_PROPERTIES.SECURE_TEXT_INPUT) {
+		throw new Error('Ti.UI.iPhone.AlertDialogStyle.SECURE_TEXT_INPUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SECURE_TEXT_INPUT = undefined;
+	} else {
+		this.SECURE_TEXT_INPUT = 0;
+	}
+	if (__SLAG_PROPERTIES.LOGIN_AND_PASSWORD_INPUT) {
+		throw new Error('Ti.UI.iPhone.AlertDialogStyle.LOGIN_AND_PASSWORD_INPUT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LOGIN_AND_PASSWORD_INPUT = undefined;
+	} else {
+		this.LOGIN_AND_PASSWORD_INPUT = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AlertDialogStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialogStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialogStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AlertDialogStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AlertDialogStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AlertDialogStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AlertDialogStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new AlertDialogStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/AnimationStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/AnimationStyle.js
@@ -1,0 +1,95 @@
+var crypto = require('crypto');
+function AnimationStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'CURL_DOWN',
+			'CURL_UP',
+			'FLIP_FROM_LEFT',
+			'FLIP_FROM_RIGHT',
+			'NONE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.AnimationStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.AnimationStyle';
+	if (__SLAG_PROPERTIES.CURL_DOWN) {
+		throw new Error('Ti.UI.iPhone.AnimationStyle.CURL_DOWN was deprecated, since 5.4.0');
+	}
+	if (__SLAG_PROPERTIES.CURL_UP) {
+		throw new Error('Ti.UI.iPhone.AnimationStyle.CURL_UP was deprecated, since 5.4.0');
+	}
+	if (__SLAG_PROPERTIES.FLIP_FROM_LEFT) {
+		throw new Error('Ti.UI.iPhone.AnimationStyle.FLIP_FROM_LEFT was deprecated, since 5.4.0');
+	}
+	if (__SLAG_PROPERTIES.FLIP_FROM_RIGHT) {
+		throw new Error('Ti.UI.iPhone.AnimationStyle.FLIP_FROM_RIGHT was deprecated, since 5.4.0');
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.AnimationStyle.NONE was deprecated, since 5.4.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+AnimationStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnimationStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnimationStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+AnimationStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+AnimationStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+AnimationStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+AnimationStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new AnimationStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewCellSelectionStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewCellSelectionStyle.js
@@ -1,0 +1,64 @@
+var crypto = require('crypto');
+function ListViewCellSelectionStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'BLUE',
+			'GRAY',
+			'NONE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.ListViewCellSelectionStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.ListViewCellSelectionStyle';
+	if (__SLAG_PROPERTIES.BLUE) {
+		throw new Error('Ti.UI.iPhone.ListViewCellSelectionStyle.BLUE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUE = undefined;
+	} else {
+		this.BLUE = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAY) {
+		throw new Error('Ti.UI.iPhone.ListViewCellSelectionStyle.GRAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAY = undefined;
+	} else {
+		this.GRAY = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.ListViewCellSelectionStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListViewCellSelectionStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ListViewCellSelectionStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewScrollPosition.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewScrollPosition.js
@@ -1,0 +1,73 @@
+var crypto = require('crypto');
+function ListViewScrollPosition(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'BOTTOM',
+			'MIDDLE',
+			'NONE',
+			'TOP',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.ListViewScrollPosition.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.ListViewScrollPosition';
+	if (__SLAG_PROPERTIES.BOTTOM) {
+		throw new Error('Ti.UI.iPhone.ListViewScrollPosition.BOTTOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOTTOM = undefined;
+	} else {
+		this.BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.MIDDLE) {
+		throw new Error('Ti.UI.iPhone.ListViewScrollPosition.MIDDLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MIDDLE = undefined;
+	} else {
+		this.MIDDLE = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.ListViewScrollPosition.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.TOP) {
+		throw new Error('Ti.UI.iPhone.ListViewScrollPosition.TOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TOP = undefined;
+	} else {
+		this.TOP = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListViewScrollPosition.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ListViewScrollPosition(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewSeparatorStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewSeparatorStyle.js
@@ -1,0 +1,93 @@
+var crypto = require('crypto');
+function ListViewSeparatorStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'NONE',
+			'SINGLE_LINE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.ListViewSeparatorStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.ListViewSeparatorStyle';
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.ListViewSeparatorStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.SINGLE_LINE) {
+		throw new Error('Ti.UI.iPhone.ListViewSeparatorStyle.SINGLE_LINE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SINGLE_LINE = undefined;
+	} else {
+		this.SINGLE_LINE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListViewSeparatorStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListViewSeparatorStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListViewSeparatorStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ListViewSeparatorStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ListViewSeparatorStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ListViewSeparatorStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ListViewSeparatorStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ListViewSeparatorStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ListViewStyle.js
@@ -1,0 +1,55 @@
+var crypto = require('crypto');
+function ListViewStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'apiName',
+			'GROUPED',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.ListViewStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.ListViewStyle';
+	if (__SLAG_PROPERTIES.GROUPED) {
+		throw new Error('Ti.UI.iPhone.ListViewStyle.GROUPED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GROUPED = undefined;
+	} else {
+		this.GROUPED = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iPhone.ListViewStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ListViewStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ListViewStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/NavigationGroup.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/NavigationGroup.js
@@ -1,0 +1,880 @@
+var crypto = require('crypto');
+function NavigationGroup(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'accessibilityHidden',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityValue',
+			'anchorPoint',
+			'animatedCenter',
+			'backgroundColor',
+			'backgroundGradient',
+			'backgroundImage',
+			'backgroundRepeat',
+			'backgroundLeftCap',
+			'backgroundTopCap',
+			'borderColor',
+			'borderRadius',
+			'borderWidth',
+			'bottom',
+			'center',
+			'children',
+			'clipMode',
+			'height',
+			'left',
+			'layout',
+			'opacity',
+			'pullBackgroundColor',
+			'previewContext',
+			'right',
+			'rect',
+			'size',
+			'tintColor',
+			'top',
+			'touchEnabled',
+			'transform',
+			'viewShadowRadius',
+			'viewShadowColor',
+			'viewShadowOffset',
+			'visible',
+			'width',
+			'horizontalWrap',
+			'zIndex',
+			'window',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.NavigationGroup.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.NavigationGroup';
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHidden = undefined;
+	} else {
+		this.accessibilityHidden = __SLAG_PROPERTIES.accessibilityHidden || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityHint = undefined;
+	} else {
+		this.accessibilityHint = __SLAG_PROPERTIES.accessibilityHint || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityLabel = undefined;
+	} else {
+		this.accessibilityLabel = __SLAG_PROPERTIES.accessibilityLabel || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.accessibilityValue = undefined;
+	} else {
+		this.accessibilityValue = __SLAG_PROPERTIES.accessibilityValue || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.anchorPoint = undefined;
+	} else {
+		this.anchorPoint = __SLAG_PROPERTIES.anchorPoint || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.animatedCenter) {
+		throw new Error('Ti.UI.iPhone.NavigationGroup.animatedCenter is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animatedCenter = undefined;
+	} else {
+		this.animatedCenter = {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundColor = undefined;
+	} else {
+		this.backgroundColor = __SLAG_PROPERTIES.backgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundGradient = undefined;
+	} else {
+		this.backgroundGradient = __SLAG_PROPERTIES.backgroundGradient || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundImage = undefined;
+	} else {
+		this.backgroundImage = __SLAG_PROPERTIES.backgroundImage || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundRepeat = undefined;
+	} else {
+		this.backgroundRepeat = __SLAG_PROPERTIES.backgroundRepeat || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundLeftCap = undefined;
+	} else {
+		this.backgroundLeftCap = __SLAG_PROPERTIES.backgroundLeftCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.backgroundTopCap = undefined;
+	} else {
+		this.backgroundTopCap = __SLAG_PROPERTIES.backgroundTopCap || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderColor = undefined;
+	} else {
+		this.borderColor = __SLAG_PROPERTIES.borderColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderRadius = undefined;
+	} else {
+		this.borderRadius = __SLAG_PROPERTIES.borderRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.borderWidth = undefined;
+	} else {
+		this.borderWidth = __SLAG_PROPERTIES.borderWidth || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.center = undefined;
+	} else {
+		this.center = __SLAG_PROPERTIES.center || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.children) {
+		throw new Error('Ti.UI.iPhone.NavigationGroup.children is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.children = undefined;
+	} else {
+		this.children = [];
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.clipMode = undefined;
+	} else {
+		this.clipMode = __SLAG_PROPERTIES.clipMode || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.layout = undefined;
+	} else {
+		this.layout = __SLAG_PROPERTIES.layout || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.opacity = undefined;
+	} else {
+		this.opacity = __SLAG_PROPERTIES.opacity || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.pullBackgroundColor = undefined;
+	} else {
+		this.pullBackgroundColor = __SLAG_PROPERTIES.pullBackgroundColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previewContext = undefined;
+	} else {
+		this.previewContext = __SLAG_PROPERTIES.previewContext || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if (__SLAG_PROPERTIES.rect) {
+		throw new Error('Ti.UI.iPhone.NavigationGroup.rect is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (__SLAG_PROPERTIES.size) {
+		throw new Error('Ti.UI.iPhone.NavigationGroup.size is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.size = undefined;
+	} else {
+		this.size = {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.touchEnabled = undefined;
+	} else {
+		this.touchEnabled = __SLAG_PROPERTIES.touchEnabled || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transform = undefined;
+	} else {
+		this.transform = __SLAG_PROPERTIES.transform || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowRadius = undefined;
+	} else {
+		this.viewShadowRadius = __SLAG_PROPERTIES.viewShadowRadius || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowColor = undefined;
+	} else {
+		this.viewShadowColor = __SLAG_PROPERTIES.viewShadowColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.viewShadowOffset = undefined;
+	} else {
+		this.viewShadowOffset = __SLAG_PROPERTIES.viewShadowOffset || {
+			x: 0,
+			y: 0
+		};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.visible = undefined;
+	} else {
+		this.visible = __SLAG_PROPERTIES.visible || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.horizontalWrap = undefined;
+	} else {
+		this.horizontalWrap = __SLAG_PROPERTIES.horizontalWrap || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.zIndex = undefined;
+	} else {
+		this.zIndex = __SLAG_PROPERTIES.zIndex || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.window = undefined;
+	} else {
+		this.window = __SLAG_PROPERTIES.window || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+NavigationGroup.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+NavigationGroup.prototype.add = function (__SLAG_PARAMETER) {
+	this.children.push(__SLAG_PARAMETER);
+	__SLAG_PARAMETER.__SLAG_PARENT = this;
+};
+NavigationGroup.prototype.animate = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.finishLayout = function () {
+	throw new Error('Ti.UI.iPhone.NavigationGroup.finishLayout was deprecated, since 3.0.0');
+};
+NavigationGroup.prototype.hide = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.insertAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.remove = function (__SLAG_PARAMETER) {
+	for (var __SLAG_COUNTER = 0; __SLAG_COUNTER < this.children.length; __SLAG_COUNTER++) {
+		if (this.children[__SLAG_COUNTER].__SLAG_ID === __SLAG_PARAMETER.__SLAG_ID) {
+			this.children.splice(__SLAG_COUNTER, 1);
+			break;
+		}
+	}
+	__SLAG_PARAMETER.__SLAG_PARENT = undefined;
+};
+NavigationGroup.prototype.replaceAt = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.show = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.startLayout = function () {
+	throw new Error('Ti.UI.iPhone.NavigationGroup.startLayout was deprecated, since 3.0.0');
+};
+NavigationGroup.prototype.toImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NavigationGroup.prototype.updateLayout = function () {
+	throw new Error('Ti.UI.iPhone.NavigationGroup.updateLayout was deprecated, since 3.0.0');
+};
+NavigationGroup.prototype.convertPointToView = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {
+		x: 0,
+		y: 0
+	};
+};
+NavigationGroup.prototype.close = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.open = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NavigationGroup.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+NavigationGroup.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+NavigationGroup.prototype.getAccessibilityHidden = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHidden;
+};
+NavigationGroup.prototype.setAccessibilityHidden = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHidden = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getAccessibilityHint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityHint;
+};
+NavigationGroup.prototype.setAccessibilityHint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityHint = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getAccessibilityLabel = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityLabel;
+};
+NavigationGroup.prototype.setAccessibilityLabel = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityLabel = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getAccessibilityValue = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.accessibilityValue;
+};
+NavigationGroup.prototype.setAccessibilityValue = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.accessibilityValue = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getAnchorPoint = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.anchorPoint;
+};
+NavigationGroup.prototype.setAnchorPoint = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.anchorPoint = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getAnimatedCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.animatedCenter;
+};
+NavigationGroup.prototype.getBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundColor;
+};
+NavigationGroup.prototype.setBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundGradient = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundGradient;
+};
+NavigationGroup.prototype.setBackgroundGradient = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundGradient = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundImage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundImage;
+};
+NavigationGroup.prototype.setBackgroundImage = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundImage = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundRepeat = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundRepeat;
+};
+NavigationGroup.prototype.setBackgroundRepeat = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundRepeat = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundLeftCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundLeftCap;
+};
+NavigationGroup.prototype.setBackgroundLeftCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundLeftCap = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBackgroundTopCap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.backgroundTopCap;
+};
+NavigationGroup.prototype.setBackgroundTopCap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.backgroundTopCap = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBorderColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderColor;
+};
+NavigationGroup.prototype.setBorderColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBorderRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderRadius;
+};
+NavigationGroup.prototype.setBorderRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderRadius = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBorderWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.borderWidth;
+};
+NavigationGroup.prototype.setBorderWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.borderWidth = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getBottom = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bottom;
+};
+NavigationGroup.prototype.setBottom = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bottom = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getCenter = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.center;
+};
+NavigationGroup.prototype.setCenter = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.center = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getParent = function () {
+	return this.__SLAG_PARENT;
+};
+NavigationGroup.prototype.getChildren = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.children;
+};
+NavigationGroup.prototype.getClipMode = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.clipMode;
+};
+NavigationGroup.prototype.setClipMode = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.clipMode = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getHeight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.height;
+};
+NavigationGroup.prototype.setHeight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.height = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getLeft = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.left;
+};
+NavigationGroup.prototype.setLeft = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.left = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getLayout = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.layout;
+};
+NavigationGroup.prototype.setLayout = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.layout = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getOpacity = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.opacity;
+};
+NavigationGroup.prototype.setOpacity = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.opacity = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getPullBackgroundColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.pullBackgroundColor;
+};
+NavigationGroup.prototype.setPullBackgroundColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.pullBackgroundColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getPreviewContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previewContext;
+};
+NavigationGroup.prototype.setPreviewContext = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.previewContext = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getRight = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.right;
+};
+NavigationGroup.prototype.setRight = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.right = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getRect = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.rect;
+};
+NavigationGroup.prototype.getSize = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.size;
+};
+NavigationGroup.prototype.getTintColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tintColor;
+};
+NavigationGroup.prototype.setTintColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.tintColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getTop = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.top;
+};
+NavigationGroup.prototype.setTop = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.top = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getTouchEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.touchEnabled;
+};
+NavigationGroup.prototype.setTouchEnabled = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.touchEnabled = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getTransform = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.transform;
+};
+NavigationGroup.prototype.setTransform = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.transform = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getViewShadowRadius = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowRadius;
+};
+NavigationGroup.prototype.setViewShadowRadius = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowRadius = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getViewShadowColor = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowColor;
+};
+NavigationGroup.prototype.setViewShadowColor = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowColor = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getViewShadowOffset = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.viewShadowOffset;
+};
+NavigationGroup.prototype.setViewShadowOffset = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.viewShadowOffset = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getVisible = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.visible;
+};
+NavigationGroup.prototype.setVisible = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.visible = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getWidth = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.width;
+};
+NavigationGroup.prototype.setWidth = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.width = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getHorizontalWrap = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.horizontalWrap;
+};
+NavigationGroup.prototype.setHorizontalWrap = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.horizontalWrap = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getZIndex = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.zIndex;
+};
+NavigationGroup.prototype.setZIndex = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.zIndex = __SLAG__PROPERTY;
+};
+NavigationGroup.prototype.getWindow = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.window;
+};
+NavigationGroup.prototype.setWindow = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.window = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new NavigationGroup(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ProgressBarStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ProgressBarStyle.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function ProgressBarStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BAR',
+			'DEFAULT',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.ProgressBarStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.ProgressBarStyle';
+	if (__SLAG_PROPERTIES.BAR) {
+		throw new Error('Ti.UI.iPhone.ProgressBarStyle.BAR is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BAR = undefined;
+	} else {
+		this.BAR = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iPhone.ProgressBarStyle.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iPhone.ProgressBarStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ProgressBarStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBarStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBarStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProgressBarStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ProgressBarStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ProgressBarStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ProgressBarStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ProgressBarStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/RowAnimationStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/RowAnimationStyle.js
@@ -1,0 +1,129 @@
+var crypto = require('crypto');
+function RowAnimationStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BOTTOM',
+			'FADE',
+			'LEFT',
+			'NONE',
+			'RIGHT',
+			'TOP',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.RowAnimationStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.RowAnimationStyle';
+	if (__SLAG_PROPERTIES.BOTTOM) {
+		throw new Error('Ti.UI.iPhone.RowAnimationStyle.BOTTOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOTTOM = undefined;
+	} else {
+		this.BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.FADE) {
+		throw new Error('Ti.UI.iPhone.RowAnimationStyle.FADE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FADE = undefined;
+	} else {
+		this.FADE = 0;
+	}
+	if (__SLAG_PROPERTIES.LEFT) {
+		throw new Error('Ti.UI.iPhone.RowAnimationStyle.LEFT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LEFT = undefined;
+	} else {
+		this.LEFT = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.RowAnimationStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.RIGHT) {
+		throw new Error('Ti.UI.iPhone.RowAnimationStyle.RIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RIGHT = undefined;
+	} else {
+		this.RIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.TOP) {
+		throw new Error('Ti.UI.iPhone.RowAnimationStyle.TOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TOP = undefined;
+	} else {
+		this.TOP = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+RowAnimationStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RowAnimationStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RowAnimationStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+RowAnimationStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+RowAnimationStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+RowAnimationStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+RowAnimationStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new RowAnimationStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ScrollIndicatorStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/ScrollIndicatorStyle.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function ScrollIndicatorStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BLACK',
+			'DEFAULT',
+			'WHITE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.ScrollIndicatorStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.ScrollIndicatorStyle';
+	if (__SLAG_PROPERTIES.BLACK) {
+		throw new Error('Ti.UI.iPhone.ScrollIndicatorStyle.BLACK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLACK = undefined;
+	} else {
+		this.BLACK = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iPhone.ScrollIndicatorStyle.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.WHITE) {
+		throw new Error('Ti.UI.iPhone.ScrollIndicatorStyle.WHITE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.WHITE = undefined;
+	} else {
+		this.WHITE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ScrollIndicatorStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollIndicatorStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollIndicatorStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ScrollIndicatorStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ScrollIndicatorStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ScrollIndicatorStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ScrollIndicatorStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new ScrollIndicatorStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/StatusBar.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/StatusBar.js
@@ -1,0 +1,146 @@
+var crypto = require('crypto');
+function StatusBar(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'ANIMATION_STYLE_NONE',
+			'ANIMATION_STYLE_SLIDE',
+			'ANIMATION_STYLE_FADE',
+			'DEFAULT',
+			'GRAY',
+			'GREY',
+			'LIGHT_CONTENT',
+			'OPAQUE_BLACK',
+			'TRANSLUCENT_BLACK',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.StatusBar.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.StatusBar';
+	if (__SLAG_PROPERTIES.ANIMATION_STYLE_NONE) {
+		throw new Error('Ti.UI.iPhone.StatusBar.ANIMATION_STYLE_NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_STYLE_NONE = undefined;
+	} else {
+		this.ANIMATION_STYLE_NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_STYLE_SLIDE) {
+		throw new Error('Ti.UI.iPhone.StatusBar.ANIMATION_STYLE_SLIDE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_STYLE_SLIDE = undefined;
+	} else {
+		this.ANIMATION_STYLE_SLIDE = 0;
+	}
+	if (__SLAG_PROPERTIES.ANIMATION_STYLE_FADE) {
+		throw new Error('Ti.UI.iPhone.StatusBar.ANIMATION_STYLE_FADE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ANIMATION_STYLE_FADE = undefined;
+	} else {
+		this.ANIMATION_STYLE_FADE = 0;
+	}
+	if (__SLAG_PROPERTIES.DEFAULT) {
+		throw new Error('Ti.UI.iPhone.StatusBar.DEFAULT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DEFAULT = undefined;
+	} else {
+		this.DEFAULT = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAY) {
+		throw new Error('Ti.UI.iPhone.StatusBar.GRAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAY = undefined;
+	} else {
+		this.GRAY = 0;
+	}
+	if (__SLAG_PROPERTIES.GREY) {
+		throw new Error('Ti.UI.iPhone.StatusBar.GREY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GREY = undefined;
+	} else {
+		this.GREY = 0;
+	}
+	if (__SLAG_PROPERTIES.LIGHT_CONTENT) {
+		throw new Error('Ti.UI.iPhone.StatusBar.LIGHT_CONTENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.LIGHT_CONTENT = undefined;
+	} else {
+		this.LIGHT_CONTENT = 0;
+	}
+	if (__SLAG_PROPERTIES.OPAQUE_BLACK) {
+		throw new Error('Ti.UI.iPhone.StatusBar.OPAQUE_BLACK was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.TRANSLUCENT_BLACK) {
+		throw new Error('Ti.UI.iPhone.StatusBar.TRANSLUCENT_BLACK was deprecated, since 3.4.2');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+StatusBar.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+StatusBar.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+StatusBar.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+StatusBar.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+StatusBar.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+StatusBar.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+StatusBar.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new StatusBar(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/SystemButton.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/SystemButton.js
@@ -1,0 +1,309 @@
+var crypto = require('crypto');
+function SystemButton(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'ACTION',
+			'ACTIVITY',
+			'ADD',
+			'BOOKMARKS',
+			'CAMERA',
+			'CANCEL',
+			'COMPOSE',
+			'CONTACT_ADD',
+			'DISCLOSURE',
+			'DONE',
+			'EDIT',
+			'FAST_FORWARD',
+			'FIXED_SPACE',
+			'FLEXIBLE_SPACE',
+			'INFO_DARK',
+			'INFO_LIGHT',
+			'ORGANIZE',
+			'PAUSE',
+			'PLAY',
+			'REFRESH',
+			'REPLY',
+			'REWIND',
+			'SAVE',
+			'SPINNER',
+			'STOP',
+			'TRASH',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.SystemButton.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.SystemButton';
+	if (__SLAG_PROPERTIES.ACTION) {
+		throw new Error('Ti.UI.iPhone.SystemButton.ACTION is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTION = undefined;
+	} else {
+		this.ACTION = 0;
+	}
+	if (__SLAG_PROPERTIES.ACTIVITY) {
+		throw new Error('Ti.UI.iPhone.SystemButton.ACTIVITY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVITY = undefined;
+	} else {
+		this.ACTIVITY = 0;
+	}
+	if (__SLAG_PROPERTIES.ADD) {
+		throw new Error('Ti.UI.iPhone.SystemButton.ADD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ADD = undefined;
+	} else {
+		this.ADD = 0;
+	}
+	if (__SLAG_PROPERTIES.BOOKMARKS) {
+		throw new Error('Ti.UI.iPhone.SystemButton.BOOKMARKS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOOKMARKS = undefined;
+	} else {
+		this.BOOKMARKS = 0;
+	}
+	if (__SLAG_PROPERTIES.CAMERA) {
+		throw new Error('Ti.UI.iPhone.SystemButton.CAMERA is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CAMERA = undefined;
+	} else {
+		this.CAMERA = 0;
+	}
+	if (__SLAG_PROPERTIES.CANCEL) {
+		throw new Error('Ti.UI.iPhone.SystemButton.CANCEL is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CANCEL = undefined;
+	} else {
+		this.CANCEL = 0;
+	}
+	if (__SLAG_PROPERTIES.COMPOSE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.COMPOSE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMPOSE = undefined;
+	} else {
+		this.COMPOSE = 0;
+	}
+	if (__SLAG_PROPERTIES.CONTACT_ADD) {
+		throw new Error('Ti.UI.iPhone.SystemButton.CONTACT_ADD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONTACT_ADD = undefined;
+	} else {
+		this.CONTACT_ADD = 0;
+	}
+	if (__SLAG_PROPERTIES.DISCLOSURE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.DISCLOSURE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DISCLOSURE = undefined;
+	} else {
+		this.DISCLOSURE = 0;
+	}
+	if (__SLAG_PROPERTIES.DONE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.DONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DONE = undefined;
+	} else {
+		this.DONE = 0;
+	}
+	if (__SLAG_PROPERTIES.EDIT) {
+		throw new Error('Ti.UI.iPhone.SystemButton.EDIT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.EDIT = undefined;
+	} else {
+		this.EDIT = 0;
+	}
+	if (__SLAG_PROPERTIES.FAST_FORWARD) {
+		throw new Error('Ti.UI.iPhone.SystemButton.FAST_FORWARD is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FAST_FORWARD = undefined;
+	} else {
+		this.FAST_FORWARD = 0;
+	}
+	if (__SLAG_PROPERTIES.FIXED_SPACE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.FIXED_SPACE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FIXED_SPACE = undefined;
+	} else {
+		this.FIXED_SPACE = 0;
+	}
+	if (__SLAG_PROPERTIES.FLEXIBLE_SPACE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.FLEXIBLE_SPACE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FLEXIBLE_SPACE = undefined;
+	} else {
+		this.FLEXIBLE_SPACE = 0;
+	}
+	if (__SLAG_PROPERTIES.INFO_DARK) {
+		throw new Error('Ti.UI.iPhone.SystemButton.INFO_DARK is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INFO_DARK = undefined;
+	} else {
+		this.INFO_DARK = 0;
+	}
+	if (__SLAG_PROPERTIES.INFO_LIGHT) {
+		throw new Error('Ti.UI.iPhone.SystemButton.INFO_LIGHT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.INFO_LIGHT = undefined;
+	} else {
+		this.INFO_LIGHT = 0;
+	}
+	if (__SLAG_PROPERTIES.ORGANIZE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.ORGANIZE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ORGANIZE = undefined;
+	} else {
+		this.ORGANIZE = 0;
+	}
+	if (__SLAG_PROPERTIES.PAUSE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.PAUSE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PAUSE = undefined;
+	} else {
+		this.PAUSE = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAY) {
+		throw new Error('Ti.UI.iPhone.SystemButton.PLAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAY = undefined;
+	} else {
+		this.PLAY = 0;
+	}
+	if (__SLAG_PROPERTIES.REFRESH) {
+		throw new Error('Ti.UI.iPhone.SystemButton.REFRESH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.REFRESH = undefined;
+	} else {
+		this.REFRESH = 0;
+	}
+	if (__SLAG_PROPERTIES.REPLY) {
+		throw new Error('Ti.UI.iPhone.SystemButton.REPLY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.REPLY = undefined;
+	} else {
+		this.REPLY = 0;
+	}
+	if (__SLAG_PROPERTIES.REWIND) {
+		throw new Error('Ti.UI.iPhone.SystemButton.REWIND is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.REWIND = undefined;
+	} else {
+		this.REWIND = 0;
+	}
+	if (__SLAG_PROPERTIES.SAVE) {
+		throw new Error('Ti.UI.iPhone.SystemButton.SAVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SAVE = undefined;
+	} else {
+		this.SAVE = 0;
+	}
+	if (__SLAG_PROPERTIES.SPINNER) {
+		throw new Error('Ti.UI.iPhone.SystemButton.SPINNER is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SPINNER = undefined;
+	} else {
+		this.SPINNER = 0;
+	}
+	if (__SLAG_PROPERTIES.STOP) {
+		throw new Error('Ti.UI.iPhone.SystemButton.STOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.STOP = undefined;
+	} else {
+		this.STOP = 0;
+	}
+	if (__SLAG_PROPERTIES.TRASH) {
+		throw new Error('Ti.UI.iPhone.SystemButton.TRASH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TRASH = undefined;
+	} else {
+		this.TRASH = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SystemButton.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButton.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButton.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButton.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SystemButton.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SystemButton.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SystemButton.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new SystemButton(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/SystemButtonStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/SystemButtonStyle.js
@@ -1,0 +1,106 @@
+var crypto = require('crypto');
+function SystemButtonStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BAR',
+			'BORDERED',
+			'DONE',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.SystemButtonStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.SystemButtonStyle';
+	if (__SLAG_PROPERTIES.BAR) {
+		throw new Error('Ti.UI.iPhone.SystemButtonStyle.BAR was deprecated, since 3.4.2');
+	}
+	if (__SLAG_PROPERTIES.BORDERED) {
+		throw new Error('Ti.UI.iPhone.SystemButtonStyle.BORDERED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BORDERED = undefined;
+	} else {
+		this.BORDERED = 0;
+	}
+	if (__SLAG_PROPERTIES.DONE) {
+		throw new Error('Ti.UI.iPhone.SystemButtonStyle.DONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DONE = undefined;
+	} else {
+		this.DONE = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iPhone.SystemButtonStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SystemButtonStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButtonStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButtonStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemButtonStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SystemButtonStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SystemButtonStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SystemButtonStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new SystemButtonStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/SystemIcon.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/SystemIcon.js
@@ -1,0 +1,183 @@
+var crypto = require('crypto');
+function SystemIcon(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BOOKMARKS',
+			'CONTACTS',
+			'DOWNLOADS',
+			'FAVORITES',
+			'FEATURED',
+			'HISTORY',
+			'MORE',
+			'MOST_RECENT',
+			'MOST_VIEWED',
+			'RECENTS',
+			'SEARCH',
+			'TOP_RATED',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.SystemIcon';
+	if (__SLAG_PROPERTIES.BOOKMARKS) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.BOOKMARKS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOOKMARKS = undefined;
+	} else {
+		this.BOOKMARKS = 0;
+	}
+	if (__SLAG_PROPERTIES.CONTACTS) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.CONTACTS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CONTACTS = undefined;
+	} else {
+		this.CONTACTS = 0;
+	}
+	if (__SLAG_PROPERTIES.DOWNLOADS) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.DOWNLOADS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOWNLOADS = undefined;
+	} else {
+		this.DOWNLOADS = 0;
+	}
+	if (__SLAG_PROPERTIES.FAVORITES) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.FAVORITES is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FAVORITES = undefined;
+	} else {
+		this.FAVORITES = 0;
+	}
+	if (__SLAG_PROPERTIES.FEATURED) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.FEATURED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.FEATURED = undefined;
+	} else {
+		this.FEATURED = 0;
+	}
+	if (__SLAG_PROPERTIES.HISTORY) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.HISTORY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.HISTORY = undefined;
+	} else {
+		this.HISTORY = 0;
+	}
+	if (__SLAG_PROPERTIES.MORE) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.MORE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MORE = undefined;
+	} else {
+		this.MORE = 0;
+	}
+	if (__SLAG_PROPERTIES.MOST_RECENT) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.MOST_RECENT is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MOST_RECENT = undefined;
+	} else {
+		this.MOST_RECENT = 0;
+	}
+	if (__SLAG_PROPERTIES.MOST_VIEWED) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.MOST_VIEWED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MOST_VIEWED = undefined;
+	} else {
+		this.MOST_VIEWED = 0;
+	}
+	if (__SLAG_PROPERTIES.RECENTS) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.RECENTS is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.RECENTS = undefined;
+	} else {
+		this.RECENTS = 0;
+	}
+	if (__SLAG_PROPERTIES.SEARCH) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.SEARCH is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SEARCH = undefined;
+	} else {
+		this.SEARCH = 0;
+	}
+	if (__SLAG_PROPERTIES.TOP_RATED) {
+		throw new Error('Ti.UI.iPhone.SystemIcon.TOP_RATED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TOP_RATED = undefined;
+	} else {
+		this.TOP_RATED = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+SystemIcon.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemIcon.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemIcon.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+SystemIcon.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+SystemIcon.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+SystemIcon.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+SystemIcon.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new SystemIcon(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewCellSelectionStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewCellSelectionStyle.js
@@ -1,0 +1,102 @@
+var crypto = require('crypto');
+function TableViewCellSelectionStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BLUE',
+			'GRAY',
+			'NONE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.TableViewCellSelectionStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.TableViewCellSelectionStyle';
+	if (__SLAG_PROPERTIES.BLUE) {
+		throw new Error('Ti.UI.iPhone.TableViewCellSelectionStyle.BLUE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BLUE = undefined;
+	} else {
+		this.BLUE = 0;
+	}
+	if (__SLAG_PROPERTIES.GRAY) {
+		throw new Error('Ti.UI.iPhone.TableViewCellSelectionStyle.GRAY is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GRAY = undefined;
+	} else {
+		this.GRAY = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.TableViewCellSelectionStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewCellSelectionStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewCellSelectionStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewCellSelectionStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewCellSelectionStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewCellSelectionStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewCellSelectionStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewCellSelectionStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewCellSelectionStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewScrollPosition.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewScrollPosition.js
@@ -1,0 +1,111 @@
+var crypto = require('crypto');
+function TableViewScrollPosition(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'BOTTOM',
+			'MIDDLE',
+			'NONE',
+			'TOP',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.TableViewScrollPosition.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.TableViewScrollPosition';
+	if (__SLAG_PROPERTIES.BOTTOM) {
+		throw new Error('Ti.UI.iPhone.TableViewScrollPosition.BOTTOM is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.BOTTOM = undefined;
+	} else {
+		this.BOTTOM = 0;
+	}
+	if (__SLAG_PROPERTIES.MIDDLE) {
+		throw new Error('Ti.UI.iPhone.TableViewScrollPosition.MIDDLE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.MIDDLE = undefined;
+	} else {
+		this.MIDDLE = 0;
+	}
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.TableViewScrollPosition.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.TOP) {
+		throw new Error('Ti.UI.iPhone.TableViewScrollPosition.TOP is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TOP = undefined;
+	} else {
+		this.TOP = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewScrollPosition.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewScrollPosition.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewScrollPosition.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewScrollPosition.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewScrollPosition.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewScrollPosition.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewScrollPosition.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewScrollPosition(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewSeparatorStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewSeparatorStyle.js
@@ -1,0 +1,93 @@
+var crypto = require('crypto');
+function TableViewSeparatorStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'NONE',
+			'SINGLE_LINE',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.TableViewSeparatorStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.TableViewSeparatorStyle';
+	if (__SLAG_PROPERTIES.NONE) {
+		throw new Error('Ti.UI.iPhone.TableViewSeparatorStyle.NONE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NONE = undefined;
+	} else {
+		this.NONE = 0;
+	}
+	if (__SLAG_PROPERTIES.SINGLE_LINE) {
+		throw new Error('Ti.UI.iPhone.TableViewSeparatorStyle.SINGLE_LINE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.SINGLE_LINE = undefined;
+	} else {
+		this.SINGLE_LINE = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewSeparatorStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSeparatorStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSeparatorStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewSeparatorStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewSeparatorStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewSeparatorStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewSeparatorStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewSeparatorStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewStyle.js
+++ b/lib/titanium/6.0.4.GA/Titanium/UI/iPhone/TableViewStyle.js
@@ -1,0 +1,93 @@
+var crypto = require('crypto');
+function TableViewStyle(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'GROUPED',
+			'PLAIN',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.UI.iPhone.TableViewStyle.apiName is read only property');
+	}
+	this.apiName = 'Ti.UI.iPhone.TableViewStyle';
+	if (__SLAG_PROPERTIES.GROUPED) {
+		throw new Error('Ti.UI.iPhone.TableViewStyle.GROUPED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.GROUPED = undefined;
+	} else {
+		this.GROUPED = 0;
+	}
+	if (__SLAG_PROPERTIES.PLAIN) {
+		throw new Error('Ti.UI.iPhone.TableViewStyle.PLAIN is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PLAIN = undefined;
+	} else {
+		this.PLAIN = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+TableViewStyle.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewStyle.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewStyle.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+TableViewStyle.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+TableViewStyle.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+TableViewStyle.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+TableViewStyle.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+module.exports = function (properties) {
+	return new TableViewStyle(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Utils.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Utils.js
@@ -1,0 +1,168 @@
+var crypto = require('crypto');
+function Utils(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Utils.apiName is read only property');
+	}
+	this.apiName = 'Ti.Utils';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Utils.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Utils.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Utils.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Utils.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Utils.prototype.base64decode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Utils.prototype.base64encode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Utils.prototype.md5HexDigest = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Utils.prototype.sha1 = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Utils.prototype.sha256 = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Utils.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Utils.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Utils.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Utils.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Utils.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Utils(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/WatchSession.js
+++ b/lib/titanium/6.0.4.GA/Titanium/WatchSession.js
@@ -1,0 +1,297 @@
+var crypto = require('crypto');
+function WatchSession(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'activationState',
+			'ACTIVATION_STATE_NOT_ACTIVATED',
+			'ACTIVATION_STATE_INACTIVE',
+			'ACTIVATION_STATE_ACTIVATED',
+			'hasContentPending',
+			'remainingComplicationUserInfoTransfers',
+			'isSupported',
+			'isPaired',
+			'isWatchAppInstalled',
+			'isComplicationEnabled',
+			'isReachable',
+			'isActivated',
+			'recentApplicationContext',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.WatchSession.apiName is read only property');
+	}
+	this.apiName = 'Ti.WatchSession';
+	if (__SLAG_PROPERTIES.activationState) {
+		throw new Error('Ti.WatchSession.activationState is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activationState = undefined;
+	} else {
+		this.activationState = 0;
+	}
+	if (__SLAG_PROPERTIES.ACTIVATION_STATE_NOT_ACTIVATED) {
+		throw new Error('Ti.WatchSession.ACTIVATION_STATE_NOT_ACTIVATED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVATION_STATE_NOT_ACTIVATED = undefined;
+	} else {
+		this.ACTIVATION_STATE_NOT_ACTIVATED = 0;
+	}
+	if (__SLAG_PROPERTIES.ACTIVATION_STATE_INACTIVE) {
+		throw new Error('Ti.WatchSession.ACTIVATION_STATE_INACTIVE is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVATION_STATE_INACTIVE = undefined;
+	} else {
+		this.ACTIVATION_STATE_INACTIVE = 0;
+	}
+	if (__SLAG_PROPERTIES.ACTIVATION_STATE_ACTIVATED) {
+		throw new Error('Ti.WatchSession.ACTIVATION_STATE_ACTIVATED is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ACTIVATION_STATE_ACTIVATED = undefined;
+	} else {
+		this.ACTIVATION_STATE_ACTIVATED = 0;
+	}
+	if (__SLAG_PROPERTIES.hasContentPending) {
+		throw new Error('Ti.WatchSession.hasContentPending is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.hasContentPending = undefined;
+	} else {
+		this.hasContentPending = true;
+	}
+	if (__SLAG_PROPERTIES.remainingComplicationUserInfoTransfers) {
+		throw new Error('Ti.WatchSession.remainingComplicationUserInfoTransfers is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.remainingComplicationUserInfoTransfers = undefined;
+	} else {
+		this.remainingComplicationUserInfoTransfers = 0;
+	}
+	if (__SLAG_PROPERTIES.isSupported) {
+		throw new Error('Ti.WatchSession.isSupported is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isSupported = undefined;
+	} else {
+		this.isSupported = true;
+	}
+	if (__SLAG_PROPERTIES.isPaired) {
+		throw new Error('Ti.WatchSession.isPaired is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isPaired = undefined;
+	} else {
+		this.isPaired = true;
+	}
+	if (__SLAG_PROPERTIES.isWatchAppInstalled) {
+		throw new Error('Ti.WatchSession.isWatchAppInstalled is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isWatchAppInstalled = undefined;
+	} else {
+		this.isWatchAppInstalled = true;
+	}
+	if (__SLAG_PROPERTIES.isComplicationEnabled) {
+		throw new Error('Ti.WatchSession.isComplicationEnabled is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isComplicationEnabled = undefined;
+	} else {
+		this.isComplicationEnabled = true;
+	}
+	if (__SLAG_PROPERTIES.isReachable) {
+		throw new Error('Ti.WatchSession.isReachable is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isReachable = undefined;
+	} else {
+		this.isReachable = true;
+	}
+	if (__SLAG_PROPERTIES.isActivated) {
+		throw new Error('Ti.WatchSession.isActivated is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.isActivated = undefined;
+	} else {
+		this.isActivated = true;
+	}
+	if (__SLAG_PROPERTIES.recentApplicationContext) {
+		throw new Error('Ti.WatchSession.recentApplicationContext is read only property');
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.recentApplicationContext = undefined;
+	} else {
+		this.recentApplicationContext = {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+WatchSession.prototype.addEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.removeEventListener = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.fireEvent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+WatchSession.prototype.activateSession = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.sendMessage = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.updateApplicationContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.transferUserInfo = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.transferFile = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.transferCurrentComplication = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.cancelAllUserInfoTransfers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.cancelAllFileTransfers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.cancelAllTransfers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+WatchSession.prototype.getBubbleParent = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+WatchSession.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+WatchSession.prototype.getApiName = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+WatchSession.prototype.getActivationState = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.activationState;
+};
+WatchSession.prototype.getHasContentPending = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.hasContentPending;
+};
+WatchSession.prototype.getRemainingComplicationUserInfoTransfers = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.remainingComplicationUserInfoTransfers;
+};
+WatchSession.prototype.getIsSupported = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isSupported;
+};
+WatchSession.prototype.getIsPaired = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isPaired;
+};
+WatchSession.prototype.getIsWatchAppInstalled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isWatchAppInstalled;
+};
+WatchSession.prototype.getIsComplicationEnabled = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isComplicationEnabled;
+};
+WatchSession.prototype.getIsReachable = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isReachable;
+};
+WatchSession.prototype.getIsActivated = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.isActivated;
+};
+WatchSession.prototype.getRecentApplicationContext = function () {
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.recentApplicationContext;
+};
+module.exports = function (properties) {
+	return new WatchSession(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML.js
@@ -1,0 +1,138 @@
+var crypto = require('crypto');
+function XML(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+XML.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+XML.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+XML.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+XML.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+XML.prototype.parseString = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+XML.prototype.serializeToString = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+XML.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+XML.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+XML.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+XML.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+XML.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new XML(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Attr.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Attr.js
@@ -1,0 +1,832 @@
+var crypto = require('crypto');
+function Attr(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'name',
+			'ownerElement',
+			'specified',
+			'value',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Attr.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Attr';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.Attr.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.Attr.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.Attr.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.Attr.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.Attr.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.Attr.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.Attr.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.Attr.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.Attr.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.Attr.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.Attr.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.Attr.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.Attr.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.Attr.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.Attr.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.Attr.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.Attr.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.Attr.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.Attr.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.Attr.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.Attr.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.Attr.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.Attr.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.Attr.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.Attr.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.XML.Attr.name is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if (__SLAG_PROPERTIES.ownerElement) {
+		throw new Error('Ti.XML.Attr.ownerElement is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerElement = undefined;
+	} else {
+		this.ownerElement = {};
+	}
+	if (__SLAG_PROPERTIES.specified) {
+		throw new Error('Ti.XML.Attr.specified is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.specified = undefined;
+	} else {
+		this.specified = true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.value = undefined;
+	} else {
+		this.value = __SLAG_PROPERTIES.value || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Attr.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attr.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attr.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attr.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Attr.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Attr.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Attr.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Attr.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Attr.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Attr.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Attr.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Attr.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Attr.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Attr.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Attr.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Attr.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Attr.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Attr.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Attr.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+Attr.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+Attr.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+Attr.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+Attr.prototype.getText = function () {
+	throw new Error('Ti.XML.Attr.getText was deprecated, since 2.0.0');
+};
+Attr.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+Attr.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+Attr.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+Attr.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+Attr.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+Attr.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+Attr.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+Attr.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+Attr.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+Attr.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+Attr.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Attr.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+Attr.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+Attr.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+Attr.prototype.getName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+Attr.prototype.getOwnerElement = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerElement;
+};
+Attr.prototype.getSpecified = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.specified;
+};
+Attr.prototype.getValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.value;
+};
+Attr.prototype.setValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.value = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Attr(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/CDATASection.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/CDATASection.js
@@ -1,0 +1,844 @@
+var crypto = require('crypto');
+function CDATASection(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'data',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.CDATASection.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.CDATASection';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.CDATASection.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.CDATASection.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.CDATASection.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.CDATASection.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.CDATASection.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.CDATASection.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.CDATASection.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.CDATASection.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.CDATASection.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.CDATASection.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.CDATASection.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.CDATASection.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.CDATASection.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.CDATASection.textContent is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.CDATASection.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.CDATASection.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.CDATASection.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.CDATASection.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.CDATASection.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.CDATASection.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.CDATASection.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.CDATASection.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.CDATASection.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.CDATASection.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.CDATASection.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || '';
+	}
+	if (__SLAG_PROPERTIES.length) {
+		throw new Error('Ti.XML.CDATASection.length is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+CDATASection.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+CDATASection.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CDATASection.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CDATASection.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+CDATASection.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+CDATASection.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CDATASection.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+CDATASection.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CDATASection.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CDATASection.prototype.appendData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.deleteData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.insertData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.replaceData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CDATASection.prototype.substringData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+CDATASection.prototype.splitText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CDATASection.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+CDATASection.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+CDATASection.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+CDATASection.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+CDATASection.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+CDATASection.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+CDATASection.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+CDATASection.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+CDATASection.prototype.getTextContent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+CDATASection.prototype.getText = function () {
+	throw new Error('Ti.XML.CDATASection.getText was deprecated, since 2.0.0');
+};
+CDATASection.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+CDATASection.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+CDATASection.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+CDATASection.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+CDATASection.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+CDATASection.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+CDATASection.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+CDATASection.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+CDATASection.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+CDATASection.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+CDATASection.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+CDATASection.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+CDATASection.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+CDATASection.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+CDATASection.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+CDATASection.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+CDATASection.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+module.exports = function (properties) {
+	return new CDATASection(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/CharacterData.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/CharacterData.js
@@ -1,0 +1,832 @@
+var crypto = require('crypto');
+function CharacterData(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'data',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.CharacterData.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.CharacterData';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.CharacterData.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.CharacterData.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.CharacterData.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.CharacterData.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.CharacterData.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.CharacterData.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.CharacterData.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.CharacterData.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.CharacterData.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.CharacterData.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.CharacterData.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.CharacterData.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.CharacterData.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.CharacterData.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.CharacterData.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.CharacterData.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.CharacterData.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.CharacterData.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.CharacterData.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.CharacterData.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.CharacterData.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.CharacterData.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.CharacterData.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.CharacterData.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.CharacterData.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || '';
+	}
+	if (__SLAG_PROPERTIES.length) {
+		throw new Error('Ti.XML.CharacterData.length is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+CharacterData.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+CharacterData.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CharacterData.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CharacterData.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+CharacterData.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+CharacterData.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CharacterData.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+CharacterData.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CharacterData.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+CharacterData.prototype.appendData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.deleteData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.insertData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.replaceData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+CharacterData.prototype.substringData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+CharacterData.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+CharacterData.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+CharacterData.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+CharacterData.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+CharacterData.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+CharacterData.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+CharacterData.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+CharacterData.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+CharacterData.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+CharacterData.prototype.getText = function () {
+	throw new Error('Ti.XML.CharacterData.getText was deprecated, since 2.0.0');
+};
+CharacterData.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+CharacterData.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+CharacterData.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+CharacterData.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+CharacterData.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+CharacterData.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+CharacterData.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+CharacterData.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+CharacterData.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+CharacterData.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+CharacterData.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+CharacterData.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+CharacterData.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+CharacterData.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+CharacterData.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+CharacterData.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+CharacterData.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+module.exports = function (properties) {
+	return new CharacterData(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Comment.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Comment.js
@@ -1,0 +1,832 @@
+var crypto = require('crypto');
+function Comment(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'data',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Comment.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Comment';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.Comment.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.Comment.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.Comment.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.Comment.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.Comment.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.Comment.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.Comment.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.Comment.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.Comment.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.Comment.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.Comment.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.Comment.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.Comment.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.Comment.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.Comment.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.Comment.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.Comment.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.Comment.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.Comment.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.Comment.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.Comment.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.Comment.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.Comment.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.Comment.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.Comment.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || '';
+	}
+	if (__SLAG_PROPERTIES.length) {
+		throw new Error('Ti.XML.Comment.length is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Comment.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Comment.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Comment.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Comment.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Comment.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Comment.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Comment.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Comment.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Comment.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Comment.prototype.appendData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.deleteData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.insertData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.replaceData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Comment.prototype.substringData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Comment.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Comment.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Comment.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Comment.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Comment.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Comment.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+Comment.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+Comment.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+Comment.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+Comment.prototype.getText = function () {
+	throw new Error('Ti.XML.Comment.getText was deprecated, since 2.0.0');
+};
+Comment.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+Comment.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+Comment.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+Comment.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+Comment.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+Comment.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+Comment.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+Comment.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+Comment.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+Comment.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+Comment.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Comment.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+Comment.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+Comment.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+Comment.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+Comment.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+Comment.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+module.exports = function (properties) {
+	return new Comment(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/DOMImplementation.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/DOMImplementation.js
@@ -1,0 +1,150 @@
+var crypto = require('crypto');
+function DOMImplementation(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.DOMImplementation.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.DOMImplementation';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DOMImplementation.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DOMImplementation.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DOMImplementation.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DOMImplementation.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DOMImplementation.prototype.createDocument = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Document = require('./DOMImplementation/Document');
+	return Document(__SLAG_PROPERTY);
+};
+DOMImplementation.prototype.createDocumentType = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var DocumentType = require('./DOMImplementation/DocumentType');
+	return DocumentType(__SLAG_PROPERTY);
+};
+DOMImplementation.prototype.hasFeature = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+DOMImplementation.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DOMImplementation.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DOMImplementation.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DOMImplementation.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+DOMImplementation.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DOMImplementation(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Document.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Document.js
@@ -1,0 +1,952 @@
+var crypto = require('crypto');
+function Document(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'doctype',
+			'documentElement',
+			'implementation',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Document.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Document';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.Document.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.Document.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.Document.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.Document.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.Document.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.Document.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.Document.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.Document.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.Document.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.Document.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.Document.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.Document.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.Document.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.Document.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.Document.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.Document.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.Document.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.Document.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.Document.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.Document.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.Document.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.Document.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.Document.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.Document.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.Document.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if (__SLAG_PROPERTIES.doctype) {
+		throw new Error('Ti.XML.Document.doctype is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.doctype = undefined;
+	} else {
+		this.doctype = {};
+	}
+	if (__SLAG_PROPERTIES.documentElement) {
+		throw new Error('Ti.XML.Document.documentElement is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.documentElement = undefined;
+	} else {
+		this.documentElement = {};
+	}
+	if (__SLAG_PROPERTIES.implementation) {
+		throw new Error('Ti.XML.Document.implementation is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.implementation = undefined;
+	} else {
+		this.implementation = {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Document.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Document.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Document.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Document.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Document.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Document.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Document.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Document.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Document.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.createAttribute = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Attribute = require('./Document/Attribute');
+	return Attribute(__SLAG_PROPERTY);
+};
+Document.prototype.createAttributeNS = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var AttributeNS = require('./Document/AttributeNS');
+	return AttributeNS(__SLAG_PROPERTY);
+};
+Document.prototype.createCDATASection = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var CDATASection = require('./Document/CDATASection');
+	return CDATASection(__SLAG_PROPERTY);
+};
+Document.prototype.createComment = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Comment = require('./Document/Comment');
+	return Comment(__SLAG_PROPERTY);
+};
+Document.prototype.createDocumentFragment = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var DocumentFragment = require('./Document/DocumentFragment');
+	return DocumentFragment(__SLAG_PROPERTY);
+};
+Document.prototype.createElement = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var Element = require('./Document/Element');
+	return Element(__SLAG_PROPERTY);
+};
+Document.prototype.createElementNS = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ElementNS = require('./Document/ElementNS');
+	return ElementNS(__SLAG_PROPERTY);
+};
+Document.prototype.createEntityReference = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var EntityReference = require('./Document/EntityReference');
+	return EntityReference(__SLAG_PROPERTY);
+};
+Document.prototype.createProcessingInstruction = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var ProcessingInstruction = require('./Document/ProcessingInstruction');
+	return ProcessingInstruction(__SLAG_PROPERTY);
+};
+Document.prototype.createTextNode = function (__SLAG_PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	var TextNode = require('./Document/TextNode');
+	return TextNode(__SLAG_PROPERTY);
+};
+Document.prototype.getElementById = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.getElementsByTagName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.getElementsByTagNameNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.importNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Document.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Document.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Document.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Document.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Document.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Document.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+Document.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+Document.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+Document.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+Document.prototype.getText = function () {
+	throw new Error('Ti.XML.Document.getText was deprecated, since 2.0.0');
+};
+Document.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+Document.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+Document.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+Document.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+Document.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+Document.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+Document.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+Document.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+Document.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+Document.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+Document.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Document.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+Document.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+Document.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+Document.prototype.getDoctype = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.doctype;
+};
+Document.prototype.getDocumentElement = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.documentElement;
+};
+Document.prototype.getImplementation = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.implementation;
+};
+module.exports = function (properties) {
+	return new Document(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/DocumentFragment.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/DocumentFragment.js
@@ -1,0 +1,733 @@
+var crypto = require('crypto');
+function DocumentFragment(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.DocumentFragment.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.DocumentFragment';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.DocumentFragment.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.DocumentFragment.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.DocumentFragment.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.DocumentFragment.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.DocumentFragment.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.DocumentFragment.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.DocumentFragment.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.DocumentFragment.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.DocumentFragment.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.DocumentFragment.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.DocumentFragment.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.DocumentFragment.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.DocumentFragment.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.DocumentFragment.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DocumentFragment.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentFragment.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentFragment.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentFragment.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DocumentFragment.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentFragment.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentFragment.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+DocumentFragment.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+DocumentFragment.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentFragment.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+DocumentFragment.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentFragment.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentFragment.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentFragment.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DocumentFragment.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DocumentFragment.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DocumentFragment.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+DocumentFragment.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+DocumentFragment.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+DocumentFragment.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+DocumentFragment.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+DocumentFragment.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+DocumentFragment.prototype.getText = function () {
+	throw new Error('Ti.XML.DocumentFragment.getText was deprecated, since 2.0.0');
+};
+DocumentFragment.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+DocumentFragment.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+DocumentFragment.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+DocumentFragment.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+DocumentFragment.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+DocumentFragment.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+DocumentFragment.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+DocumentFragment.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+DocumentFragment.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+DocumentFragment.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+DocumentFragment.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+DocumentFragment.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+DocumentFragment.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+DocumentFragment.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new DocumentFragment(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/DocumentType.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/DocumentType.js
@@ -1,0 +1,871 @@
+var crypto = require('crypto');
+function DocumentType(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'entities',
+			'internalSubset',
+			'name',
+			'notations',
+			'publicId',
+			'systemId',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.DocumentType.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.DocumentType';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.DocumentType.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.DocumentType.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.DocumentType.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.DocumentType.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.DocumentType.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.DocumentType.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.DocumentType.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.DocumentType.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.DocumentType.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.DocumentType.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.DocumentType.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.DocumentType.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.DocumentType.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.DocumentType.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.DocumentType.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.DocumentType.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.DocumentType.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.DocumentType.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.DocumentType.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.DocumentType.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.DocumentType.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.DocumentType.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.DocumentType.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.DocumentType.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.DocumentType.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if (__SLAG_PROPERTIES.entities) {
+		throw new Error('Ti.XML.DocumentType.entities is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.entities = undefined;
+	} else {
+		this.entities = {};
+	}
+	if (__SLAG_PROPERTIES.internalSubset) {
+		throw new Error('Ti.XML.DocumentType.internalSubset is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.internalSubset = undefined;
+	} else {
+		this.internalSubset = '';
+	}
+	if (__SLAG_PROPERTIES.name) {
+		throw new Error('Ti.XML.DocumentType.name is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.name = undefined;
+	} else {
+		this.name = '';
+	}
+	if (__SLAG_PROPERTIES.notations) {
+		throw new Error('Ti.XML.DocumentType.notations is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.notations = undefined;
+	} else {
+		this.notations = {};
+	}
+	if (__SLAG_PROPERTIES.publicId) {
+		throw new Error('Ti.XML.DocumentType.publicId is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.publicId = undefined;
+	} else {
+		this.publicId = '';
+	}
+	if (__SLAG_PROPERTIES.systemId) {
+		throw new Error('Ti.XML.DocumentType.systemId is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.systemId = undefined;
+	} else {
+		this.systemId = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+DocumentType.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentType.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentType.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentType.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+DocumentType.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentType.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentType.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+DocumentType.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+DocumentType.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentType.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+DocumentType.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+DocumentType.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentType.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+DocumentType.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+DocumentType.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+DocumentType.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+DocumentType.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+DocumentType.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+DocumentType.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+DocumentType.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+DocumentType.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+DocumentType.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+DocumentType.prototype.getText = function () {
+	throw new Error('Ti.XML.DocumentType.getText was deprecated, since 2.0.0');
+};
+DocumentType.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+DocumentType.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+DocumentType.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+DocumentType.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+DocumentType.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+DocumentType.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+DocumentType.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+DocumentType.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+DocumentType.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+DocumentType.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+DocumentType.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+DocumentType.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+DocumentType.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+DocumentType.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+DocumentType.prototype.getEntities = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.entities;
+};
+DocumentType.prototype.getInternalSubset = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.internalSubset;
+};
+DocumentType.prototype.getName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.name;
+};
+DocumentType.prototype.getNotations = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.notations;
+};
+DocumentType.prototype.getPublicId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.publicId;
+};
+DocumentType.prototype.getSystemId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.systemId;
+};
+module.exports = function (properties) {
+	return new DocumentType(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Element.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Element.js
@@ -1,0 +1,903 @@
+var crypto = require('crypto');
+function Element(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'tagName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Element.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Element';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.Element.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.Element.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.Element.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.Element.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.Element.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.Element.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.Element.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.Element.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.Element.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.Element.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.Element.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.Element.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.Element.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.Element.textContent is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.Element.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.Element.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.Element.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.Element.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.Element.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.Element.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.Element.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.Element.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.Element.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.Element.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.Element.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if (__SLAG_PROPERTIES.tagName) {
+		throw new Error('Ti.XML.Element.tagName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tagName = undefined;
+	} else {
+		this.tagName = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Element.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Element.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Element.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Element.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Element.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.getAttribute = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Element.prototype.setAttribute = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.removeAttribute = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.getAttributeNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.setAttributeNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.removeAttributeNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.getElementsByTagName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.getAttributeNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Element.prototype.setAttributeNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.removeAttributeNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Element.prototype.getAttributeNodeNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.setAttributeNodeNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.getElementsByTagNameNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Element.prototype.hasAttribute = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Element.prototype.hasAttributeNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Element.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Element.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Element.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Element.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Element.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Element.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+Element.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+Element.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+Element.prototype.getTextContent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+Element.prototype.getText = function () {
+	throw new Error('Ti.XML.Element.getText was deprecated, since 2.0.0');
+};
+Element.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+Element.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+Element.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+Element.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+Element.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+Element.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+Element.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+Element.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+Element.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+Element.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+Element.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Element.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+Element.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+Element.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+Element.prototype.getTagName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.tagName;
+};
+module.exports = function (properties) {
+	return new Element(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Entity.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Entity.js
@@ -1,0 +1,802 @@
+var crypto = require('crypto');
+function Entity(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'notationName',
+			'publicId',
+			'systemId',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Entity.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Entity';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.Entity.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.Entity.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.Entity.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.Entity.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.Entity.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.Entity.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.Entity.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.Entity.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.Entity.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.Entity.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.Entity.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.Entity.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.Entity.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.Entity.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.Entity.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.Entity.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.Entity.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.Entity.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.Entity.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.Entity.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.Entity.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.Entity.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.Entity.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.Entity.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.Entity.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if (__SLAG_PROPERTIES.notationName) {
+		throw new Error('Ti.XML.Entity.notationName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.notationName = undefined;
+	} else {
+		this.notationName = '';
+	}
+	if (__SLAG_PROPERTIES.publicId) {
+		throw new Error('Ti.XML.Entity.publicId is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.publicId = undefined;
+	} else {
+		this.publicId = '';
+	}
+	if (__SLAG_PROPERTIES.systemId) {
+		throw new Error('Ti.XML.Entity.systemId is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.systemId = undefined;
+	} else {
+		this.systemId = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Entity.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Entity.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Entity.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Entity.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Entity.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Entity.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Entity.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Entity.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Entity.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Entity.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Entity.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Entity.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Entity.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Entity.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Entity.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Entity.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Entity.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Entity.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Entity.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+Entity.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+Entity.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+Entity.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+Entity.prototype.getText = function () {
+	throw new Error('Ti.XML.Entity.getText was deprecated, since 2.0.0');
+};
+Entity.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+Entity.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+Entity.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+Entity.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+Entity.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+Entity.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+Entity.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+Entity.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+Entity.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+Entity.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+Entity.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Entity.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+Entity.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+Entity.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+Entity.prototype.getNotationName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.notationName;
+};
+Entity.prototype.getPublicId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.publicId;
+};
+Entity.prototype.getSystemId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.systemId;
+};
+module.exports = function (properties) {
+	return new Entity(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/EntityReference.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/EntityReference.js
@@ -1,0 +1,733 @@
+var crypto = require('crypto');
+function EntityReference(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.EntityReference.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.EntityReference';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.EntityReference.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.EntityReference.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.EntityReference.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.EntityReference.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.EntityReference.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.EntityReference.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.EntityReference.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.EntityReference.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.EntityReference.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.EntityReference.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.EntityReference.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.EntityReference.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.EntityReference.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.EntityReference.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.EntityReference.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.EntityReference.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.EntityReference.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.EntityReference.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.EntityReference.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.EntityReference.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.EntityReference.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.EntityReference.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.EntityReference.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.EntityReference.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.EntityReference.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+EntityReference.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EntityReference.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EntityReference.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EntityReference.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+EntityReference.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+EntityReference.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+EntityReference.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+EntityReference.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+EntityReference.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+EntityReference.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+EntityReference.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+EntityReference.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+EntityReference.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+EntityReference.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+EntityReference.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+EntityReference.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+EntityReference.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+EntityReference.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+EntityReference.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+EntityReference.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+EntityReference.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+EntityReference.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+EntityReference.prototype.getText = function () {
+	throw new Error('Ti.XML.EntityReference.getText was deprecated, since 2.0.0');
+};
+EntityReference.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+EntityReference.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+EntityReference.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+EntityReference.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+EntityReference.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+EntityReference.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+EntityReference.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+EntityReference.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+EntityReference.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+EntityReference.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+EntityReference.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+EntityReference.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+EntityReference.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+EntityReference.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new EntityReference(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/NamedNodeMap.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/NamedNodeMap.js
@@ -1,0 +1,211 @@
+var crypto = require('crypto');
+function NamedNodeMap(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.NamedNodeMap.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.NamedNodeMap';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.length) {
+		throw new Error('Ti.XML.NamedNodeMap.length is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+NamedNodeMap.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NamedNodeMap.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NamedNodeMap.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NamedNodeMap.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+NamedNodeMap.prototype.getNamedItem = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NamedNodeMap.prototype.setNamedItem = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NamedNodeMap.prototype.removeNamedItem = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NamedNodeMap.prototype.item = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NamedNodeMap.prototype.getNamedItemNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NamedNodeMap.prototype.setNamedItemNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NamedNodeMap.prototype.removeNamedItemNS = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NamedNodeMap.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+NamedNodeMap.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+NamedNodeMap.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+NamedNodeMap.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+NamedNodeMap.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+NamedNodeMap.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+module.exports = function (properties) {
+	return new NamedNodeMap(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Node.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Node.js
@@ -1,0 +1,733 @@
+var crypto = require('crypto');
+function Node(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Node.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Node';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.Node.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.Node.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.Node.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.Node.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.Node.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.Node.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.Node.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.Node.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.Node.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.Node.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.Node.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.Node.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.Node.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.Node.textContent is read only property');
+	}
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.Node.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.Node.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.Node.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.Node.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.Node.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.Node.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.Node.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.Node.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.Node.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.Node.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.Node.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Node.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Node.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Node.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Node.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Node.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Node.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Node.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Node.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Node.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Node.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Node.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Node.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Node.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Node.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Node.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Node.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Node.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Node.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Node.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+Node.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+Node.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+Node.prototype.getTextContent = function () {
+	if ([
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+Node.prototype.getText = function () {
+	throw new Error('Ti.XML.Node.getText was deprecated, since 2.0.0');
+};
+Node.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+Node.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+Node.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+Node.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+Node.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+Node.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+Node.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+Node.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+Node.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+Node.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+Node.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Node.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+Node.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+Node.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Node(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/NodeList.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/NodeList.js
@@ -1,0 +1,151 @@
+var crypto = require('crypto');
+function NodeList(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.NodeList.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.NodeList';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.length) {
+		throw new Error('Ti.XML.NodeList.length is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+NodeList.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NodeList.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NodeList.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+NodeList.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+NodeList.prototype.item = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+NodeList.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+NodeList.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+NodeList.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+NodeList.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+NodeList.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+NodeList.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+module.exports = function (properties) {
+	return new NodeList(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Notation.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Notation.js
@@ -1,0 +1,164 @@
+var crypto = require('crypto');
+function Notation(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'publicId',
+			'systemId',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Notation.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Notation';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.publicId) {
+		throw new Error('Ti.XML.Notation.publicId is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.publicId = undefined;
+	} else {
+		this.publicId = '';
+	}
+	if (__SLAG_PROPERTIES.systemId) {
+		throw new Error('Ti.XML.Notation.systemId is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.systemId = undefined;
+	} else {
+		this.systemId = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Notation.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notation.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notation.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Notation.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Notation.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Notation.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Notation.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Notation.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Notation.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Notation.prototype.getPublicId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.publicId;
+};
+Notation.prototype.getSystemId = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.systemId;
+};
+module.exports = function (properties) {
+	return new Notation(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/ProcessingInstruction.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/ProcessingInstruction.js
@@ -1,0 +1,171 @@
+var crypto = require('crypto');
+function ProcessingInstruction(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'data',
+			'target',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.ProcessingInstruction.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.ProcessingInstruction';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || '';
+	}
+	if (__SLAG_PROPERTIES.target) {
+		throw new Error('Ti.XML.ProcessingInstruction.target is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.target = undefined;
+	} else {
+		this.target = '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+ProcessingInstruction.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProcessingInstruction.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProcessingInstruction.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+ProcessingInstruction.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+ProcessingInstruction.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+ProcessingInstruction.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+ProcessingInstruction.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+ProcessingInstruction.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+ProcessingInstruction.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+ProcessingInstruction.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+ProcessingInstruction.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+ProcessingInstruction.prototype.getTarget = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.target;
+};
+module.exports = function (properties) {
+	return new ProcessingInstruction(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/XML/Text.js
+++ b/lib/titanium/6.0.4.GA/Titanium/XML/Text.js
@@ -1,0 +1,844 @@
+var crypto = require('crypto');
+function Text(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'ELEMENT_NODE',
+			'ATTRIBUTE_NODE',
+			'TEXT_NODE',
+			'CDATA_SECTION_NODE',
+			'ENTITY_REFERENCE_NODE',
+			'ENTITY_NODE',
+			'PROCESSING_INSTRUCTION_NODE',
+			'COMMENT_NODE',
+			'DOCUMENT_NODE',
+			'DOCUMENT_TYPE_NODE',
+			'DOCUMENT_FRAGMENT_NODE',
+			'NOTATION_NODE',
+			'nodeName',
+			'nodeValue',
+			'textContent',
+			'text',
+			'nodeType',
+			'parentNode',
+			'childNodes',
+			'firstChild',
+			'lastChild',
+			'previousSibling',
+			'nextSibling',
+			'attributes',
+			'ownerDocument',
+			'namespaceURI',
+			'prefix',
+			'localName',
+			'data',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.XML.Text.apiName is read only property');
+	}
+	this.apiName = 'Ti.XML.Text';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	if (__SLAG_PROPERTIES.ELEMENT_NODE) {
+		throw new Error('Ti.XML.Text.ELEMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ELEMENT_NODE = undefined;
+	} else {
+		this.ELEMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ATTRIBUTE_NODE) {
+		throw new Error('Ti.XML.Text.ATTRIBUTE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ATTRIBUTE_NODE = undefined;
+	} else {
+		this.ATTRIBUTE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.TEXT_NODE) {
+		throw new Error('Ti.XML.Text.TEXT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.TEXT_NODE = undefined;
+	} else {
+		this.TEXT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.CDATA_SECTION_NODE) {
+		throw new Error('Ti.XML.Text.CDATA_SECTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.CDATA_SECTION_NODE = undefined;
+	} else {
+		this.CDATA_SECTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_REFERENCE_NODE) {
+		throw new Error('Ti.XML.Text.ENTITY_REFERENCE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_REFERENCE_NODE = undefined;
+	} else {
+		this.ENTITY_REFERENCE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.ENTITY_NODE) {
+		throw new Error('Ti.XML.Text.ENTITY_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ENTITY_NODE = undefined;
+	} else {
+		this.ENTITY_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.PROCESSING_INSTRUCTION_NODE) {
+		throw new Error('Ti.XML.Text.PROCESSING_INSTRUCTION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.PROCESSING_INSTRUCTION_NODE = undefined;
+	} else {
+		this.PROCESSING_INSTRUCTION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.COMMENT_NODE) {
+		throw new Error('Ti.XML.Text.COMMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.COMMENT_NODE = undefined;
+	} else {
+		this.COMMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_NODE) {
+		throw new Error('Ti.XML.Text.DOCUMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_TYPE_NODE) {
+		throw new Error('Ti.XML.Text.DOCUMENT_TYPE_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_TYPE_NODE = undefined;
+	} else {
+		this.DOCUMENT_TYPE_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.DOCUMENT_FRAGMENT_NODE) {
+		throw new Error('Ti.XML.Text.DOCUMENT_FRAGMENT_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.DOCUMENT_FRAGMENT_NODE = undefined;
+	} else {
+		this.DOCUMENT_FRAGMENT_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.NOTATION_NODE) {
+		throw new Error('Ti.XML.Text.NOTATION_NODE is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.NOTATION_NODE = undefined;
+	} else {
+		this.NOTATION_NODE = 0;
+	}
+	if (__SLAG_PROPERTIES.nodeName) {
+		throw new Error('Ti.XML.Text.nodeName is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeName = undefined;
+	} else {
+		this.nodeName = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeValue = undefined;
+	} else {
+		this.nodeValue = __SLAG_PROPERTIES.nodeValue || '';
+	}
+	if (__SLAG_PROPERTIES.textContent) {
+		throw new Error('Ti.XML.Text.textContent is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.textContent = undefined;
+	} else {
+		this.textContent = '';
+	}
+	if (__SLAG_PROPERTIES.text) {
+		throw new Error('Ti.XML.Text.text was deprecated, since 2.0.0');
+	}
+	if (__SLAG_PROPERTIES.nodeType) {
+		throw new Error('Ti.XML.Text.nodeType is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nodeType = undefined;
+	} else {
+		this.nodeType = 0;
+	}
+	if (__SLAG_PROPERTIES.parentNode) {
+		throw new Error('Ti.XML.Text.parentNode is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.parentNode = undefined;
+	} else {
+		this.parentNode = {};
+	}
+	if (__SLAG_PROPERTIES.childNodes) {
+		throw new Error('Ti.XML.Text.childNodes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childNodes = undefined;
+	} else {
+		this.childNodes = {};
+	}
+	if (__SLAG_PROPERTIES.firstChild) {
+		throw new Error('Ti.XML.Text.firstChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.firstChild = undefined;
+	} else {
+		this.firstChild = {};
+	}
+	if (__SLAG_PROPERTIES.lastChild) {
+		throw new Error('Ti.XML.Text.lastChild is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lastChild = undefined;
+	} else {
+		this.lastChild = {};
+	}
+	if (__SLAG_PROPERTIES.previousSibling) {
+		throw new Error('Ti.XML.Text.previousSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.previousSibling = undefined;
+	} else {
+		this.previousSibling = {};
+	}
+	if (__SLAG_PROPERTIES.nextSibling) {
+		throw new Error('Ti.XML.Text.nextSibling is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.nextSibling = undefined;
+	} else {
+		this.nextSibling = {};
+	}
+	if (__SLAG_PROPERTIES.attributes) {
+		throw new Error('Ti.XML.Text.attributes is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.attributes = undefined;
+	} else {
+		this.attributes = {};
+	}
+	if (__SLAG_PROPERTIES.ownerDocument) {
+		throw new Error('Ti.XML.Text.ownerDocument is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.ownerDocument = undefined;
+	} else {
+		this.ownerDocument = {};
+	}
+	if (__SLAG_PROPERTIES.namespaceURI) {
+		throw new Error('Ti.XML.Text.namespaceURI is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.namespaceURI = undefined;
+	} else {
+		this.namespaceURI = '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.prefix = undefined;
+	} else {
+		this.prefix = __SLAG_PROPERTIES.prefix || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.localName = undefined;
+	} else {
+		this.localName = __SLAG_PROPERTIES.localName || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || '';
+	}
+	if (__SLAG_PROPERTIES.length) {
+		throw new Error('Ti.XML.Text.length is read only property');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Text.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Text.prototype.appendChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Text.prototype.cloneNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Text.prototype.hasAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Text.prototype.hasChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Text.prototype.insertBefore = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Text.prototype.isSupported = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return true;
+};
+Text.prototype.normalize = function () {
+	if ([
+			'android',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.removeChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Text.prototype.replaceChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Text.prototype.appendData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.deleteData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.insertData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.replaceData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Text.prototype.substringData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return '';
+};
+Text.prototype.splitText = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return {};
+};
+Text.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Text.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Text.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Text.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Text.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+Text.prototype.getNodeName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeName;
+};
+Text.prototype.getNodeValue = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeValue;
+};
+Text.prototype.setNodeValue = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.nodeValue = __SLAG__PROPERTY;
+};
+Text.prototype.getTextContent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.textContent;
+};
+Text.prototype.getText = function () {
+	throw new Error('Ti.XML.Text.getText was deprecated, since 2.0.0');
+};
+Text.prototype.getNodeType = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nodeType;
+};
+Text.prototype.getParentNode = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.parentNode;
+};
+Text.prototype.getChildNodes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.childNodes;
+};
+Text.prototype.getFirstChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.firstChild;
+};
+Text.prototype.getLastChild = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lastChild;
+};
+Text.prototype.getPreviousSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.previousSibling;
+};
+Text.prototype.getNextSibling = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.nextSibling;
+};
+Text.prototype.getAttributes = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.attributes;
+};
+Text.prototype.getOwnerDocument = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.ownerDocument;
+};
+Text.prototype.getNamespaceURI = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.namespaceURI;
+};
+Text.prototype.getPrefix = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.prefix;
+};
+Text.prototype.setPrefix = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.prefix = __SLAG__PROPERTY;
+};
+Text.prototype.getLocalName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.localName;
+};
+Text.prototype.setLocalName = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.localName = __SLAG__PROPERTY;
+};
+Text.prototype.getData = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.data;
+};
+Text.prototype.setData = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.data = __SLAG__PROPERTY;
+};
+Text.prototype.getLength = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.length;
+};
+module.exports = function (properties) {
+	return new Text(properties);
+};

--- a/lib/titanium/6.0.4.GA/Titanium/Yahoo.js
+++ b/lib/titanium/6.0.4.GA/Titanium/Yahoo.js
@@ -1,0 +1,127 @@
+var crypto = require('crypto');
+function Yahoo(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'bubbleParent',
+			'apiName',
+			'lifecycleContainer',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bubbleParent = undefined;
+	} else {
+		this.bubbleParent = __SLAG_PROPERTIES.bubbleParent || true;
+	}
+	if (__SLAG_PROPERTIES.apiName) {
+		throw new Error('Ti.Yahoo.apiName is read only property');
+	}
+	this.apiName = 'Ti.Yahoo';
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.lifecycleContainer = undefined;
+	} else {
+		this.lifecycleContainer = __SLAG_PROPERTIES.lifecycleContainer || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+Yahoo.prototype.addEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Yahoo.prototype.removeEventListener = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Yahoo.prototype.fireEvent = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Yahoo.prototype.applyProperties = function (__SLAG_PROPERTIES) {
+	for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+		this[__SLAG_NAME] = __SLAG_PROPERTIES[__SLAG_NAME];
+	}
+};
+Yahoo.prototype.yql = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+};
+Yahoo.prototype.getBubbleParent = function () {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.bubbleParent;
+};
+Yahoo.prototype.setBubbleParent = function (__SLAG__PROPERTY) {
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.bubbleParent = __SLAG__PROPERTY;
+};
+Yahoo.prototype.getApiName = function () {
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.apiName;
+};
+Yahoo.prototype.getLifecycleContainer = function () {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	return this.lifecycleContainer;
+};
+Yahoo.prototype.setLifecycleContainer = function (__SLAG__PROPERTY) {
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		throw new Error('This method is not support specified platform');
+	}
+	this.lifecycleContainer = __SLAG__PROPERTY;
+};
+module.exports = function (properties) {
+	return new Yahoo(properties);
+};

--- a/lib/titanium/6.0.4.GA/UserNotificationSettings.js
+++ b/lib/titanium/6.0.4.GA/UserNotificationSettings.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function UserNotificationSettings(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'types',
+			'categories',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.types = undefined;
+	} else {
+		this.types = __SLAG_PROPERTIES.types || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.categories = undefined;
+	} else {
+		this.categories = __SLAG_PROPERTIES.categories || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new UserNotificationSettings(properties);
+};

--- a/lib/titanium/6.0.4.GA/ViewTemplate.js
+++ b/lib/titanium/6.0.4.GA/ViewTemplate.js
@@ -1,0 +1,71 @@
+var crypto = require('crypto');
+function ViewTemplate(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'type',
+			'bindId',
+			'properties',
+			'events',
+			'childTemplates',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.type = undefined;
+	} else {
+		this.type = __SLAG_PROPERTIES.type || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bindId = undefined;
+	} else {
+		this.bindId = __SLAG_PROPERTIES.bindId || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.properties = undefined;
+	} else {
+		this.properties = __SLAG_PROPERTIES.properties || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.events = undefined;
+	} else {
+		this.events = __SLAG_PROPERTIES.events || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.childTemplates = undefined;
+	} else {
+		this.childTemplates = __SLAG_PROPERTIES.childTemplates || [];
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new ViewTemplate(properties);
+};

--- a/lib/titanium/6.0.4.GA/WriteCallbackArgs.js
+++ b/lib/titanium/6.0.4.GA/WriteCallbackArgs.js
@@ -1,0 +1,84 @@
+var crypto = require('crypto');
+function WriteCallbackArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'source',
+			'bytesProcessed',
+			'errorState',
+			'errorDescription',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bytesProcessed = undefined;
+	} else {
+		this.bytesProcessed = __SLAG_PROPERTIES.bytesProcessed || 0;
+	}
+	if (__SLAG_PROPERTIES.errorState) {
+		throw new Error('WriteCallbackArgs.errorState was deprecated, since 3.1.0');
+	}
+	if (__SLAG_PROPERTIES.errorDescription) {
+		throw new Error('WriteCallbackArgs.errorDescription was deprecated, since 3.1.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new WriteCallbackArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/WriteStreamCallbackArgs.js
+++ b/lib/titanium/6.0.4.GA/WriteStreamCallbackArgs.js
@@ -1,0 +1,94 @@
+var crypto = require('crypto');
+function WriteStreamCallbackArgs(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'fromStream',
+			'toStream',
+			'bytesProcessed',
+			'errorState',
+			'errorDescription',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fromStream = undefined;
+	} else {
+		this.fromStream = __SLAG_PROPERTIES.fromStream || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.toStream = undefined;
+	} else {
+		this.toStream = __SLAG_PROPERTIES.toStream || {};
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bytesProcessed = undefined;
+	} else {
+		this.bytesProcessed = __SLAG_PROPERTIES.bytesProcessed || 0;
+	}
+	if (__SLAG_PROPERTIES.errorState) {
+		throw new Error('WriteStreamCallbackArgs.errorState was deprecated, since 3.1.0');
+	}
+	if (__SLAG_PROPERTIES.errorDescription) {
+		throw new Error('WriteStreamCallbackArgs.errorDescription was deprecated, since 3.1.0');
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new WriteStreamCallbackArgs(properties);
+};

--- a/lib/titanium/6.0.4.GA/YQLResponse.js
+++ b/lib/titanium/6.0.4.GA/YQLResponse.js
@@ -1,0 +1,70 @@
+var crypto = require('crypto');
+function YQLResponse(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'success',
+			'error',
+			'code',
+			'message',
+			'data',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.success = undefined;
+	} else {
+		this.success = __SLAG_PROPERTIES.success || true;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.error = undefined;
+	} else {
+		this.error = __SLAG_PROPERTIES.error || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.code = undefined;
+	} else {
+		this.code = __SLAG_PROPERTIES.code || 0;
+	}
+	if (__SLAG_PROPERTIES.message) {
+		throw new Error('YQLResponse.message was deprecated, since 3.1.0');
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.data = undefined;
+	} else {
+		this.data = __SLAG_PROPERTIES.data || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new YQLResponse(properties);
+};

--- a/lib/titanium/6.0.4.GA/closeWindowParams.js
+++ b/lib/titanium/6.0.4.GA/closeWindowParams.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function closeWindowParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'activityEnterAnimation',
+			'activityExitAnimation',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityEnterAnimation = undefined;
+	} else {
+		this.activityEnterAnimation = __SLAG_PROPERTIES.activityEnterAnimation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityExitAnimation = undefined;
+	} else {
+		this.activityExitAnimation = __SLAG_PROPERTIES.activityExitAnimation || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new closeWindowParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/contentOffsetOption.js
+++ b/lib/titanium/6.0.4.GA/contentOffsetOption.js
@@ -1,0 +1,32 @@
+var crypto = require('crypto');
+function contentOffsetOption(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new contentOffsetOption(properties);
+};

--- a/lib/titanium/6.0.4.GA/daysOfTheWeekDictionary.js
+++ b/lib/titanium/6.0.4.GA/daysOfTheWeekDictionary.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function daysOfTheWeekDictionary(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'daysOfWeek',
+			'week',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.daysOfWeek = undefined;
+	} else {
+		this.daysOfWeek = __SLAG_PROPERTIES.daysOfWeek || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.week = undefined;
+	} else {
+		this.week = __SLAG_PROPERTIES.week || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new daysOfTheWeekDictionary(properties);
+};

--- a/lib/titanium/6.0.4.GA/hideParams.js
+++ b/lib/titanium/6.0.4.GA/hideParams.js
@@ -1,0 +1,32 @@
+var crypto = require('crypto');
+function hideParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new hideParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/hideStatusBarParams.js
+++ b/lib/titanium/6.0.4.GA/hideStatusBarParams.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function hideStatusBarParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'animationStyle',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animationStyle = undefined;
+	} else {
+		this.animationStyle = __SLAG_PROPERTIES.animationStyle || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new hideStatusBarParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/launchOptions.js
+++ b/lib/titanium/6.0.4.GA/launchOptions.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function launchOptions(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'url',
+			'source',
+			'launchOptionsLocationKey',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.url = undefined;
+	} else {
+		this.url = __SLAG_PROPERTIES.url || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.source = undefined;
+	} else {
+		this.source = __SLAG_PROPERTIES.source || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.launchOptionsLocationKey = undefined;
+	} else {
+		this.launchOptionsLocationKey = __SLAG_PROPERTIES.launchOptionsLocationKey || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new launchOptions(properties);
+};

--- a/lib/titanium/6.0.4.GA/openWindowParams.js
+++ b/lib/titanium/6.0.4.GA/openWindowParams.js
@@ -1,0 +1,146 @@
+var crypto = require('crypto');
+function openWindowParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'bottom',
+			'fullscreen',
+			'height',
+			'left',
+			'modal',
+			'modalStyle',
+			'modalTransitionStyle',
+			'navBarHidden',
+			'right',
+			'top',
+			'transition',
+			'width',
+			'activityEnterAnimation',
+			'activityExitAnimation',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.bottom = undefined;
+	} else {
+		this.bottom = __SLAG_PROPERTIES.bottom || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fullscreen = undefined;
+	} else {
+		this.fullscreen = __SLAG_PROPERTIES.fullscreen || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.height = undefined;
+	} else {
+		this.height = __SLAG_PROPERTIES.height || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.left = undefined;
+	} else {
+		this.left = __SLAG_PROPERTIES.left || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modal = undefined;
+	} else {
+		this.modal = __SLAG_PROPERTIES.modal || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modalStyle = undefined;
+	} else {
+		this.modalStyle = __SLAG_PROPERTIES.modalStyle || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.modalTransitionStyle = undefined;
+	} else {
+		this.modalTransitionStyle = __SLAG_PROPERTIES.modalTransitionStyle || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.navBarHidden = undefined;
+	} else {
+		this.navBarHidden = __SLAG_PROPERTIES.navBarHidden || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.right = undefined;
+	} else {
+		this.right = __SLAG_PROPERTIES.right || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.top = undefined;
+	} else {
+		this.top = __SLAG_PROPERTIES.top || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transition = undefined;
+	} else {
+		this.transition = __SLAG_PROPERTIES.transition || 0;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.width = undefined;
+	} else {
+		this.width = __SLAG_PROPERTIES.width || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityEnterAnimation = undefined;
+	} else {
+		this.activityEnterAnimation = __SLAG_PROPERTIES.activityEnterAnimation || 0;
+	}
+	if (['android'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.activityExitAnimation = undefined;
+	} else {
+		this.activityExitAnimation = __SLAG_PROPERTIES.activityExitAnimation || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new openWindowParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/recurrenceEndDictionary.js
+++ b/lib/titanium/6.0.4.GA/recurrenceEndDictionary.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function recurrenceEndDictionary(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'endDate',
+			'occurrenceCount',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.endDate = undefined;
+	} else {
+		this.endDate = __SLAG_PROPERTIES.endDate || new Date();
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.occurrenceCount = undefined;
+	} else {
+		this.occurrenceCount = __SLAG_PROPERTIES.occurrenceCount || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new recurrenceEndDictionary(properties);
+};

--- a/lib/titanium/6.0.4.GA/shadowDict.js
+++ b/lib/titanium/6.0.4.GA/shadowDict.js
@@ -1,0 +1,56 @@
+var crypto = require('crypto');
+function shadowDict(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'blurRadius',
+			'color',
+			'offset',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.blurRadius = undefined;
+	} else {
+		this.blurRadius = __SLAG_PROPERTIES.blurRadius || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.offset = undefined;
+	} else {
+		this.offset = __SLAG_PROPERTIES.offset || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new shadowDict(properties);
+};

--- a/lib/titanium/6.0.4.GA/showContactsParams.js
+++ b/lib/titanium/6.0.4.GA/showContactsParams.js
@@ -1,0 +1,68 @@
+var crypto = require('crypto');
+function showContactsParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'fields',
+			'cancel',
+			'selectedPerson',
+			'selectedProperty',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.fields = undefined;
+	} else {
+		this.fields = __SLAG_PROPERTIES.fields || '';
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.cancel = undefined;
+	} else {
+		this.cancel = __SLAG_PROPERTIES.cancel || {};
+	}
+	if ([
+			'android',
+			'ios'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedPerson = undefined;
+	} else {
+		this.selectedPerson = __SLAG_PROPERTIES.selectedPerson || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.selectedProperty = undefined;
+	} else {
+		this.selectedProperty = __SLAG_PROPERTIES.selectedProperty || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new showContactsParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/showParams.js
+++ b/lib/titanium/6.0.4.GA/showParams.js
@@ -1,0 +1,49 @@
+var crypto = require('crypto');
+function showParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'view',
+			'rect',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.view = undefined;
+	} else {
+		this.view = __SLAG_PROPERTIES.view || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.rect = undefined;
+	} else {
+		this.rect = __SLAG_PROPERTIES.rect || {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0
+		};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new showParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/showStatusBarParams.js
+++ b/lib/titanium/6.0.4.GA/showStatusBarParams.js
@@ -1,0 +1,38 @@
+var crypto = require('crypto');
+function showStatusBarParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'animationStyle',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animationStyle = undefined;
+	} else {
+		this.animationStyle = __SLAG_PROPERTIES.animationStyle || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new showStatusBarParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/textAreaSelectedParams.js
+++ b/lib/titanium/6.0.4.GA/textAreaSelectedParams.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function textAreaSelectedParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'location',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.location = undefined;
+	} else {
+		this.location = __SLAG_PROPERTIES.location || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = __SLAG_PROPERTIES.length || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new textAreaSelectedParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/textFieldSelectedParams.js
+++ b/lib/titanium/6.0.4.GA/textFieldSelectedParams.js
@@ -1,0 +1,46 @@
+var crypto = require('crypto');
+function textFieldSelectedParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'location',
+			'length',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.location = undefined;
+	} else {
+		this.location = __SLAG_PROPERTIES.location || 0;
+	}
+	if ([
+			'android',
+			'ios',
+			'mobileweb'
+		].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.length = undefined;
+	} else {
+		this.length = __SLAG_PROPERTIES.length || 0;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new textFieldSelectedParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/titleAttributesParams.js
+++ b/lib/titanium/6.0.4.GA/titleAttributesParams.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function titleAttributesParams(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'color',
+			'font',
+			'shadow',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.color = undefined;
+	} else {
+		this.color = __SLAG_PROPERTIES.color || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.font = undefined;
+	} else {
+		this.font = __SLAG_PROPERTIES.font || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.shadow = undefined;
+	} else {
+		this.shadow = __SLAG_PROPERTIES.shadow || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new titleAttributesParams(properties);
+};

--- a/lib/titanium/6.0.4.GA/transitionAnimationParam.js
+++ b/lib/titanium/6.0.4.GA/transitionAnimationParam.js
@@ -1,0 +1,44 @@
+var crypto = require('crypto');
+function transitionAnimationParam(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'duration',
+			'transitionFrom',
+			'transitionTo',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.duration = undefined;
+	} else {
+		this.duration = __SLAG_PROPERTIES.duration || 0;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionFrom = undefined;
+	} else {
+		this.transitionFrom = __SLAG_PROPERTIES.transitionFrom || {};
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.transitionTo = undefined;
+	} else {
+		this.transitionTo = __SLAG_PROPERTIES.transitionTo || {};
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new transitionAnimationParam(properties);
+};

--- a/lib/titanium/6.0.4.GA/windowToolbarParam.js
+++ b/lib/titanium/6.0.4.GA/windowToolbarParam.js
@@ -1,0 +1,50 @@
+var crypto = require('crypto');
+function windowToolbarParam(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'translucent',
+			'animated',
+			'barColor',
+			'tintColor',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.translucent = undefined;
+	} else {
+		this.translucent = __SLAG_PROPERTIES.translucent || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.barColor = undefined;
+	} else {
+		this.barColor = __SLAG_PROPERTIES.barColor || '';
+	}
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.tintColor = undefined;
+	} else {
+		this.tintColor = __SLAG_PROPERTIES.tintColor || '';
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new windowToolbarParam(properties);
+};

--- a/lib/titanium/6.0.4.GA/zoomScaleOption.js
+++ b/lib/titanium/6.0.4.GA/zoomScaleOption.js
@@ -1,0 +1,32 @@
+var crypto = require('crypto');
+function zoomScaleOption(__SLAG_PROPERTIES) {
+	__SLAG_PROPERTIES = __SLAG_PROPERTIES || {};
+	var __SLAG_DEVICE = JSON.parse(process.env.SLAG_DEVICE);
+	var __SLAG_CHECKS = [], __SLAG_NAMES = [
+			'animated',
+			'id'
+		];
+	if (__SLAG_NAMES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		for (var __SLAG_NAME in __SLAG_PROPERTIES) {
+			if (__SLAG_NAMES.indexOf(__SLAG_NAME) === -1) {
+				throw new Error('Use user custom property ' + __SLAG_NAME);
+			}
+		}
+	} else if (__SLAG_NAMES.length === 0 && __SLAG_PROPERTIES.length > 0 && process.env.SLAG_STRICT === 'true') {
+		throw new Error('Use user custom properties. ' + __SLAG_PROPERTIES.join(', '));
+	}
+	var md5 = crypto.createHash('md5');
+	md5.update(crypto.randomBytes(32), 'binary');
+	this.__SLAG_ID = md5.digest('hex');
+	this.__SLAG_PARENT;
+	if (['ios'].indexOf(process.env.SLAG_PLATFORM) === -1) {
+		this.animated = undefined;
+	} else {
+		this.animated = __SLAG_PROPERTIES.animated || true;
+	}
+	this.id = __SLAG_PROPERTIES.id || '';
+	return this;
+}
+module.exports = function (properties) {
+	return new zoomScaleOption(properties);
+};

--- a/test.js
+++ b/test.js
@@ -14,6 +14,15 @@ describe('ti-slag', function(){
 		depjs = path.join(__dirname, 'test', 'classic', 'Resources', 'deprecated.js'),
 		cspjs = path.join(__dirname, 'test', 'classic', 'Resources', 'customprop.js');
 
+	it('should support Titanium SDK version 6.0.4.GA', function(){
+		assert.doesNotThrow(function(){
+			slag(appjs, {
+				titanium: '6.0.4.GA',
+				platform: 'ios'
+			});
+		});
+	});
+
 	it('should support Titanium SDK version 5.2.0.GA', function(){
 		assert.doesNotThrow(function(){
 			slag(appjs, {
@@ -53,7 +62,7 @@ describe('ti-slag', function(){
 	it('should support platform iOS', function(){
 		assert.doesNotThrow(function(){
 			slag(iosjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios'
 			});
 		});
@@ -62,7 +71,7 @@ describe('ti-slag', function(){
 	it('should support platform Android', function(){
 		assert.doesNotThrow(function(){
 			slag(andjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'android'
 			});
 		});
@@ -71,7 +80,7 @@ describe('ti-slag', function(){
 	it('should support modules specified', function(){
 		assert.doesNotThrow(function(){
 			slag(modjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				module: {
 					'be.k0suke.module': {
@@ -87,7 +96,7 @@ describe('ti-slag', function(){
 
 	it('should simulate L', function(){
 		var context = slag(appjs, {
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios'
 		});
 		assert.equal('Hello, world.', context.L('Hello, world.'));
@@ -95,7 +104,7 @@ describe('ti-slag', function(){
 
 	it('should simulate String.format', function(){
 		var context = slag(appjs, {
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios'
 		});
 		assert.equal('Hello, world.', context.String.format('Hello, world.'));
@@ -103,7 +112,7 @@ describe('ti-slag', function(){
 
 	it('should simulate String.formatCurrency', function(){
 		var context = slag(appjs, {
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios'
 		});
 		assert.equal('Hello, world.', context.String.formatCurrency('Hello, world.'));
@@ -111,7 +120,7 @@ describe('ti-slag', function(){
 
 	it('should simulate String.formatDate', function(){
 		var context = slag(appjs, {
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios'
 		});
 		assert.equal('Hello, world.', context.String.formatDate('Hello, world.'));
@@ -119,7 +128,7 @@ describe('ti-slag', function(){
 
 	it('should simulate String.formatDecimal', function(){
 		var context = slag(appjs, {
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios'
 		});
 		assert.equal('Hello, world.', context.String.formatDecimal('Hello, world.'));
@@ -127,7 +136,7 @@ describe('ti-slag', function(){
 
 	it('should simulate String.formatTime', function(){
 		var context = slag(appjs, {
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios'
 		});
 		assert.equal('Hello, world.', context.String.formatTime('Hello, world.'));
@@ -135,7 +144,7 @@ describe('ti-slag', function(){
 
 	it('should simulate alert', function(){
 		var context = slag(appjs, {
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios',
 			silent: true
 		});
@@ -147,7 +156,7 @@ describe('ti-slag', function(){
 	it('should throw exception invalid file path', function(){
 		assert.throws(function(){
 			slag('file_does_not_exist.js', {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios'
 			});
 		}, Error);
@@ -165,7 +174,7 @@ describe('ti-slag', function(){
 	it('should throw exception invalid plafrom specified', function(){
 		assert.throws(function(){
 			slag(appjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'tizen'
 			});
 		}, Error);
@@ -174,7 +183,7 @@ describe('ti-slag', function(){
 	it('should throw exception invalid plafrom specified', function(){
 		assert.throws(function(){
 			slag(andjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios'
 			});
 		}, Error);
@@ -183,7 +192,7 @@ describe('ti-slag', function(){
 	it('should throw exception invalid plafrom specified', function(){
 		assert.throws(function(){
 			slag(iosjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'android'
 			});
 		}, Error);
@@ -192,7 +201,7 @@ describe('ti-slag', function(){
 	it('should throw exception invalid modules specified', function(){
 		assert.throws(function(){
 			slag(modjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				module: 'invalid_module'
 			});
@@ -202,7 +211,7 @@ describe('ti-slag', function(){
 	it('should throw exception unknown module detect', function(){
 		assert.throws(function(){
 			slag(modjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				module: {}
 			});
@@ -212,7 +221,7 @@ describe('ti-slag', function(){
 	it('should throw exception deprecated detect', function(){
 		assert.throws(function(){
 			slag(depjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios'
 			});
 		}, Error);
@@ -221,7 +230,7 @@ describe('ti-slag', function(){
 	it('should throw exception custom property detect', function(){
 		assert.throws(function(){
 			slag(cspjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios'
 			});
 		}, Error);
@@ -230,7 +239,7 @@ describe('ti-slag', function(){
 	it('should strict mode avoidance custom property detect', function(){
 		assert.doesNotThrow(function(){
 			slag(cspjs, {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				strict: false
 			});
@@ -244,7 +253,7 @@ describe('Classic', function(){
 	it('should does not throw exception', function(){
 		assert.doesNotThrow(function(){
 			context = slag(path.join(__dirname, 'test', 'classic', 'Resources', 'app.js'), {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios'
 			});
 		});
@@ -295,7 +304,7 @@ describe('lib/alloy.js', function(){
 	it('should does not throw exception default platform is iOS', function(){
 		assert.doesNotThrow(function(){
 			alloy.load({
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy.js'),
 				BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'BaseController.js'),
 				underscore: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'underscore.js'),
@@ -309,7 +318,7 @@ describe('lib/alloy.js', function(){
 	it('should throw exception alloy path specified, default path is Resources/iphone/alloy.js', function(){
 		assert.throws(function(){
 			alloy.load({
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'BaseController.js'),
 				underscore: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'underscore.js'),
@@ -323,7 +332,7 @@ describe('lib/alloy.js', function(){
 	it('should throw exception BaseController path specified, default path is Resources/iphone/alloy/controllers/BaseController.js', function(){
 		assert.throws(function(){
 			alloy.load({
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy.js'),
 				underscore: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'underscore.js'),
@@ -337,7 +346,7 @@ describe('lib/alloy.js', function(){
 	it('should throw exception underscore path specified, default path is Resources/iphone/alloy/underscore.js', function(){
 		assert.throws(function(){
 			alloy.load({
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy.js'),
 				BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'BaseController.js'),
@@ -351,7 +360,7 @@ describe('lib/alloy.js', function(){
 	it('should throw exception backbone path specified, default path is Resources/iphone/alloy/backbone.js', function(){
 		assert.throws(function(){
 			alloy.load({
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy.js'),
 				BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'BaseController.js'),
@@ -365,7 +374,7 @@ describe('lib/alloy.js', function(){
 	it('should throw exception constants path specified, default path is Resources/iphone/alloy/constants.js', function(){
 		assert.throws(function(){
 			alloy.load({
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy.js'),
 				BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'BaseController.js'),
@@ -379,7 +388,7 @@ describe('lib/alloy.js', function(){
 	it('should throw exception CFG path specified, default path is Resources/alloy/CFG.js', function(){
 		assert.throws(function(){
 			alloy.load({
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy.js'),
 				BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'BaseController.js'),
@@ -395,7 +404,7 @@ describe('Alloy iOS', function(){
 	var views,
 		listeners,
 		Alloy = alloy.load({
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'ios',
 			alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy.js'),
 			BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'BaseController.js'),
@@ -406,7 +415,7 @@ describe('Alloy iOS', function(){
 		});
 
 	var context = slag(path.join(__dirname, 'test', 'alloy', 'Resources', 'iphone', 'alloy', 'controllers', 'index.js'), {
-		titanium: '5.2.0.GA',
+		titanium: '6.0.4.GA',
 		platform: 'ios',
 		silent: true,
 		module: {
@@ -448,7 +457,7 @@ describe('Alloy Android', function(){
 	var views,
 		listeners,
 		Alloy = alloy.load({
-			titanium: '5.2.0.GA',
+			titanium: '6.0.4.GA',
 			platform: 'android',
 			alloy: path.join(__dirname, 'test', 'alloy', 'Resources', 'android', 'alloy.js'),
 			BaseController: path.join(__dirname, 'test', 'alloy', 'Resources', 'android', 'alloy', 'controllers', 'BaseController.js'),
@@ -459,7 +468,7 @@ describe('Alloy Android', function(){
 		});
 
 	var context = slag(path.join(__dirname, 'test', 'alloy', 'Resources', 'android', 'alloy', 'controllers', 'index.js'), {
-		titanium:'5.2.0.GA',
+		titanium:'6.0.4.GA',
 		platform: 'android',
 		silent: true,
 		module: {
@@ -709,7 +718,7 @@ describe('Ti.Platform(.displayCaps)', function(){
 
 /* describe('Titanium API cover test', function(){
 			var context = slag(path.join(__dirname, 'test', 'coverage', 'android.js'), {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'android',
 				strict: false
 			});
@@ -718,7 +727,7 @@ describe('Ti.Platform(.displayCaps)', function(){
 	it('should does not throw exception iOS', function(){
 		assert.doesNotThrow(function(){
 			var context = slag(path.join(__dirname, 'test', 'coverage', 'ios.js'), {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'ios',
 				strict: false
 			});
@@ -728,7 +737,7 @@ describe('Ti.Platform(.displayCaps)', function(){
 	it('should does not throw exception Android', function(){
 		assert.doesNotThrow(function(){
 			var context = slag(path.join(__dirname, 'test', 'coverage', 'android.js'), {
-				titanium: '5.2.0.GA',
+				titanium: '6.0.4.GA',
 				platform: 'android',
 				strict: false
 			});


### PR DESCRIPTION
Hello, I would like to use ti-slag under Titanium 6.0.4.GA, so I created with referring [added 5.2.0.GA](https://github.com/k0sukey/ti-slag/commit/8e246b29e87a81acb6fb0823bdeb30cd0d40fc2b).
Could you please merge this and release new version?
If there is something not enough to do it, feel free to tell me that.

In detail of the process:
- api.json=Titanium_6.0.4.GA.json was generated by the following way
    - checkout 6.0.4.GA from https://github.com/appcelerator/titanium_mobile
    - node docgen.js --format json
- furnace.js was modified with replacing 6.0.4.GA to 5.2.0.GA
- lib/titanium/6.0.4.GA/*.js was generated by furnace.js with api.json above
- lib/titanium/6.0.4.GA.js was copied 5.2.0.GA.js and added Ti.UI.iOS.StatusBar
- Edit other files with the same way of 5.2.0.GA

NOTE: I don't have classic environments, so I cannot test anything about ti-slag itself. Just I have run tests of my alloy application with ti-slag of this commit.

Thank you for your great work!